### PR TITLE
Run remote-action-evaluator-headless with `RemoteActionEvaluator`

### DIFF
--- a/9c-main/chart/templates/remote-action-evaluator-headless.yaml
+++ b/9c-main/chart/templates/remote-action-evaluator-headless.yaml
@@ -336,7 +336,7 @@ data:
         },
         "Headless": {
             "ActionEvaluator": {
-                "type": "Default",
+                "type": "RemoteActionEvaluator",
                 "stateServiceEndpoint": "http://lib9c-state-service.9c-network.svc.cluster.local:5157/evaluation"
             }
         }


### PR DESCRIPTION
As I said in #358, I will recover the PR's changes because the node synced blocks without `InvalidBlockStateRootHashException` to the tip block.