### PR TITLE
Add logger configuration in appsettings.json

### DIFF
--- a/9c-main/chart/templates/remote-action-evaluator-headless.yaml
+++ b/9c-main/chart/templates/remote-action-evaluator-headless.yaml
@@ -41,7 +41,7 @@ spec:
           name: remote-action-evaluator-headless-data
         env:
         - name: RESET_SNAPSHOT_OPTION
-          value: true
+          value: "true"
         - name: SLACK_WEBHOOK_URL
           valueFrom:
             secretKeyRef:
@@ -268,9 +268,75 @@ metadata:
 data:
   appsettings.json: |-
     {
-      "ActionEvaluator": {
-        "type": "RemoteActionEvaluator",
-        "stateServiceEndpoint": "http://lib9c-state-service.9c-network.svc.cluster.local:5157/evaluation"
-      }
+        "Serilog": {
+            "Using": [
+                "Serilog.Expressions",
+                "Serilog.Sinks.Console",
+                "Serilog.Sinks.RollingFile"
+            ],
+            "MinimumLevel": "Debug",
+            "WriteTo": [
+                {
+                    "Name": "Logger",
+                    "Args": {
+                        "configureLogger": {
+                            "WriteTo": [
+                                {
+                                    "Name": "Console",
+                                    "Args": {
+                                        "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact",
+                                        "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] [{Source}] {Message:lj}{NewLine}{Exception}"
+                                    }
+                                }
+                            ],
+                            "Filter": [
+                                {
+                                    "Name": "ByIncludingOnly",
+                                    "Args": {
+                                        "expression": "Source is not null"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "Name": "Logger",
+                    "Args": {
+                        "configureLogger": {
+                            "WriteTo": [
+                                {
+                                    "Name": "Console",
+                                    "Args": {
+                                        "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact",
+                                        "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"
+                                    }
+                                }
+                            ],
+                            "Filter": [
+                                {
+                                    "Name": "ByExcluding",
+                                    "Args": {
+                                        "expression": "Source is not null"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ],
+            "Filter": [
+                {
+                    "Name": "ByExcluding",
+                    "Args": {
+                        "expression": "SourceContext = 'Libplanet.Stun.TurnClient'"
+                    }
+                }
+            ]
+        },
+        "ActionEvaluator": {
+            "type": "RemoteActionEvaluator",
+            "stateServiceEndpoint": "http://lib9c-state-service.9c-network.svc.cluster.local:5157/evaluation"
+        }
     }
 {{- end }}


### PR DESCRIPTION
By using the custom `appsettings.json`, the `Serilog` log configuration was missed. This pull request inject the logger configuration.