### PR TITLE
increase internal-v2 node max-size

### DIFF
--- a/9c-internal/terraform/.terraform.lock.hcl
+++ b/9c-internal/terraform/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/aws" {
   version = "4.25.0"
   hashes = [
+    "h1:0dYkCnmIGkx+TlvUy21GpK7/8cCfN/fiZjHV+AAt3Xw=",
     "h1:EVNvuFgSV/Vaer3SOE0cZcc2yR0xNBRWfaJ4vo+oNB8=",
     "h1:JyQAQ3YrE4utVAQsLGy1LjMbAzzRI/X2XsrY7CFBGxw=",
     "zh:51fddc33f289108f60c2de78537f758ae913b2614187abfc3f560f9dd277bc1a",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version = "4.0.1"
   hashes = [
     "h1:NUd1WMN8YPDlMrBbDuiuGDpPlAM6JtDd75qbN+6tw4Q=",
+    "h1:oyckFNWXgZtgUanWHbNyz3txRgXYkDpCsTLSv5JSD1I=",
     "h1:suLkTTvsuB5kqV5gc12PyGT4zY0J9G0RTyWMlZDwSVY=",
     "zh:1aa2e4c07ddf87f7bda65a4a0f3b45c3edfbe983768d49a105f7ab9f2e4f8320",
     "zh:1b7993daaf659dec421043ccf2dea021972ebacf47e5da3387e1ef35a0ffecbe",

--- a/9c-internal/terraform/terraform.tfvars
+++ b/9c-internal/terraform/terraform.tfvars
@@ -34,7 +34,7 @@ node_groups = {
     capacity_type     = "SPOT"
     desired_size      = 4
     min_size          = 0
-    max_size          = 4
+    max_size          = 10
   }
 
   "9c-internal-m5d_2xl_2c" = {
@@ -43,7 +43,7 @@ node_groups = {
     capacity_type     = "SPOT"
     desired_size      = 2
     min_size          = 0
-    max_size          = 2
+    max_size          = 5
   }
 
   "9c-internal-m5d_xl_2c" = {
@@ -52,6 +52,6 @@ node_groups = {
     capacity_type     = "SPOT"
     desired_size      = 5
     min_size          = 0
-    max_size          = 5
+    max_size          = 15
   }
 }


### PR DESCRIPTION
```
Terraform will perform the following actions:

  # aws_eks_node_group.node_groups["9c-internal-m5d_2xl_2c"] will be updated in-place
  ~ resource "aws_eks_node_group" "node_groups" {
        id              = "9c-internal-v2:9c-internal-m5d_2xl_2c"
        tags            = {}
        # (15 unchanged attributes hidden)

      ~ scaling_config {
          ~ max_size     = 2 -> 5
            # (2 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

  # aws_eks_node_group.node_groups["9c-internal-m5d_l_2c"] will be updated in-place
  ~ resource "aws_eks_node_group" "node_groups" {
        id              = "9c-internal-v2:9c-internal-m5d_l_2c"
        tags            = {}
        # (15 unchanged attributes hidden)

      ~ scaling_config {
          ~ max_size     = 4 -> 10
            # (2 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

  # aws_eks_node_group.node_groups["9c-internal-m5d_xl_2c"] will be updated in-place
  ~ resource "aws_eks_node_group" "node_groups" {
        id              = "9c-internal-v2:9c-internal-m5d_xl_2c"
        tags            = {}
        # (15 unchanged attributes hidden)

      ~ scaling_config {
          ~ max_size     = 5 -> 15
            # (2 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.
```