### PR TITLE
Convert environment value into string

### DIFF
--- a/9c-main/chart/templates/remote-action-evaluator-headless.yaml
+++ b/9c-main/chart/templates/remote-action-evaluator-headless.yaml
@@ -41,7 +41,7 @@ spec:
           name: remote-action-evaluator-headless-data
         env:
         - name: RESET_SNAPSHOT_OPTION
-          value: true
+          value: "true"
         - name: SLACK_WEBHOOK_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Since #342, the synchronization was failing... I'm not sure but I guess the environment was not `string` type. 🤔 I'll search more but if you already saw such case, please let me know it 🙏🏻 