### PR TITLE
update validator & rpc image

### DIFF
--- a/9c-main/chart/values.yaml
+++ b/9c-main/chart/values.yaml
@@ -128,7 +128,7 @@ remoteHeadless:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "git-20ff46aa5556aa1e0a958fb89040084ccd02e624"
+    tag: "git-9b1afbdae83e23b97e28c3ae7e31b94decd16b30"
 
   # dotnet args
 
@@ -416,7 +416,7 @@ validator:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v200020-1"
+    tag: "git-8e02112450d149641c7feef06fdb3b18a12dcaf4"
 
   consensusSeedStrings:
   - "027bd36895d68681290e570692ad3736750ceaab37be402442ffb203967f98f7b6,9c-main-tcp-seed-1.planetarium.dev,31235"


### PR DESCRIPTION
The updated validator image is for `HAS` logging and the new RPC image is for IP banning.