### PR TITLE
feat(bootstrap): add nodeGroup configuration for argocd and prometheus

### DIFF
--- a/9c-main/argocd/argocd-node-selectors.yaml
+++ b/9c-main/argocd/argocd-node-selectors.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: argocd-application-controller
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node.kubernetes.io/instance-type: r6g.xlarge
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-dex-server
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node.kubernetes.io/instance-type: r6g.xlarge
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-notifications-controller
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node.kubernetes.io/instance-type: r6g.xlarge
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-server
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node.kubernetes.io/instance-type: r6g.xlarge
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-applicationset-controller
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node.kubernetes.io/instance-type: r6g.xlarge

--- a/9c-main/argocd/kustomization.yaml
+++ b/9c-main/argocd/kustomization.yaml
@@ -29,3 +29,33 @@ patchesJson6902:
             name: 9c-main-v2-external-secrets
             annotations:
               eks.amazonaws.com/role-arn: arn:aws:iam::319679068466:role/eks-9c-main-v2-external-secrets
+  - target:
+      name: argocd-applicationset-controller
+    patch: |-
+      - op: add
+        path: /spec/template/spec/container/0/nodeGroup
+        value: 9c-main-r6g_xl_2c
+  - target:
+      name: argocd-dex-server
+    patch: |-
+      - op: add
+        path: /spec/template/spec/container/0/nodeGroup
+        value: 9c-main-r6g_xl_2c
+  - target:
+      name: argocd-notifications-controller
+    patch: |-
+      - op: add
+        path: /spec/template/spec/container/0/nodeGroup
+        value: 9c-main-r6g_xl_2c
+  - target:
+      name: argocd-server
+    patch: |-
+      - op: add
+        path: /spec/template/spec/container/0/nodeGroup
+        value: 9c-main-r6g_xl_2c
+  - target:
+      name: argocd-application-controller
+    patch: |-
+      - op: add
+        path: /spec/template/spec/container/0/nodeGroup
+        value: 9c-main-r6g_xl_2c

--- a/9c-main/argocd/kustomization.yaml
+++ b/9c-main/argocd/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 patchesStrategicMerge:
   - argocd-cm.yaml
   - argocd-rbac-cm.yaml
+  - argocd-nodeSelectors.yaml
 patchesJson6902:
   - target:
       group: argoproj.io
@@ -29,33 +30,3 @@ patchesJson6902:
             name: 9c-main-v2-external-secrets
             annotations:
               eks.amazonaws.com/role-arn: arn:aws:iam::319679068466:role/eks-9c-main-v2-external-secrets
-  - target:
-      name: argocd-applicationset-controller
-    patch: |-
-      - op: add
-        path: /spec/template/spec/container/0/nodeGroup
-        value: 9c-main-r6g_xl_2c
-  - target:
-      name: argocd-dex-server
-    patch: |-
-      - op: add
-        path: /spec/template/spec/container/0/nodeGroup
-        value: 9c-main-r6g_xl_2c
-  - target:
-      name: argocd-notifications-controller
-    patch: |-
-      - op: add
-        path: /spec/template/spec/container/0/nodeGroup
-        value: 9c-main-r6g_xl_2c
-  - target:
-      name: argocd-server
-    patch: |-
-      - op: add
-        path: /spec/template/spec/container/0/nodeGroup
-        value: 9c-main-r6g_xl_2c
-  - target:
-      name: argocd-application-controller
-    patch: |-
-      - op: add
-        path: /spec/template/spec/container/0/nodeGroup
-        value: 9c-main-r6g_xl_2c

--- a/9c-main/argocd/kustomization.yaml
+++ b/9c-main/argocd/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 patchesStrategicMerge:
   - argocd-cm.yaml
   - argocd-rbac-cm.yaml
-  - argocd-nodeSelectors.yaml
+  - argocd-node-selectors.yaml
 patchesJson6902:
   - target:
       group: argoproj.io

--- a/common/bootstrap/templates/argocd-app.yaml
+++ b/common/bootstrap/templates/argocd-app.yaml
@@ -11,6 +11,7 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd
+
   # syncPolicy:
   #   automated:
   #     prune: true

--- a/common/bootstrap/templates/prometheus.yaml
+++ b/common/bootstrap/templates/prometheus.yaml
@@ -50,7 +50,11 @@ spec:
             type: Recreate
           extraArgs:
             log.level: debug
-        
+          {{- with $.Values.prometheus.server.nodeGroup }}
+          nodeSelector:
+            eks.amazonaws.com/nodegroup: {{ . }}
+          {{- end }}
+
         serverFiles:
           prometheus.yml:
             rule_files:

--- a/common/bootstrap/values.yaml
+++ b/common/bootstrap/values.yaml
@@ -25,3 +25,7 @@ loki:
         cpu: 1500m
         memory: 8Gi
     nodeGroup: ""
+
+prometheus:
+  server:
+    nodeGroup: ""


### PR DESCRIPTION
Set node group for argocd and prometheus to `9c-main-r6g_xl_2c` for better performance.

ref: https://raw.githubusercontent.com/argoproj/argo-cd/v2.6.4/manifests/ha/install.yaml