### PR TITLE
Update rate limit

### DIFF
--- a/9c-main/chart/templates/remote-headless.yaml
+++ b/9c-main/chart/templates/remote-headless.yaml
@@ -120,9 +120,13 @@ spec:
         - name: IpRateLimiting__EnableEndpointRateLimiting
           value: "true"
         - name: IpRateLimiting__GeneralRules__0__Period
-          value: "10s"
+          value: "60s"
+        - name: IpRateLimiting__GeneralRules__0__Limit
+          value: "12"
         - name: IpRateLimiting__GeneralRules__1__Period
-          value: "10s"
+          value: "60s"
+        - name: IpRateLimiting__GeneralRules__1__Limit
+          value: "12"
       nodeSelector:
         eks.amazonaws.com/nodegroup: 9c-main-m7g_2xl_2c
       {{- with $.Values.remoteHeadless.tolerations }}

--- a/9c-main/chart/templates/remote-headless.yaml
+++ b/9c-main/chart/templates/remote-headless.yaml
@@ -120,9 +120,9 @@ spec:
         - name: IpRateLimiting__EnableEndpointRateLimiting
           value: "true"
         - name: IpRateLimiting__GeneralRules__0__Period
-          value: "5s"
+          value: "10s"
         - name: IpRateLimiting__GeneralRules__1__Period
-          value: "5s"
+          value: "10s"
       nodeSelector:
         eks.amazonaws.com/nodegroup: 9c-main-m7g_2xl_2c
       {{- with $.Values.remoteHeadless.tolerations }}

--- a/9c-main/chart/values.yaml
+++ b/9c-main/chart/values.yaml
@@ -128,7 +128,7 @@ remoteHeadless:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v200020-1"
+    tag: "git-20ff46aa5556aa1e0a958fb89040084ccd02e624"
 
   # dotnet args
 


### PR DESCRIPTION
Update RPC image to https://github.com/planetarium/NineChronicles.Headless/commit/20ff46aa5556aa1e0a958fb89040084ccd02e624(remove `port` from rate-limiting) and update rate -limiting from `1tx/5sec` to `12tx/60sec`(to enable simultaneous tx staging from the same IP).