### PR TITLE
Change RPC nodegroup

### DIFF
--- a/9c-main/chart/templates/remote-headless.yaml
+++ b/9c-main/chart/templates/remote-headless.yaml
@@ -120,11 +120,11 @@ spec:
         - name: IpRateLimiting__EnableEndpointRateLimiting
           value: "true"
         - name: IpRateLimiting__GeneralRules__0__Period
-          value: "2s"
+          value: "5s"
         - name: IpRateLimiting__GeneralRules__1__Period
-          value: "2s"
+          value: "5s"
       nodeSelector:
-        node.kubernetes.io/instance-type: c7g.4xlarge
+        eks.amazonaws.com/nodegroup: 9c-main-m7g_2xl_2c
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/9c-main/terraform/terraform.tfvars
+++ b/9c-main/terraform/terraform.tfvars
@@ -58,13 +58,23 @@ node_groups = {
     ami_type          = "AL2_ARM_64"
   }
 
+  "9c-main-m7g_2xl_2c" = {
+    instance_types    = ["m7g.2xlarge"]
+    availability_zone = "us-east-2c"
+    capacity_type     = "ON_DEMAND"
+    desired_size      = 5
+    min_size          = 5
+    max_size          = 10
+    ami_type          = "AL2_ARM_64"
+  }
+
   "9c-main-c7g_4xl_2c" = {
     instance_types    = ["c7g.4xlarge"]
     availability_zone = "us-east-2c"
     capacity_type     = "ON_DEMAND"
-    desired_size      = 10
-    min_size          = 10
-    max_size          = 20
+    desired_size      = 4
+    min_size          = 4
+    max_size          = 10
     ami_type          = "AL2_ARM_64"
   }
 


### PR DESCRIPTION
Configure RPC nodes to use `m7g.2xlarge`(8CPU, 32GB ram) instances and reduce original `c7g.4xlarge`(16CPU, 32GB ram) count.