### PR TITLE
Run `remote-action-evaluator-headless` with default `ActionEvaluator`

### DIFF
--- a/9c-main/chart/templates/remote-action-evaluator-headless.yaml
+++ b/9c-main/chart/templates/remote-action-evaluator-headless.yaml
@@ -336,7 +336,7 @@ data:
         },
         "Headless": {
             "ActionEvaluator": {
-                "type": "RemoteActionEvaluator",
+                "type": "Default",
                 "stateServiceEndpoint": "http://lib9c-state-service.9c-network.svc.cluster.local:5157/evaluation"
             }
         }


### PR DESCRIPTION
Currently, the `remote-action-evaluator-headless` node is syncing blocks from the network. But its storage is too staled and `RemoteActionEvaluator` is too slow. This pull request makes the `remote-action-evaluator-headless` node sync with the default `ActionEvaluator`. After it arrives in the tip block of the network, I will revert this pull request.