### PR TITLE
Update prometheus scrape configs

### DIFF
--- a/common/bootstrap/templates/prometheus.yaml
+++ b/common/bootstrap/templates/prometheus.yaml
@@ -74,6 +74,42 @@ spec:
                 static_configs:
                   - targets:
                     - ninechronicles-headless-metrics-aggregator.monitoring.svc.cluster.local:80
+              - job_name: scrape-headlesses
+                metrics_path: /metrics
+                scrape_interval: 1m
+                scrape_timeout: 50s
+                static_configs:
+                  - targets:
+                    - 9c-main-validator-1.nine-chronicles.com:80
+                    - 9c-main-validator-2.nine-chronicles.com:80
+                    - 9c-main-validator-3.nine-chronicles.com:80
+                    - 9c-main-validator-4.nine-chronicles.com:80
+                    labels:
+                      group: validator
+                  - targets:
+                    - 9c-main-rpc-1.nine-chronicles.com:80
+                    - 9c-main-rpc-2.nine-chronicles.com:80
+                    - 9c-main-rpc-3.nine-chronicles.com:80
+                    - tky-nc-1.ninodes.com:80
+                    - sgp-nc-1.ninodes.com:80
+                    - nj-nc-1.ninodes.com:80
+                    - la-nc-1.ninodes.com:80
+                    - fra-nc-1.ninodes.com:80
+                    labels:
+                      group: rpc
+                  - targets:
+                    - 9c-main-full-state.planetarium.dev:80
+                    labels:
+                      group: full-state
+                  - targets:
+                    - api.9c.gg:80
+                    - 9c-main-data-provider-db.nine-chronicles.com:80
+                    labels:
+                      group: data-provider
+                  - targets:
+                    - d131807iozwu1d.cloudfront.net:80
+                    labels:
+                      group: explorer
                 tls_config:
                   insecure_skip_verify: true
               - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
Previously, it scrapes metrics through 9c-headless-gql-metrics-aggregator instance. This pull request makes prometheus scrape them directly without the metrics aggregator instance while maintaining current scraping rules. It may cause an unexpected downtown then I'll rollback these changes.

## Plan

 - [x] https://github.com/planetarium/NineChronicles.Headless/pull/2008
 - [x] Ready to deploy the above feature (v200020 release).
 - [ ] Apply these changes.
 - [ ] Update Grafana Dashboard with the metrics.
 - [ ] Deprecate 9c-headless-gql-metrics-aggregator deployment and archive the repository.