### PR TITLE
Bump lib9c-stateservice

### DIFF
--- a/9c-main/chart/values.yaml
+++ b/9c-main/chart/values.yaml
@@ -497,7 +497,7 @@ lib9cStateService:
   image:
     repository: planetariumhq/lib9c-stateservice
     pullPolicy: Always # Overrides the image tag whose default is the chart appVersion.
-    tag: "git-4f5c5d2978acaf04771849ad74c5ea15d5dbab97"
+    tag: "v200020-1"
 
   ports:
     http: 5157


### PR DESCRIPTION
This pull request bumps lib9c-stateservice image manually. ([`planetariumhq/lib9c-stateservice:v200020-1`](https://hub.docker.com/layers/planetariumhq/lib9c-stateservice/v200020-1/images/sha256-a299c30334faad0fbae4adb52ab006008764ccdefca29732438293afaff0fcb4?context=explore))