### PR TITLE
RPC node test

### DIFF
--- a/9c-main/chart/templates/remote-headless.yaml
+++ b/9c-main/chart/templates/remote-headless.yaml
@@ -128,7 +128,7 @@ spec:
         - name: IpRateLimiting__GeneralRules__1__Limit
           value: "12"
       nodeSelector:
-        eks.amazonaws.com/nodegroup: 9c-main-m7g_2xl_2c
+        eks.amazonaws.com/nodegroup: 9c-main-m7g_2xl_2c_test
       {{- with $.Values.remoteHeadless.tolerations }}
       tolerations:
         {{- toYaml $.Values.remoteHeadless.tolerations | nindent 8 }}

--- a/9c-main/chart/values.yaml
+++ b/9c-main/chart/values.yaml
@@ -162,7 +162,7 @@ remoteHeadless:
   tolerations:
     - key: "dedicated"
       operator: "Equal"
-      value: "remote-headless"
+      value: "remote-headless-test"
       effect: "NoSchedule"
   affinity: {}
 

--- a/9c-main/terraform/node_group.tf
+++ b/9c-main/terraform/node_group.tf
@@ -7,6 +7,7 @@ resource "aws_eks_node_group" "node_groups" {
   instance_types  = each.value["instance_types"]
   capacity_type   = try(each.value["capacity_type"], "ON_DEMAND")
   ami_type        = try(each.value["ami_type"], "AL2_x86_64")
+  disk_size       = try(each.value["disk_size"], 20)
 
   scaling_config {
     desired_size = each.value["desired_size"]

--- a/9c-main/terraform/terraform.tfvars
+++ b/9c-main/terraform/terraform.tfvars
@@ -73,6 +73,22 @@ node_groups = {
     }]
   }
 
+  "9c-main-m7g_2xl_2c_test" = {
+    instance_types    = ["m7g.2xlarge"]
+    availability_zone = "us-east-2c"
+    capacity_type     = "ON_DEMAND"
+    desired_size      = 3
+    min_size          = 3
+    max_size          = 10
+    ami_type          = "AL2_ARM_64"
+    disk_size         = 50
+    taints = [{
+      key    = "dedicated"
+      value  = "remote-headless-test"
+      effect = "NO_SCHEDULE"
+    }]
+  }
+
   "9c-main-c7g_4xl_2c" = {
     instance_types    = ["c7g.4xlarge"]
     availability_zone = "us-east-2c"


### PR DESCRIPTION
Test RPC node to use a nodegroup with 50Gb volume (previously, 20Gb). 