### PR TITLE
update internal nodegroups

### DIFF
--- a/9c-internal/terraform/terraform.tfvars
+++ b/9c-internal/terraform/terraform.tfvars
@@ -32,7 +32,7 @@ node_groups = {
     instance_types    = ["m5d.large"]
     availability_zone = "us-east-2c"
     capacity_type     = "SPOT"
-    desired_size      = 4
+    desired_size      = 3
     min_size          = 0
     max_size          = 10
   }
@@ -41,7 +41,7 @@ node_groups = {
     instance_types    = ["m5d.2xlarge"]
     availability_zone = "us-east-2c"
     capacity_type     = "SPOT"
-    desired_size      = 2
+    desired_size      = 0
     min_size          = 0
     max_size          = 5
   }
@@ -50,16 +50,26 @@ node_groups = {
     instance_types    = ["m5d.xlarge"]
     availability_zone = "us-east-2c"
     capacity_type     = "SPOT"
+    desired_size      = 0
+    min_size          = 0
+    max_size          = 15
+  }
+
+  "9c-internal-r6g_l_2c" = {
+    instance_types    = ["r6g.large"]
+    availability_zone = "us-east-2c"
+    capacity_type     = "SPOT"
     desired_size      = 5
     min_size          = 0
     max_size          = 15
+    ami_type          = "AL2_ARM_64"
   }
 
   "9c-internal-r6g_xl_2c" = {
     instance_types    = ["r6g.xlarge"]
     availability_zone = "us-east-2c"
     capacity_type     = "SPOT"
-    desired_size      = 4
+    desired_size      = 0
     min_size          = 0
     max_size          = 15
     ami_type          = "AL2_ARM_64"


### PR DESCRIPTION
Use `r6g.large` instead of `r6g.xlarge` for internal rpc and validators.