### PR TITLE
Add resources related to `RemoteActionEvaluator` testing

### DIFF
--- a/9c-main/chart/templates/remote-action-evaluator-headless.yaml
+++ b/9c-main/chart/templates/remote-action-evaluator-headless.yaml
@@ -1,0 +1,249 @@
+{{ if .Values.remoteActionEvaluatorHeadless.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: remote-action-evaluator-headless
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
+  name: remote-action-evaluator-headless
+  namespace: {{ $.Chart.Name }}
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: remote-action-evaluator-headless
+  serviceName: remote-action-evaluator-headless
+  template:
+    metadata:
+      labels:
+        app: remote-action-evaluator-headless
+      name: remote-action-evaluator-headless
+    spec:
+      containers:
+      - args:
+        - NineChronicles.Headless.Executable.dll
+        - run
+        - --app-protocol-version={{ $.Values.appProtocolVersion }}
+        - --trusted-app-protocol-version-signer={{ $.Values.trustedAppProtocolVersionSigner }}
+        - --genesis-block-path={{ $.Values.genesisBlockPath }}
+        - --port={{ $.Values.remoteActionEvaluatorHeadless.ports.headless }}
+        - --no-miner
+        - --store-type=rocksdb
+        - --store-path=/data/headless
+        {{- if $.Values.remoteActionEvaluatorHeadless.useTurnServer }}
+        {{- range $.Values.iceServers }}
+        - --ice-server={{ . }}
+        {{- end }}
+        {{- else }}
+        - --host={{ $.Values.remoteActionEvaluatorHeadless.host }}
+        {{- end }}
+        {{- range $.Values.peerStrings }}
+        - --peer={{ . }}
+        {{- end }}
+        - --graphql-server
+        - --graphql-host=0.0.0.0
+        - --graphql-port={{ $.Values.remoteActionEvaluatorHeadless.ports.graphql }}
+        - --rpc-server
+        - --rpc-remote-server
+        - --rpc-listen-host=0.0.0.0
+        - --rpc-listen-port={{ $.Values.remoteActionEvaluatorHeadless.ports.rpc }}
+        - --no-cors
+        - --chain-tip-stale-behavior-type=reboot
+        - --sentry-dsn=https://625a444555a547e8822ee86d4f38f046@o195672.ingest.sentry.io/6197051
+        - --sentry-trace-sample-rate=0.5
+        - --tx-life-time=10
+        - --network-type={{ $.Values.networkType }}
+        {{- with $.Values.remoteActionEvaluatorHeadless.extraArgs }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        command:
+        - dotnet
+        image: {{ $.Values.remoteActionEvaluatorHeadless.image.repository }}:{{ $.Values.remoteActionEvaluatorHeadless.image.tag }}
+        imagePullPolicy: Always
+        name: remote-action-evaluator-headless
+        ports:
+        - containerPort: {{ $.Values.remoteActionEvaluatorHeadless.ports.graphql }}
+          name: graphql
+          protocol: TCP
+        - containerPort: {{ $.Values.remoteActionEvaluatorHeadless.ports.headless }}
+          name: headless
+          protocol: TCP
+        - containerPort: {{ $.Values.remoteActionEvaluatorHeadless.ports.rpc }}
+          name: rpc
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /bin/readiness_probe.sh
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 10
+        resources:
+          {{- toYaml $.Values.remoteActionEvaluatorHeadless.resources | nindent 10 }}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /data
+          name: remote-action-evaluator-headless-data
+        - mountPath: /bin/liveness_probe.sh
+          name: probe-script
+          readOnly: true
+          subPath: liveness_probe.sh
+        - mountPath: /bin/readiness_probe.sh
+          name: probe-script
+          readOnly: true
+          subPath: readiness_probe.sh
+        - mountPath: /bin/appsettings.json
+          name: remote-action-evaluator-headless-configmap
+          readOnly: true
+          subPath: appsettings.json
+        {{- if $.Values.remoteActionEvaluatorHeadless.loggingEnabled }}
+        - mountPath: /app/logs
+          name: json-log
+        {{- end }}
+        env:
+        {{- if $.Values.remoteActionEvaluatorHeadless.loggingEnabled }}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: JSON_LOG_PATH
+          value: ./logs/$(POD_NAME)_$(NAMESPACE_NAME)_remote-action-evaluator-headless.json
+        {{- end }}
+        - name: IpRateLimiting__EnableRateLimiting
+          value: "true"
+        - name: IpRateLimiting__GeneralRules__0__Limit
+          value: "15"
+      nodeSelector:
+        eks.amazonaws.com/nodegroup: 9c-main-r7g_xl_2c
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 448
+          name: {{ $.Chart.Name }}-probe-script
+        name: probe-script
+      - name: download-snapshot-script
+        configMap:
+          defaultMode: 0700
+          name: {{ $.Chart.Name }}-download-snapshot-script
+      - name: remote-action-evaluator-headless-configmap
+        configMap:
+          defaultMode: 0700
+          name: {{ $.Chart.Name }}-remote-action-evaluator-headless-configmap
+      {{- if $.Values.remoteActionEvaluatorHeadless.loggingEnabled }}
+      - hostPath:
+          path: /var/log/headless
+          type: DirectoryOrCreate
+        name: json-log
+      {{- end }}
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      name: remote-action-evaluator-headless-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ $.Values.remoteActionEvaluatorHeadless.storage.data }}
+      storageClassName: {{ $.Chart.Name }}-gp3
+      volumeMode: Filesystem
+
+---
+{{- end }}
+{{ if .Values.lib9cStateService.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: lib9c-state-service
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
+  name: lib9c-state-service
+  namespace: {{ $.Chart.Name }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: lib9c-state-service
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: lib9c-state-service
+      name: lib9c-state-service
+    spec:
+      containers:
+      - args:
+        - Lib9c.StateService.dll
+        - --urls=http://0.0.0.0:5157/
+        command:
+        - dotnet
+        image: "{{ $.Values.lib9cStateService.image.repository }}:{{ $.Values.lib9cStateService.image.tag | default $.Chart.AppVersion }}"
+        env:
+        - name: RemoteBlockChainStatesEndpoint
+          value: "http://remote-action-evaluator-headless.9c-network.svc.cluster.local:{{ $.Values.remoteActionEvaluatorHeadless.ports.graphql }}/graphql/explorer"
+        imagePullPolicy: Always
+        livenessProbe:
+          initialDelaySeconds: 120
+          periodSeconds: 5
+          successThreshold: 1
+          tcpSocket:
+            port: {{ $.Values.lib9cStateService.ports.http }}
+          timeoutSeconds: 1
+        name: lib9c-state-service
+        ports:
+          - containerPort: 5157
+            name: http
+            protocol: TCP
+        resources:
+          {{- toYaml $.Values.lib9cStateService.resources | nindent 10 }}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        {{- toYaml $.Values.lib9cStateService.podSecurityContext | nindent 8 }}
+      {{- with $.Values.lib9cStateService.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.lib9cStateService.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.lib9cStateService.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+{{- end }}
+{{ if .Values.remoteActionEvaluatorHeadless.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-remote-action-evaluator-headless-configmap
+  namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
+data:
+  appsettings.json: |-
+    {
+      "ActionEvaluator": {
+        "type": "RemoteActionEvaluator",
+        "stateServiceEndpoint": "http://lib9c-state-service.9c-network.svc.cluster.local:5157/evaluation"
+      }
+    }
+{{- end }}

--- a/9c-main/chart/templates/service.yaml
+++ b/9c-main/chart/templates/service.yaml
@@ -539,3 +539,62 @@ spec:
 
 ---
 {{ end }}
+
+{{ if .Values.remoteActionEvaluatorHeadless.enabled }}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: remote-action-evaluator-headless
+  namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+    service.beta.kubernetes.io/aws-load-balancer-type: "external"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-2:319679068466:certificate/2481ac9e-2037-4331-9234-4b3f86d50ad3
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+spec:
+  externalTrafficPolicy: Local
+  ports:
+  - name: graphql
+    port: {{ $.Values.remoteActionEvaluatorHeadless.ports.graphql }}
+    targetPort: {{ $.Values.remoteActionEvaluatorHeadless.ports.graphql }}
+  - name: rpc
+    port: {{ $.Values.remoteActionEvaluatorHeadless.ports.rpc }}
+    targetPort: {{ $.Values.remoteActionEvaluatorHeadless.ports.rpc }}
+  - name: headless
+    port: {{ $.Values.remoteActionEvaluatorHeadless.ports.headless }}
+    targetPort: {{ $.Values.remoteActionEvaluatorHeadless.ports.headless }}
+  - name: https
+    port: 443
+    targetPort: {{ $.Values.remoteActionEvaluatorHeadless.ports.graphql }}
+  selector:
+    app: remote-action-evaluator-headless
+  type: LoadBalancer
+
+---
+{{ end }}
+
+{{ if .Values.lib9cStateService.enabled }}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: lib9c-state-service
+  namespace: {{ $.Chart.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
+spec:
+  ports:
+  - name: http
+    port: 5157
+    targetPort: 5157
+  selector:
+    app: lib9c-state-service
+  type: ClusterIP
+
+---
+{{ end }}

--- a/9c-main/chart/values.yaml
+++ b/9c-main/chart/values.yaml
@@ -448,3 +448,56 @@ validator:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
+remoteActionEvaluatorHeadless:
+  enabled: true
+  image:
+    repository: planetariumhq/ninechronicles-headless
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "git-e61d14e8cbf0a8e9f738c6d0d1dc0f07812e67fe"
+
+  loggingEnabled: true
+
+  extraArgs: []
+  # - --key=val
+
+  useTurnServer: true
+
+  host: "9c-main-remote-aev-test.nine-chronicles.com"
+
+  ports:
+    headless: 31234
+    graphql: 80
+    rpc: 31238
+
+  storage:
+    data: 1000Gi
+
+  resources:
+    requests:
+      cpu: 2
+      memory: 20Gi
+
+  nodeSelector:
+    beta.kubernetes.io/os: linux
+  tolerations: []
+  affinity: {}
+
+lib9cStateService:
+  enabled: true
+  image:
+    repository: planetariumhq/lib9c-stateservice
+    pullPolicy: Always # Overrides the image tag whose default is the chart appVersion.
+    tag: "git-e61d14e8cbf0a8e9f738c6d0d1dc0f07812e67fe"
+
+  ports:
+    http: 5157
+
+  resources:
+    requests:
+      cpu: 1
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}


### PR DESCRIPTION
## Description

This pull request adds resources related with `RemoteActionEvaluator` testing, to `9c-main-v2` cluster.

 - StatefulSet/remote-action-evaluator-headless: A headless to use `RemoteActionEvaluator` to evaluate block.
 - ConfigMap/remote-action-evaluator-headless-configmap: A configmap including `appsettings.json` to enable `RemoteActionEvaluator`.
 - Deployment/lib9c-state-service: A service named `Lib9c.StateService`, provides block evaluation API over RPC.

## Testing 🤔 

I just run `helm install --dry-run --generate-name . --debug` and it seems there is no template issue. 🤔 (maybe...)

## Links

 - https://github.com/planetarium/NineChronicles.Headless/tree/development/Lib9c.StateService
   - https://github.com/planetarium/NineChronicles.Headless/blob/development/Dockerfile.lib9c-stateservice
 - https://github.com/planetarium/NineChronicles.Headless/pull/2024