### PR TITLE
Setup remote-aev headless with snapshot

### DIFF
--- a/9c-main/chart/templates/remote-action-evaluator-headless.yaml
+++ b/9c-main/chart/templates/remote-action-evaluator-headless.yaml
@@ -81,6 +81,7 @@ spec:
         - --sentry-trace-sample-rate=0.5
         - --tx-life-time=10
         - --network-type={{ $.Values.networkType }}
+        - --config=/bin/appsettings.json
         {{- with $.Values.remoteActionEvaluatorHeadless.extraArgs }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/9c-main/chart/templates/remote-action-evaluator-headless.yaml
+++ b/9c-main/chart/templates/remote-action-evaluator-headless.yaml
@@ -21,6 +21,32 @@ spec:
         app: remote-action-evaluator-headless
       name: remote-action-evaluator-headless
     spec:
+      initContainers:
+      - args:
+        - https://snapshots.nine-chronicles.com/main/partition
+        - /data/headless
+        - $(RESET_SNAPSHOT_OPTION)
+        - remote-action-evaluator-headless
+        - $(SLACK_WEBHOOK_URL)
+        command:
+        - /bin/download_snapshot.sh
+        image: {{ $.Values.remoteActionEvaluatorHeadless.image.repository }}:{{ $.Values.remoteActionEvaluatorHeadless.image.tag }}
+        name: reset-snapshot
+        volumeMounts:
+        - name: download-snapshot-script
+          mountPath: /bin/download_snapshot.sh
+          readOnly: true
+          subPath: download_snapshot.sh
+        - mountPath: /data
+          name: remote-action-evaluator-headless-data
+        env:
+        - name: RESET_SNAPSHOT_OPTION
+          value: true
+        - name: SLACK_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: slack
+              key: slack-webhook-url
       containers:
       - args:
         - NineChronicles.Headless.Executable.dll

--- a/9c-main/chart/values.yaml
+++ b/9c-main/chart/values.yaml
@@ -455,7 +455,7 @@ remoteActionEvaluatorHeadless:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "git-e61d14e8cbf0a8e9f738c6d0d1dc0f07812e67fe"
+    tag: "git-9b5a4a417df03860bad6de9a16892a95ebd56ddb"
 
   loggingEnabled: true
 
@@ -489,7 +489,7 @@ lib9cStateService:
   image:
     repository: planetariumhq/lib9c-stateservice
     pullPolicy: Always # Overrides the image tag whose default is the chart appVersion.
-    tag: "git-e61d14e8cbf0a8e9f738c6d0d1dc0f07812e67fe"
+    tag: "git-9b5a4a417df03860bad6de9a16892a95ebd56ddb"
 
   ports:
     http: 5157


### PR DESCRIPTION
# You can always mege this pull request, maintainers.

This pull request includes:

 - Bump planetarium/lib9c-stateservice (To support arm64v8 arch)
 - Add initContainer to setup remote-aev PVC with snapshot.