### PR TITLE
Update validators' image

### DIFF
--- a/9c-main/chart/values.yaml
+++ b/9c-main/chart/values.yaml
@@ -416,7 +416,7 @@ validator:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "git-b0cf1ac0c2608de144326477751c29b9a6665cb5"
+    tag: "git-bef2cbc0f1bf1872c5ed09f0e67a34628f9ea4c5"
 
   consensusSeedStrings:
   - "027bd36895d68681290e570692ad3736750ceaab37be402442ffb203967f98f7b6,9c-main-tcp-seed-1.planetarium.dev,31235"


### PR DESCRIPTION
In v200020, the current version, the obsolete check doesn't work well as expected. So I update the validators' image at first as a hotfix. It will not allow obsoleted actions staged on the validator nodes. See also https://github.com/planetarium/NineChronicles.Headless/commit/bef2cbc0f1bf1872c5ed09f0e67a34628f9ea4c5.