### PR TITLE
ci(gh-actions): validate chart

### DIFF
--- a/.github/workflows/validate-chart.yaml
+++ b/.github/workflows/validate-chart.yaml
@@ -1,0 +1,14 @@
+name: validate-chart
+on: [push, pull_request]
+jobs:
+  validate-9c-main-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install kubeconform
+        run: wget https://github.com/yannh/kubeconform/releases/download/v0.6.1/kubeconform-linux-amd64.tar.gz && tar -xvzf kubeconform-linux-amd64.tar.gz
+        working-directory: 9c-main/chart
+      - run: helm lint
+        working-directory: 9c-main/chart
+      - run: helm template . | ./kubeconform -summary -skip "ExternalSecret,SecretStore"
+        working-directory: 9c-main/chart


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow to automate checking the Helm chart and Kubernetes manifest files.

Before this pull request, getting feedback and applying it on the contributor side was too hard and slow. Though I didn't want to disturb maintainers, it felt like disturbing them by requesting reviews and merging.

So I made a GitHub Actions workflow to check Helm syntax and Kubernetes Manifest syntax. If someone mistakes (e.g., `env.value: true`), the workflow will fail automatically.

```
moreal@moreals-MBP chart % helm template . | kubeconform -summary -skip "ExternalSecret"                                                                                
stdin - StatefulSet remote-action-evaluator-headless is invalid: problem validating schema. Check JSON formatting: jsonschema: '/spec/template/spec/initContainers/0/env/0/value' does not validate with https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone/statefulset-apps-v1.json#/properties/spec/properties/template/properties/spec/properties/initContainers/items/properties/env/items/properties/value/type: expected string or null, but got boolean
```