### PR TITLE
Update 9c-internal rpc headless' image

### DIFF
--- a/9c-internal/chart/values.yaml
+++ b/9c-internal/chart/values.yaml
@@ -102,7 +102,7 @@ remoteHeadless:
   image:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
-    tag: git-9be9127d951fe30bc9def310560c7d2eaa39deb1
+    tag: git-8a1268671089a6cff8fda174e8ca954b48252fa6
   extraArgs: []
   useTurnServer: false
   hosts:


### PR DESCRIPTION
This pull request updates Docker image of the RPC headless in 9c-internal-v2 network. The Docker image is built on https://github.com/planetarium/NineChronicles.Headless/commit/8a1268671089a6cff8fda174e8ca954b48252fa6. This update is to test https://github.com/planetarium/NineChronicles.Headless/commit/6263659b94dc33c6d1497e9a20d595615b7dc1cb change.