### PR TITLE
Update nodegroup to reduce instance cost

### DIFF
--- a/9c-main/chart/templates/data-provider-read.yaml
+++ b/9c-main/chart/templates/data-provider-read.yaml
@@ -92,15 +92,15 @@ spec:
           protocol: TCP
         resources:
           requests:
-            cpu: 1000m
-            memory: 20Gi
+            cpu: '3'
+            memory: 12Gi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /data
           name: data-provider-read-data
       nodeSelector:
-        node.kubernetes.io/instance-type: r6g.xlarge
+        eks.amazonaws.com/nodegroup: 9c-main-m7g_xl_2c
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/9c-main/chart/templates/data-provider-write.yaml
+++ b/9c-main/chart/templates/data-provider-write.yaml
@@ -110,8 +110,8 @@ spec:
           protocol: TCP
         resources:
           requests:
-            cpu: 1000m
-            memory: 10Gi
+            cpu: '3'
+            memory: 12Gi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -122,7 +122,7 @@ spec:
         - mountPath: /data
           name: data-provider-write-data
       nodeSelector:
-        node.kubernetes.io/instance-type: c7g.2xlarge
+        eks.amazonaws.com/nodegroup: 9c-main-m7g_xl_2c
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/9c-main/chart/templates/market-service-write.yaml
+++ b/9c-main/chart/templates/market-service-write.yaml
@@ -48,7 +48,7 @@ spec:
           cpu: 6000m
       restartPolicy: Always
       nodeSelector:
-        node.kubernetes.io/instance-type: c7g.2xlarge
+        eks.amazonaws.com/nodegroup: 9c-main-m7g_xl_2c
   updateStrategy:
     type: RollingUpdate
 {{ end }}

--- a/9c-main/chart/templates/onboarding-headless.yaml
+++ b/9c-main/chart/templates/onboarding-headless.yaml
@@ -80,7 +80,7 @@ spec:
           readOnly: true
           subPath: readiness_probe.sh
       nodeSelector:
-        node.kubernetes.io/instance-type: r6g.xlarge
+        eks.amazonaws.com/nodegroup: 9c-main-m7g_xl_2c
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/9c-main/chart/templates/test-headless-1.yaml
+++ b/9c-main/chart/templates/test-headless-1.yaml
@@ -108,7 +108,7 @@ spec:
         - name: IpRateLimiting__GeneralRules__0__Limit
           value: "15"
       nodeSelector:
-        node.kubernetes.io/instance-type: r6g.xlarge
+        eks.amazonaws.com/nodegroup: 9c-main-r7g_xl_2c
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/9c-main/terraform/terraform.tfvars
+++ b/9c-main/terraform/terraform.tfvars
@@ -32,9 +32,29 @@ node_groups = {
     instance_types    = ["c7g.2xlarge"]
     availability_zone = "us-east-2c"
     capacity_type     = "ON_DEMAND"
+    desired_size      = 0
+    min_size          = 0
+    max_size          = 1
+    ami_type          = "AL2_ARM_64"
+  }
+
+  "9c-main-r7g_xl_2c" = {
+    instance_types    = ["r7g.xlarge"]
+    availability_zone = "us-east-2c"
+    capacity_type     = "ON_DEMAND"
     desired_size      = 1
     min_size          = 0
-    max_size          = 3
+    max_size          = 2
+    ami_type          = "AL2_ARM_64"
+  }
+
+  "9c-main-m7g_xl_2c" = {
+    instance_types    = ["m7g.xlarge"]
+    availability_zone = "us-east-2c"
+    capacity_type     = "ON_DEMAND"
+    desired_size      = 5
+    min_size          = 0
+    max_size          = 6
     ami_type          = "AL2_ARM_64"
   }
 
@@ -52,7 +72,7 @@ node_groups = {
     instance_types    = ["r6g.xlarge"]
     availability_zone = "us-east-2c"
     capacity_type     = "ON_DEMAND"
-    desired_size      = 11
+    desired_size      = 10
     min_size          = 0
     max_size          = 20
     ami_type          = "AL2_ARM_64"
@@ -62,8 +82,7 @@ node_groups = {
     instance_types    = ["m5.2xlarge"]
     availability_zone = "us-east-2c"
     capacity_type     = "ON_DEMAND"
-    desired_size      = 2
+    desired_size      = 0
     min_size          = 0
     max_size          = 5
   }
-}


### PR DESCRIPTION
- Use `m7g.xlarge` (4CPU, 16GB ram) instead of `r6g.xlarge` (4CPU, 32GB ram) or `c7g.2xlarge` (8CPU, 16GB ram) to reduce cost.
- `r6g.xlarge` instance count lowered from 16 to 10 and `c7g.2xlarge` from 1 to 0.
- `r7g.xlarge` added for `test-headless-1-0` (used by `market-service-write`).