### PR TITLE
set tx quota per signer to 1

### DIFF
--- a/9c-main/chart/templates/validator.yaml
+++ b/9c-main/chart/templates/validator.yaml
@@ -61,6 +61,7 @@ spec:
         {{- end }}
         - --network-type={{ $.Values.networkType }}
         - --tx-life-time=10
+        - --tx-quota-per-signer=1
         command:
           - dotnet
         env:


### PR DESCRIPTION
Temporarily testing to see if lowering the `tx-quota-per-signer` helps with bot spamming.