### PR TITLE
Fix parameter for miner

### DIFF
--- a/9c-sample/chart/templates/miner.yaml
+++ b/9c-sample/chart/templates/miner.yaml
@@ -41,6 +41,7 @@ spec:
         - $(PRIVATE_KEY)
         - --miner-private-key
         - $(PRIVATE_KEY)
+        - --no-miner=false
         {{- range $.Values.peerStrings }}
         - --peer={{ . }}
         {{- end }}


### PR DESCRIPTION
Due to NineChronicles.Headless's default config, we need to specify `--no-miner=false` to mining. (I think it's a little bit weird too... 😕 ) cc @planetarium/9c-dx 