### PR TITLE
use 9c-snapshots-v2 bucket

### DIFF
--- a/.github/scripts/reset-snapshot.sh
+++ b/.github/scripts/reset-snapshot.sh
@@ -85,7 +85,7 @@ reset_snapshot() {
 
   fi
 
-  BUCKET="s3://9c-snapshots"
+  BUCKET="s3://9c-snapshots-v2"
   BUCKET_PREFIX=$(echo $BUCKET | awk '{gsub(/\//,"\\/");print}')
   CF_PATH=$(echo $1/ | sed -e "s/^$BUCKET_PREFIX//" | sed "s/.*/&*/")
 
@@ -104,7 +104,7 @@ if [ $response = y ]
 then
     echo "Reset cluster with a new snapshot"
     curl -X POST -H 'Content-type: application/json' --data '{"text":"[K8S] Reset cluster with a new snapshot"}' $SLACK_WEBHOOK_URL
-    reset_snapshot "s3://9c-snapshots/internal" "s3://9c-snapshots/main/partition/internal" $SLACK_WEBHOOK_URL || true
+    reset_snapshot "s3://9c-snapshots-v2/internal" "s3://9c-snapshots-v2/main/partition/internal" $SLACK_WEBHOOK_URL || true
 else
     echo "Reset cluster without resetting snapshot."
     curl -X POST -H 'Content-type: application/json' --data '{"text":"[K8S] Reset cluster without resetting snapshot."}' $SLACK_WEBHOOK_URL

--- a/9c-internal/chart/templates/configmap-snapshot.yaml
+++ b/9c-internal/chart/templates/configmap-snapshot.yaml
@@ -344,7 +344,7 @@ data:
       LATEST_STATE_FILENAME=$(basename "$LATEST_STATE")
       STATE_FILENAME=$(echo $LATEST_STATE_FILENAME | cut -d'.' -f 1)
 
-      S3_BUCKET_NAME="9c-snapshots"
+      S3_BUCKET_NAME="9c-snapshots-v2"
       S3_LATEST_SNAPSHOT_PATH="internal/$UPLOAD_SNAPSHOT_FILENAME"
       S3_LATEST_METADATA_PATH="internal/$UPLOAD_METADATA_FILENAME"
 

--- a/9c-main/chart/templates/configmap-full.yaml
+++ b/9c-main/chart/templates/configmap-full.yaml
@@ -178,7 +178,7 @@ data:
       UPLOAD_FULL_SNAPSHOT_FILENAME="9c-main-snapshot"
       FULL_SNAPSHOT_FILENAME="$UPLOAD_FULL_SNAPSHOT_FILENAME.zip"
 
-      S3_BUCKET_NAME="9c-snapshots"
+      S3_BUCKET_NAME="9c-snapshots-v2"
 
       AWS="/usr/local/bin/aws"
       AWS_ACCESS_KEY_ID="$(cat "/secret/aws_access_key_id")"

--- a/9c-main/chart/templates/configmap-partition-reset.yaml
+++ b/9c-main/chart/templates/configmap-partition-reset.yaml
@@ -186,7 +186,7 @@ data:
       LATEST_STATE_FILENAME=$(basename "$LATEST_STATE")
       STATE_FILENAME=$(echo $LATEST_STATE_FILENAME | cut -d'.' -f 1)
 
-      S3_BUCKET_NAME="9c-snapshots"
+      S3_BUCKET_NAME="9c-snapshots-v2"
       S3_LATEST_SNAPSHOT_PATH="main/$1/partition/$UPLOAD_SNAPSHOT_FILENAME"
       S3_LATEST_METADATA_PATH="main/$1/partition/$UPLOAD_METADATA_FILENAME"
 
@@ -268,7 +268,7 @@ data:
         aws s3 mv $(echo $f | sed "s/.*/$TEMP_PREFIX&/") $(echo $f | sed "s/.*/$SNAPSHOT_PREFIX/")
       done
 
-      BUCKET="s3://9c-snapshots"
+      BUCKET="s3://9c-snapshots-v2"
       BUCKET_PREFIX=$(echo $BUCKET | awk '{gsub(/\//,"\\/");print}')
       CF_PATH=$(echo $1 | sed -e "s/^$BUCKET_PREFIX//" | sed "s/.*/&*/")
 

--- a/9c-main/chart/templates/configmap-partition.yaml
+++ b/9c-main/chart/templates/configmap-partition.yaml
@@ -187,7 +187,7 @@ data:
       LATEST_STATE_FILENAME=$(basename "$LATEST_STATE")
       STATE_FILENAME=$(echo $LATEST_STATE_FILENAME | cut -d'.' -f 1)
 
-      S3_BUCKET_NAME="9c-snapshots"
+      S3_BUCKET_NAME="9c-snapshots-v2"
       S3_LATEST_SNAPSHOT_PATH="main/partition/$UPLOAD_SNAPSHOT_FILENAME"
       S3_LATEST_METADATA_PATH="main/partition/$UPLOAD_METADATA_FILENAME"
       S3_LATEST_INTERNAL_SNAPSHOT_PATH="main/partition/internal/$UPLOAD_SNAPSHOT_FILENAME"

--- a/9c-main/chart/templates/snapshot-partition-reset.yaml
+++ b/9c-main/chart/templates/snapshot-partition-reset.yaml
@@ -96,8 +96,8 @@ spec:
               readOnly: true
           containers:
           - args:
-            - s3://9c-snapshots/main/partition/
-            - s3://9c-snapshots/main/temp/partition/
+            - s3://9c-snapshots-v2/main/partition/
+            - s3://9c-snapshots-v2/main/temp/partition/
             - $(SLACK_TOKEN)
             - $(CF_DISTRIBUTION_ID)
             command:


### PR DESCRIPTION
Move the official snapshot bucket from `9c-snapshots`(ap-northeast-2) to `9c-snapshots-v2`(us-east-2) to minimize data transfer cost. (I've also moved `https://snapshots.nine-chronicles.com`'s bucket to `9c-snapshots-v2`)