### PR TITLE
Bump lib9c-stateservice

### DIFF
--- a/9c-main/chart/values.yaml
+++ b/9c-main/chart/values.yaml
@@ -497,7 +497,7 @@ lib9cStateService:
   image:
     repository: planetariumhq/lib9c-stateservice
     pullPolicy: Always # Overrides the image tag whose default is the chart appVersion.
-    tag: "git-9b90f4a92f8a972ef9abae34f230c88ddc9e3cde"
+    tag: "git-34a0b75138ad69cb754576826465c3a96f9c7455"
 
   ports:
     http: 5157


### PR DESCRIPTION
I bumped the lib9c-state-service's image again—the development branches in lib9c and NineChronicles.Headless repositories were not merged with the `rc-v200020-1` branch so the previous version doesn't work.

<img width="1057" alt="image" src="https://github.com/planetarium/9c-infra/assets/26626194/0c0b03a7-1f8a-408d-bcac-0feef052b33b">
