### PR TITLE
update headless image

### DIFF
--- a/9c-main/chart/values.yaml
+++ b/9c-main/chart/values.yaml
@@ -128,7 +128,7 @@ remoteHeadless:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v200010-1"
+    tag: "git-7c0815d08cb5d94700918ca4598ae2634c26ac1e"
 
   # dotnet args
 
@@ -408,7 +408,7 @@ validator:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "git-a18be1a8934d78de49fc542f1170836e91fc3a05"
+    tag: "git-7c0815d08cb5d94700918ca4598ae2634c26ac1e"
 
   consensusSeedStrings:
   - "027bd36895d68681290e570692ad3736750ceaab37be402442ffb203967f98f7b6,9c-main-tcp-seed-1.planetarium.dev,31235"


### PR DESCRIPTION
https://github.com/planetarium/NineChronicles.Headless/commit/7c0815d08cb5d94700918ca4598ae2634c26ac1e
Adjust json log rotation to prevent ephemeral-storage error in kubernetes.