### PR TITLE
Update scrape interval

### DIFF
--- a/common/bootstrap/templates/prometheus.yaml
+++ b/common/bootstrap/templates/prometheus.yaml
@@ -76,8 +76,8 @@ spec:
                     - ninechronicles-headless-metrics-aggregator.monitoring.svc.cluster.local:80
               - job_name: scrape-headlesses
                 metrics_path: /metrics
-                scrape_interval: 1m
-                scrape_timeout: 50s
+                scrape_interval: 8s
+                scrape_timeout: 6s
                 static_configs:
                   - targets:
                     - 9c-main-validator-1.nine-chronicles.com:80

--- a/common/bootstrap/templates/prometheus.yaml
+++ b/common/bootstrap/templates/prometheus.yaml
@@ -74,6 +74,8 @@ spec:
                 static_configs:
                   - targets:
                     - ninechronicles-headless-metrics-aggregator.monitoring.svc.cluster.local:80
+                tls_config:
+                  insecure_skip_verify: true
               - job_name: scrape-headlesses
                 metrics_path: /metrics
                 scrape_interval: 8s


### PR DESCRIPTION
This pull request updates the scrape interval to 8s with a 6s timeout. I guess it will be possible because they may be parallel. Also, it recovers the configuration section that I removed in #317 by mistake 😢 