### PR TITLE
decrease rate-limit interval from 1hr to 10min

### DIFF
--- a/9c-main/chart/templates/remote-headless.yaml
+++ b/9c-main/chart/templates/remote-headless.yaml
@@ -114,9 +114,9 @@ spec:
         - name: IpRateLimiting__GeneralRules__1__Endpoint
           value: "*:/graphql"
         - name: IpRateLimiting__GeneralRules__1__Period
-          value: "1h"
+          value: "10m"
         - name: IpRateLimiting__GeneralRules__1__Limit
-          value: "1800"
+          value: "300"
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Refresh every 10min because some users might not be able to participate in the arena battle if the refresh interval is 1hr.