### PR TITLE
Enable remote-action-evaluator-headless again

### DIFF
--- a/9c-main/chart/templates/remote-action-evaluator-headless.yaml
+++ b/9c-main/chart/templates/remote-action-evaluator-headless.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ $.Chart.Name }}
 spec:
   podManagementPolicy: OrderedReady
-  replicas: 0
+  replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:
@@ -41,7 +41,7 @@ spec:
           name: remote-action-evaluator-headless-data
         env:
         - name: RESET_SNAPSHOT_OPTION
-          value: "false"
+          value: "true"
         - name: SLACK_WEBHOOK_URL
           valueFrom:
             secretKeyRef:
@@ -198,7 +198,7 @@ metadata:
   name: lib9c-state-service
   namespace: {{ $.Chart.Name }}
 spec:
-  replicas: 0
+  replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:

--- a/9c-main/chart/values.yaml
+++ b/9c-main/chart/values.yaml
@@ -467,7 +467,7 @@ remoteActionEvaluatorHeadless:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v200020-1"
+    tag: "git-6eec9144a299eae74d39383a41c71b375e57fc65"
 
   loggingEnabled: true
 
@@ -497,11 +497,11 @@ remoteActionEvaluatorHeadless:
   affinity: {}
 
 lib9cStateService:
-  enabled: false
+  enabled: true
   image:
     repository: planetariumhq/lib9c-stateservice
     pullPolicy: Always # Overrides the image tag whose default is the chart appVersion.
-    tag: "git-34a0b75138ad69cb754576826465c3a96f9c7455"
+    tag: "git-6eec9144a299eae74d39383a41c71b375e57fc65"
 
   ports:
     http: 5157


### PR DESCRIPTION
https://github.com/planetarium/lib9c/pull/1954 PR changed some action logic and I enable the `remote-action-evaluator-headless` resource again to test it. The headless image was built on https://github.com/planetarium/NineChronicles.Headless/commit/6eec9144a299eae74d39383a41c71b375e57fc65.