### PR TITLE
Update lib9c-state-service image

### DIFF
--- a/9c-main/chart/values.yaml
+++ b/9c-main/chart/values.yaml
@@ -497,7 +497,7 @@ lib9cStateService:
   image:
     repository: planetariumhq/lib9c-stateservice
     pullPolicy: Always # Overrides the image tag whose default is the chart appVersion.
-    tag: "v200020-1"
+    tag: "git-9b90f4a92f8a972ef9abae34f230c88ddc9e3cde"
 
   ports:
     http: 5157


### PR DESCRIPTION
This pull request bumps lib9c-stateservice's image to the development branch because v200020-1 image doesn't include the patch for `RemoteBlockChainStates.GetTrie()` method. ([ref](https://github.com/planetarium/NineChronicles.Headless/blob/f3ca44bfb02ec01b823fcd5a15b614b4e4f58a4d/Libplanet.Extensions.RemoteActionEvaluator/RemoteBlockChainStates.cs#L155-L158))