### PR TITLE
Add app.kubernetes.io label for no difference

### DIFF
--- a/9c-internal/chart/templates/configmap-data-provider.yaml
+++ b/9c-internal/chart/templates/configmap-data-provider.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Chart.Name }}-data-provider-script
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 data:
   check_chain_tip.sh: |-
     #!/usr/bin/env bash

--- a/9c-internal/chart/templates/configmap-probe.yaml
+++ b/9c-internal/chart/templates/configmap-probe.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Chart.Name }}-probe-script
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 data:
   liveness_probe.sh: |-
     #!/usr/bin/env bash

--- a/9c-internal/chart/templates/configmap-snapshot.yaml
+++ b/9c-internal/chart/templates/configmap-snapshot.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Chart.Name }}-snapshot-script
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 data:
   download_snapshot.sh: |-
     #!/usr/bin/env bash

--- a/9c-internal/chart/templates/data-provider-db.yaml
+++ b/9c-internal/chart/templates/data-provider-db.yaml
@@ -4,6 +4,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: data-provider-db
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: data-provider-db
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-internal/chart/templates/data-provider.yaml
+++ b/9c-internal/chart/templates/data-provider.yaml
@@ -4,6 +4,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: data-provider
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: data-provider
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-internal/chart/templates/explorer.yaml
+++ b/9c-internal/chart/templates/explorer.yaml
@@ -3,6 +3,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: explorer
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: explorer
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-internal/chart/templates/gp2-extensible.yaml
+++ b/9c-internal/chart/templates/gp2-extensible.yaml
@@ -2,6 +2,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ .Chart.Name }}-gp2
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 parameters:
   fsType: ext4
   type: gp2

--- a/9c-internal/chart/templates/gp3-extensible.yaml
+++ b/9c-internal/chart/templates/gp3-extensible.yaml
@@ -2,6 +2,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ .Chart.Name }}-gp3
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 parameters:
   fsType: ext4
   type: gp3

--- a/9c-internal/chart/templates/market-db.yaml
+++ b/9c-internal/chart/templates/market-db.yaml
@@ -4,6 +4,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: market-db
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: market-db
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-internal/chart/templates/market-service.yaml
+++ b/9c-internal/chart/templates/market-service.yaml
@@ -4,6 +4,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: market-service
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: market-service
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-internal/chart/templates/miner.yaml
+++ b/9c-internal/chart/templates/miner.yaml
@@ -6,6 +6,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: miner-{{ $index }}
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: miner-{{ $index }}
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-internal/chart/templates/namespace.yaml
+++ b/9c-internal/chart/templates/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}

--- a/9c-internal/chart/templates/remote-headless.yaml
+++ b/9c-internal/chart/templates/remote-headless.yaml
@@ -5,6 +5,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: remote-headless-{{ $index }}
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: remote-headless-{{ $index }}
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-internal/chart/templates/secret-aws-keys.yaml
+++ b/9c-internal/chart/templates/secret-aws-keys.yaml
@@ -4,6 +4,8 @@ kind: ExternalSecret
 metadata:
   name: aws-keys
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   refreshInterval: 1m
   secretStoreRef:

--- a/9c-internal/chart/templates/secret-data-provider.yaml
+++ b/9c-internal/chart/templates/secret-data-provider.yaml
@@ -5,6 +5,8 @@ kind: ExternalSecret
 metadata:
   name: data-provider
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   refreshInterval: 1m
   secretStoreRef:

--- a/9c-internal/chart/templates/secret-market-db.yaml
+++ b/9c-internal/chart/templates/secret-market-db.yaml
@@ -5,6 +5,8 @@ kind: ExternalSecret
 metadata:
   name: market-db
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   refreshInterval: 1m
   secretStoreRef:

--- a/9c-internal/chart/templates/secret-private-keys.yaml
+++ b/9c-internal/chart/templates/secret-private-keys.yaml
@@ -4,6 +4,8 @@ kind: ExternalSecret
 metadata:
   name: private-keys
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   refreshInterval: 1m
   secretStoreRef:

--- a/9c-internal/chart/templates/secret-slack-token.yaml
+++ b/9c-internal/chart/templates/secret-slack-token.yaml
@@ -4,6 +4,8 @@ kind: ExternalSecret
 metadata:
   name: slack
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   refreshInterval: 1m
   secretStoreRef:

--- a/9c-internal/chart/templates/secret-store.yaml
+++ b/9c-internal/chart/templates/secret-store.yaml
@@ -4,6 +4,8 @@ kind: SecretStore
 metadata:
   name: {{ $.Chart.Name }}-secretsmanager
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   provider:
     aws:

--- a/9c-internal/chart/templates/seed.yaml
+++ b/9c-internal/chart/templates/seed.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   labels:
     app: tcp-seed-{{ $index }}
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: tcp-seed-{{ $index }}
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-internal/chart/templates/snapshot-sync-headless.yaml
+++ b/9c-internal/chart/templates/snapshot-sync-headless.yaml
@@ -3,6 +3,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: snapshot-sync-headless
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: snapshot-sync-headless
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-internal/chart/templates/snapshot-volume.yaml
+++ b/9c-internal/chart/templates/snapshot-volume.yaml
@@ -3,6 +3,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: snapshot-volume
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     volume.beta.kubernetes.io/storage-provisioner: ebs.csi.aws.com
     volume.kubernetes.io/storage-provisioner: ebs.csi.aws.com

--- a/9c-internal/chart/templates/snapshot.yaml
+++ b/9c-internal/chart/templates/snapshot.yaml
@@ -3,6 +3,8 @@ kind: CronJob
 metadata:
   name: snapshot
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   failedJobsHistoryLimit: 1
   jobTemplate:

--- a/9c-internal/chart/templates/validator.yaml
+++ b/9c-internal/chart/templates/validator.yaml
@@ -5,6 +5,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: validator-{{ $index }}
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: validator-{{ $index }}
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-main/chart/templates/bridge.yaml
+++ b/9c-main/chart/templates/bridge.yaml
@@ -4,6 +4,8 @@ kind: CronJob
 metadata:
   name: bridge-status-bot
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   schedule: "0 * * * *"
   successfulJobsHistoryLimit: 1
@@ -51,6 +53,8 @@ kind: ConfigMap
 metadata:
   name: bridge-status-bot-scripts
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 data:
   bot.sh: |-
     #!/bin/bash
@@ -65,6 +69,8 @@ kind: CronJob
 metadata:
   name: bridge-observer
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   failedJobsHistoryLimit: 1
   jobTemplate:

--- a/9c-main/chart/templates/configmap-data-provider.yaml
+++ b/9c-main/chart/templates/configmap-data-provider.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: 9c-network-data-provider-script
   namespace: 9c-network
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 data:
   check_chain_tip.sh: |-
     #!/usr/bin/env bash

--- a/9c-main/chart/templates/configmap-download-snapshot.yaml
+++ b/9c-main/chart/templates/configmap-download-snapshot.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Chart.Name }}-download-snapshot-script
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 data:
   download_snapshot.sh: |-
     #!/usr/bin/env bash

--- a/9c-main/chart/templates/configmap-full.yaml
+++ b/9c-main/chart/templates/configmap-full.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Chart.Name }}-snapshot-script-full
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 data:
   preload_headless.sh: |-
     #!/usr/bin/env bash

--- a/9c-main/chart/templates/configmap-partition-reset.yaml
+++ b/9c-main/chart/templates/configmap-partition-reset.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Chart.Name }}-snapshot-script-partition-reset
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 data:
   preload_headless.sh: |-
     #!/usr/bin/env bash

--- a/9c-main/chart/templates/configmap-partition.yaml
+++ b/9c-main/chart/templates/configmap-partition.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Chart.Name }}-snapshot-script-partition
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 data:
   preload_headless.sh: |-
     #!/usr/bin/env bash

--- a/9c-main/chart/templates/configmap-probe.yaml
+++ b/9c-main/chart/templates/configmap-probe.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Chart.Name }}-probe-script
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 data:
   liveness_probe.sh: |-
     #!/usr/bin/env bash

--- a/9c-main/chart/templates/data-provider-read.yaml
+++ b/9c-main/chart/templates/data-provider-read.yaml
@@ -3,6 +3,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: data-provider-read
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: data-provider-read
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-main/chart/templates/data-provider-write.yaml
+++ b/9c-main/chart/templates/data-provider-write.yaml
@@ -3,6 +3,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: data-provider-write
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: data-provider-write
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-main/chart/templates/explorer.yaml
+++ b/9c-main/chart/templates/explorer.yaml
@@ -3,6 +3,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: explorer
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: explorer
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-main/chart/templates/full-state.yaml
+++ b/9c-main/chart/templates/full-state.yaml
@@ -3,6 +3,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: main-full-state
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: main-full-state
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-main/chart/templates/gp2-extensible.yaml
+++ b/9c-main/chart/templates/gp2-extensible.yaml
@@ -2,6 +2,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ .Chart.Name }}-gp2
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 parameters:
   fsType: ext4
   type: gp2

--- a/9c-main/chart/templates/gp3-extensible.yaml
+++ b/9c-main/chart/templates/gp3-extensible.yaml
@@ -2,6 +2,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ .Chart.Name }}-gp3
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 parameters:
   fsType: ext4
   type: gp3

--- a/9c-main/chart/templates/market-service-write.yaml
+++ b/9c-main/chart/templates/market-service-write.yaml
@@ -4,6 +4,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: market-service-write
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: market-service-write
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-main/chart/templates/market-service.yaml
+++ b/9c-main/chart/templates/market-service.yaml
@@ -4,6 +4,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: market-service
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: market-service
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-main/chart/templates/miner-1.yaml
+++ b/9c-main/chart/templates/miner-1.yaml
@@ -3,6 +3,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: main-miner-1
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: main-miner-1
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-main/chart/templates/miner-2.yaml
+++ b/9c-main/chart/templates/miner-2.yaml
@@ -3,6 +3,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: main-miner-2
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: main-miner-2
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-main/chart/templates/miner-3.yaml
+++ b/9c-main/chart/templates/miner-3.yaml
@@ -3,6 +3,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: main-miner-3
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: main-miner-3
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-main/chart/templates/miner-4.yaml
+++ b/9c-main/chart/templates/miner-4.yaml
@@ -3,6 +3,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: main-miner-4
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: main-miner-4
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-main/chart/templates/namespace.yaml
+++ b/9c-main/chart/templates/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}

--- a/9c-main/chart/templates/remote-headless.yaml
+++ b/9c-main/chart/templates/remote-headless.yaml
@@ -5,6 +5,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: remote-headless-{{ $index }}
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: remote-headless-{{ $index }}
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-main/chart/templates/secret-aws-keys.yaml
+++ b/9c-main/chart/templates/secret-aws-keys.yaml
@@ -4,6 +4,8 @@ kind: ExternalSecret
 metadata:
   name: aws-keys
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   refreshInterval: 1m
   secretStoreRef:

--- a/9c-main/chart/templates/secret-bridge.yaml
+++ b/9c-main/chart/templates/secret-bridge.yaml
@@ -5,6 +5,8 @@ kind: ExternalSecret
 metadata:
   name: bridge
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   refreshInterval: 1m
   secretStoreRef:

--- a/9c-main/chart/templates/secret-data-provider.yaml
+++ b/9c-main/chart/templates/secret-data-provider.yaml
@@ -5,6 +5,8 @@ kind: ExternalSecret
 metadata:
   name: data-provider
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   refreshInterval: 1m
   secretStoreRef:

--- a/9c-main/chart/templates/secret-market-db.yaml
+++ b/9c-main/chart/templates/secret-market-db.yaml
@@ -5,6 +5,8 @@ kind: ExternalSecret
 metadata:
   name: market-db
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   refreshInterval: 1m
   secretStoreRef:

--- a/9c-main/chart/templates/secret-private-keys.yaml
+++ b/9c-main/chart/templates/secret-private-keys.yaml
@@ -4,6 +4,8 @@ kind: ExternalSecret
 metadata:
   name: private-keys
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   refreshInterval: 1m
   secretStoreRef:

--- a/9c-main/chart/templates/secret-slack-token.yaml
+++ b/9c-main/chart/templates/secret-slack-token.yaml
@@ -4,6 +4,8 @@ kind: ExternalSecret
 metadata:
   name: slack
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   refreshInterval: 1m
   secretStoreRef:

--- a/9c-main/chart/templates/secret-world-boss.yaml
+++ b/9c-main/chart/templates/secret-world-boss.yaml
@@ -5,6 +5,8 @@ kind: ExternalSecret
 metadata:
   name: world-boss-env
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   refreshInterval: 1m
   secretStoreRef:

--- a/9c-main/chart/templates/seed.yaml
+++ b/9c-main/chart/templates/seed.yaml
@@ -5,6 +5,7 @@ kind: Deployment
 metadata:
   labels:
     app: tcp-seed-{{ $index }}
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: tcp-seed-{{ $index }}
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-main/chart/templates/service.yaml
+++ b/9c-main/chart/templates/service.yaml
@@ -5,6 +5,8 @@ kind: Service
 metadata:
   name: tcp-seed-{{ $index }}
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
@@ -37,6 +39,8 @@ kind: Service
 metadata:
   name: main-miner-1
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
@@ -67,6 +71,8 @@ kind: Service
 metadata:
   name: main-miner-2
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
@@ -97,6 +103,8 @@ kind: Service
 metadata:
   name: main-miner-3
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
@@ -127,6 +135,8 @@ kind: Service
 metadata:
   name: main-miner-4
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
@@ -160,6 +170,8 @@ kind: Service
 metadata:
   name: remote-headless-{{ $index }}
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
@@ -194,6 +206,8 @@ kind: Service
 metadata:
   name: data-provider-write
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   ports:
   - name: graphql
@@ -210,6 +224,8 @@ kind: Service
 metadata:
   name: data-provider-read
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   ports:
   - name: graphql
@@ -226,6 +242,8 @@ kind: Service
 metadata:
   name: explorer
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
@@ -253,6 +271,8 @@ kind: Service
 metadata:
   name: main-full-state
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
@@ -282,6 +302,8 @@ kind: Service
 metadata:
   name: onboarding-headless-query
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
@@ -312,6 +334,8 @@ kind: Service
 metadata:
   name: onboarding-headless-transfer
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
@@ -347,6 +371,8 @@ kind: Service
 metadata:
   name: test-headless-{{ $index }}
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
@@ -381,6 +407,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-2:319679068466:certificate/4312c1a7-51c4-4442-8ae4-c8f3f2bce4f0
@@ -415,6 +443,8 @@ kind: Service
 metadata:
   name: market-service
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
@@ -446,6 +476,8 @@ kind: Service
 metadata:
   name: validator-{{ $index }}
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"

--- a/9c-main/chart/templates/snapshot-full.yaml
+++ b/9c-main/chart/templates/snapshot-full.yaml
@@ -3,6 +3,8 @@ kind: CronJob
 metadata:
   name: snapshot-full
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   failedJobsHistoryLimit: 1
   jobTemplate:

--- a/9c-main/chart/templates/snapshot-partition-reset.yaml
+++ b/9c-main/chart/templates/snapshot-partition-reset.yaml
@@ -3,6 +3,8 @@ kind: CronJob
 metadata:
   name: snapshot-partition-reset
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
   failedJobsHistoryLimit: 1
   jobTemplate:

--- a/9c-main/chart/templates/snapshot-volume.yaml
+++ b/9c-main/chart/templates/snapshot-volume.yaml
@@ -3,6 +3,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: snapshot-volume-partition
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     volume.beta.kubernetes.io/storage-provisioner: ebs.csi.aws.com
     volume.kubernetes.io/storage-provisioner: ebs.csi.aws.com
@@ -22,6 +24,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: snapshot-volume-full
   namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   annotations:
     volume.beta.kubernetes.io/storage-provisioner: ebs.csi.aws.com
     volume.kubernetes.io/storage-provisioner: ebs.csi.aws.com

--- a/9c-main/chart/templates/test-headless.yaml
+++ b/9c-main/chart/templates/test-headless.yaml
@@ -5,6 +5,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: test-headless-{{ $index }}
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: test-headless-{{ $index }}
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-main/chart/templates/validator.yaml
+++ b/9c-main/chart/templates/validator.yaml
@@ -5,6 +5,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: validator-{{ $index }}
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: validator-{{ $index }}
   namespace: {{ $.Chart.Name }}
 spec:

--- a/9c-main/chart/templates/worldboss.yaml
+++ b/9c-main/chart/templates/worldboss.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::319679068466:role/9c-onboarding-eks
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: {{ $.Chart.Name }}-onboarding-iam-role
   namespace: {{ $.Chart.Name }}
 
@@ -14,6 +16,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: world-boss-service
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: world-boss-service
   namespace: {{ $.Chart.Name }}
 spec:
@@ -94,6 +97,7 @@ kind: StatefulSet
 metadata:
   labels:
     app: world-boss-worker
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
   name: world-boss-worker
   namespace: {{ $.Chart.Name }}
 spec:

--- a/common/bootstrap/templates/loki.yaml
+++ b/common/bootstrap/templates/loki.yaml
@@ -107,14 +107,14 @@ spec:
           nodeSelector:
             eks.amazonaws.com/nodegroup: {{ $.Values.loki.write.nodeGroup }}
           resources:
-            {{- toYaml $.Values.loki.write.resources | nindent 10 }}
+            {{- toYaml $.Values.loki.write.resources | nindent 12 }}
 
         read:
           replicas: {{ $.Values.loki.read.count }}
           nodeSelector:
             eks.amazonaws.com/nodegroup: {{ $.Values.loki.read.nodeGroup }}
           resources:
-            {{- toYaml $.Values.loki.read.resources | nindent 10 }}
+            {{- toYaml $.Values.loki.read.resources | nindent 12 }}
 
         test:
           enabled: false


### PR DESCRIPTION
if we apply 9c-network manifests manually(for example `helm template blahblah | kubectl apply -f-`), it automatically adds `app.kubernetes.io/instance` labels.
so argoCD recognizes differences for those labels on every resources.
this PR add that label for no difference between argoCD and helm apply