### PR TITLE
reduce dp-read replica to 1

### DIFF
--- a/9c-main/chart/templates/data-provider-read.yaml
+++ b/9c-main/chart/templates/data-provider-read.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ $.Chart.Name }}
 spec:
   podManagementPolicy: OrderedReady
-  replicas: 2
+  replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:


### PR DESCRIPTION
After testing, the dp-read service doesn't need 2 replicas so it's decreased to 1.