### PR TITLE
introduce: pbft

### DIFF
--- a/9c-internal/chart/templates/seed.yaml
+++ b/9c-internal/chart/templates/seed.yaml
@@ -38,8 +38,8 @@ spec:
         - --graphql-host=0.0.0.0
         - --graphql-port={{ $.Values.seed.ports.graphql }}
         - --workers={{ $.Values.seed.workerCount }}
-        {{- if $.Values.pos.enabled }}
-        - --gossip-port={{ $.Values.pos.port }}
+        {{- if eq $.Values.consensusType "pbft" }}
+        - --gossip-port={{ $.Values.seed.ports.gossip }}
         {{- end }}
         {{- with $.Values.seed.extraArgs }}
           {{- toYaml . | nindent 8 }}
@@ -73,8 +73,8 @@ spec:
           - containerPort: {{ $.Values.seed.ports.graphql }}
             name: graphql
             protocol: TCP
-          {{- if $.Values.pos.enabled }}
-          - containerPort: {{ $.Values.pos.port }}
+          {{- if eq $.Values.consensusType "pbft" }}
+          - containerPort: {{ $.Values.seed.ports.gossip }}
             name: gossip
             protocol: TCP
           {{- end }}

--- a/9c-internal/chart/templates/service.yaml
+++ b/9c-internal/chart/templates/service.yaml
@@ -14,9 +14,9 @@ spec:
   - port: {{ $.Values.seed.ports.node }}
     targetPort: {{ $.Values.seed.ports.node }}
     name: node
-  {{- if $.Values.pos.enabled }}
-  - port: {{ $.Values.pos.port }}
-    targetPort: {{ $.Values.pos.port }}
+  {{- if eq $.Values.consensusType "pbft" }}
+  - port: {{ $.Values.seed.ports.gossip }}
+    targetPort: {{ $.Values.seed.ports.gossip }}
     name: gossip
   {{- end }}
   selector:
@@ -44,13 +44,39 @@ spec:
   - port: {{ $.Values.miner.ports.graphql }}
     targetPort: {{ $.Values.miner.ports.graphql }}
     name: gql
-  {{- if $.Values.pos.enabled }}
-  - port: {{ $.Values.pos.port }}
-    targetPort: {{ $.Values.pos.port }}
+  selector:
+    app: miner-{{ $index }}
+  type: LoadBalancer
+
+---
+{{ end }}
+
+{{ range $idx := until (int .Values.validator.count) }}
+{{ $index := add $idx 1 }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: validator-{{ $index }}
+  namespace: {{ $.Chart.Name }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+    service.beta.kubernetes.io/aws-load-balancer-type: "external"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+spec:
+  ports:
+  - port: {{ $.Values.validator.ports.headless }}
+    targetPort: {{ $.Values.validator.ports.headless }}
+    name: headless
+  - port: {{ $.Values.validator.ports.graphql }}
+    targetPort: {{ $.Values.validator.ports.graphql }}
+    name: gql
+  {{- if eq $.Values.consensusType "pbft" }}
+  - port: {{ $.Values.validator.port }}
+    targetPort: {{ $.Values.validator.port }}
     name: gossip
   {{- end }}
   selector:
-    app: miner-{{ $index }}
+    app: validator-{{ $index }}
   type: LoadBalancer
 
 ---

--- a/9c-internal/chart/templates/service.yaml
+++ b/9c-internal/chart/templates/service.yaml
@@ -71,8 +71,8 @@ spec:
     targetPort: {{ $.Values.validator.ports.graphql }}
     name: gql
   {{- if eq $.Values.consensusType "pbft" }}
-  - port: {{ $.Values.validator.port }}
-    targetPort: {{ $.Values.validator.port }}
+  - port: {{ $.Values.validator.ports.gossip }}
+    targetPort: {{ $.Values.validator.ports.gossip }}
     name: gossip
   {{- end }}
   selector:

--- a/9c-internal/chart/templates/snapshot-sync-headless.yaml
+++ b/9c-internal/chart/templates/snapshot-sync-headless.yaml
@@ -1,0 +1,132 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: snapshot-sync-headless
+  name: snapshot-sync-headless
+  namespace: {{ $.Chart.Name }}
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 0
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: snapshot-sync-headless
+  serviceName: snapshot-sync-headless
+  template:
+    metadata:
+      labels:
+        app: snapshot-sync-headless
+      name: snapshot-sync-headless
+    spec:
+      initContainers:
+      - args:
+        - https://snapshots.nine-chronicles.com/internal
+        - /data/headless
+        - $(RESET_SNAPSHOT_OPTION)
+        - snapshot-sync-headless
+        - $(SLACK_WEBHOOK_URL)
+        command:
+        - /bin/download_snapshot.sh
+        image: bash:latest
+        name: reset-snapshot
+        volumeMounts:
+        - name: script-volume
+          mountPath: /bin/download_snapshot.sh
+          readOnly: true
+          subPath: download_snapshot.sh
+        - mountPath: /data
+          name: snapshot-volume
+        env:
+        - name: RESET_SNAPSHOT_OPTION
+          value: "{{ $.Values.snapshot.resetSnapshot }}"
+        - name: SLACK_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: slack
+              key: slack-webhook-url
+      - name: wait
+        image: alpine
+        imagePullPolicy: Always
+        command:
+        - sh
+        - -c
+        - |
+          apk --no-cache add curl
+          # Endpoint to check
+          ENDPOINT="http://miner-1.{{ $.Chart.Name }}.svc.cluster.local/ui/playground"
+          echo Checking: ${ENDPOINT}
+          while [[ $(curl --silent --output /dev/null --request GET --write-out "%{http_code}" ${ENDPOINT}) -ne 200 ]]; do
+            echo "Not ready"
+            sleep 5s
+          done
+          echo Ready
+      containers:
+      - args:
+        - NineChronicles.Headless.Executable.dll
+        - run
+        - --app-protocol-version={{ $.Values.appProtocolVersion }}
+        - --trusted-app-protocol-version-signer={{ $.Values.trustedAppProtocolVersionSigner }}
+        - --genesis-block-path={{ $.Values.genesisBlockPath }}
+        - --no-miner
+        - --store-type=rocksdb
+        - --store-path=/data/headless
+        {{- range $.Values.iceServers }}
+        - --ice-server={{ . }}
+        {{- end }}
+        - --chain-tip-stale-behavior-type=reboot
+        - --network-type={{ $.Values.networkType }}
+        {{- with $.Values.remoteHeadless.extraArgs }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        command:
+        - dotnet
+        image: {{ $.Values.remoteHeadless.image.repository }}:{{ $.Values.remoteHeadless.image.tag }}
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - /bin/liveness_probe.sh
+          failureThreshold: 3
+          initialDelaySeconds: 1800
+          periodSeconds: 30
+          timeoutSeconds: 30
+        name: snapshot-sync-headless
+        readinessProbe:
+          exec:
+            command:
+            - /bin/readiness_probe.sh
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 10
+        resources:
+          {{- toYaml $.Values.miner.resources | nindent 10 }}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /data
+          name: snapshot-volume
+        - mountPath: /bin/liveness_probe.sh
+          name: probe-script
+          readOnly: true
+          subPath: liveness_probe.sh
+        - mountPath: /bin/readiness_probe.sh
+          name: probe-script
+          readOnly: true
+          subPath: readiness_probe.sh
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 448
+          name: {{ $.Chart.Name }}-probe-script
+        name: probe-script
+      - name: script-volume
+        configMap:
+          defaultMode: 0700
+          name: {{ $.Chart.Name }}-snapshot-script
+  updateStrategy:
+    type: RollingUpdate
+---

--- a/9c-internal/chart/templates/validator.yaml
+++ b/9c-internal/chart/templates/validator.yaml
@@ -1,32 +1,31 @@
-{{- if eq .Values.consensusType "pow"}}
-{{ range $idx := until (int .Values.miner.count) }}
+{{ range $idx := until (int .Values.validator.count) }}
 {{ $index := add $idx 1 }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
-    app: miner-{{ $index }}
-  name: miner-{{ $index }}
+    app: validator-{{ $index }}
+  name: validator-{{ $index }}
   namespace: {{ $.Chart.Name }}
 spec:
   replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: miner-{{ $index }}
-  serviceName: miner-{{ $index }}
+      app: validator-{{ $index }}
+  serviceName: validator-{{ $index }}
   template:
     metadata:
       labels:
-        app: miner-{{ $index }}
-      name: miner-{{ $index }}
+        app: validator-{{ $index }}
+      name: validator-{{ $index }}
     spec:
       initContainers:
       - args:
         - https://snapshots.nine-chronicles.com/internal
-        - /data/miner
+        - /data/validator
         - $(RESET_SNAPSHOT_OPTION)
-        - miner-{{ $index }}
+        - validator-{{ $index }}
         - $(SLACK_WEBHOOK_URL)
         command:
         - /bin/download_snapshot.sh
@@ -38,7 +37,7 @@ spec:
           readOnly: true
           subPath: download_snapshot.sh
         - mountPath: /data
-          name: miner-data-{{ $index }}
+          name: validator-data-{{ $index }}
         env:
         - name: RESET_SNAPSHOT_OPTION
           value: "{{ $.Values.snapshot.resetSnapshot }}"
@@ -54,16 +53,15 @@ spec:
         - --app-protocol-version={{ $.Values.appProtocolVersion }}
         - --trusted-app-protocol-version-signer={{ $.Values.trustedAppProtocolVersionSigner }}
         - --genesis-block-path={{ $.Values.genesisBlockPath }}
-        {{- if $.Values.miner.useTurnServer }}
+        {{- if eq $.Values.consensusType "pbft" }}
+        - --host={{ index $.Values.validator.hosts $idx }}
+        {{- else }}
         {{- range $.Values.iceServers }}
         - --ice-server={{ . }}
         {{- end }}
-        {{- else }}
-        - --host={{ index $.Values.miner.hosts $idx }}
         {{- end }}
-        - --port={{ $.Values.miner.ports.headless }}
-        - --no-miner=false
-        - --store-path=/data/miner
+        - --port={{ $.Values.validator.ports.headless }}
+        - --store-path=/data/validator
         - --store-type=rocksdb
         - --swarm-private-key
         - $(PRIVATE_KEY)
@@ -74,8 +72,16 @@ spec:
         {{- end }}
         - --graphql-server
         - --graphql-host=0.0.0.0
-        - --graphql-port={{ $.Values.miner.ports.graphql }}
-        {{- with $.Values.miner.extraArgs }}
+        - --graphql-port={{ $.Values.validator.ports.graphql }}
+        {{- if eq $.Values.consensusType "pbft" }}
+        - --consensus-private-key
+        - $(PRIVATE_KEY)
+        - --consensus-port={{ $.Values.validator.ports.gossip }}
+        {{- range $.Values.validator.consensusSeedStrings }}
+        - --consensus-seed={{ . }}
+        {{- end }}
+        {{- end }}
+        {{- with $.Values.validator.extraArgs }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
         - --network-type={{ $.Values.networkType }}
@@ -85,28 +91,33 @@ spec:
           - name: PRIVATE_KEY
             valueFrom:
               secretKeyRef:
-                key: miner-private-key-{{ $index }}
+                key: validator-private-key-{{ $index }}
                 name: private-keys
-          {{- with $.Values.miner.env }}
+          {{- with $.Values.validator.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        image: {{ $.Values.miner.image.repository }}:{{ $.Values.miner.image.tag }}
+        image: {{ $.Values.validator.image.repository }}:{{ $.Values.validator.image.tag }}
         imagePullPolicy: IfNotPresent
-        name: miner-{{ $index }}
+        name: validator-{{ $index }}
         ports:
-        - containerPort: {{ $.Values.miner.ports.headless }}
+        - containerPort: {{ $.Values.validator.ports.headless }}
           name: headless
           protocol: TCP
-        - containerPort: {{ $.Values.miner.ports.graphql }}
+        - containerPort: {{ $.Values.validator.ports.graphql }}
           name: graphql
           protocol: TCP
+        {{- if eq $.Values.consensusType "pbft" }}
+        - containerPort: {{ $.Values.validator.ports.gossip }}
+          name: gossip
+          protocol: TCP
+        {{- end }}
         resources:
-          {{- toYaml $.Values.miner.resources | nindent 10 }}
+          {{- toYaml $.Values.validator.resources | nindent 10 }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /data
-          name: miner-data-{{ $index }}
+          name: validator-data-{{ $index }}
       dnsPolicy: ClusterFirst
       volumes:
       - name: script-volume
@@ -124,15 +135,14 @@ spec:
   volumeClaimTemplates:
   - metadata:
       creationTimestamp: null
-      name: miner-data-{{ $index }}
+      name: validator-data-{{ $index }}
     spec:
       accessModes:
       - ReadWriteOnce
       resources:
         requests:
-          storage: {{ $.Values.miner.storage.data }}
+          storage: {{ $.Values.validator.storage.data }}
       storageClassName: {{ $.Chart.Name }}-gp2
       volumeMode: Filesystem
 ---
-{{ end }}
 {{ end }}

--- a/9c-internal/chart/values.yaml
+++ b/9c-internal/chart/values.yaml
@@ -16,6 +16,7 @@ iceServers:
   - "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us.planetarium.dev:3478"
 
 networkType: Internal
+consensusType: pow
 
 useExternalSecret: true
 slackToken: ""
@@ -36,11 +37,52 @@ snapshot:
 # if you want to delete PVC with the volume provisioned together, set this value "Delete"
 volumeReclaimPolicy: "Retain"
 
-pos:
-  enabled: false
-  port: 31235
-  consensusSeedPeerStrings:
+validator:
+  count: 4
+  image:
+    repository: planetariumhq/ninechronicles-headless
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "git-d9402507f9f7fe182348b9f8765ccf5dae673f66"
+
+  consensusSeedStrings:
   - "033369e95dbfd970dd9a7b4df31dcf5004d7cfd63289d26cc42bbdd01e25675b6f,tcp-seed-1,31235"
+  
+  # if $.Values.consensusType is "pbft", fill this value correctly.
+  # same count with $.Values.validator.count.
+  hosts: []
+  # - "<validator-1 hostname>"
+  # - "<validator-2 hostname>"
+  # - "<validator-3 hostname>"
+  # - "<validator-4 hostname>"
+
+  ports:
+    headless: 31234
+    graphql: 80
+    gossip: 6000
+
+  # dotnet args
+
+  extraArgs: []
+  # - --key=val
+
+  # private keys if not using External Secrets
+  privateKeys: []
+  # - "<private key>"
+
+  storage:
+    data: 500Gi
+
+  env: []
+
+  resources:
+    requests:
+      cpu: 2
+      memory: 8Gi
+  
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 seed:
   count: 1
@@ -55,6 +97,7 @@ seed:
 
   ports:
     node: 31234
+    gossip: 31235
     graphql: 31237
 
   # dotnet args


### PR DESCRIPTION
This PR target to ready to introduce the PBFT network.

##  Checkpoint
- `pos.isEnable` value is deprecated. instead, use `consensusType`.
  - pow: current consensus type. if you use `pow`, do nothing compare to before.
  - pbft: prepared consensus type. if you use `pbft`, some node behavior is changed.
- added `validator.yaml`.
- added `snapshot-sync-headless.yaml`.

### Behavior changed list compare `pow` and `pbft`
- `miner.yaml`
  - statefulset is not created if pbft.
- `validator.yaml`
  -  pow
     - just syncing chain. do nothing.
  - pbft
    - validate and propose block as a validator.
- `service.yaml`
  - `gossip` port is open if pbft.

### Why need the `{{ insert here to newly add statefulset }}`?
Before changing PBFT, all nodes who want to join the PBFT network are synced to the highest tip.
For that reason, the `{{ insert here to newly add statefulset }}` is act as a sync-only node before stopping the PoW network.