### PR TITLE
[Fix snapshot-partition-reset] add temp dir path to upload in s3

### DIFF
--- a/9c-main/chart/templates/snapshot-partition-reset.yaml
+++ b/9c-main/chart/templates/snapshot-partition-reset.yaml
@@ -41,6 +41,7 @@ spec:
           - name: upload-snapshot1
             image: {{ $.Values.snapshot.image }}
             args:
+            - temp
             - $(APP_PROTOCOL_VERSION_KEY)
             - $(SLACK_WEBHOOK_URL)
             - $(CF_DISTRIBUTION_ID)
@@ -82,6 +83,7 @@ spec:
           - name: upload-snapshot2
             image: {{ $.Values.snapshot.image }}
             args:
+            - temp
             - $(APP_PROTOCOL_VERSION_KEY)
             - $(SLACK_WEBHOOK_URL)
             - $(CF_DISTRIBUTION_ID)

--- a/charts/all-in-one/templates/snapshot-partition-reset.yaml
+++ b/charts/all-in-one/templates/snapshot-partition-reset.yaml
@@ -46,6 +46,7 @@ spec:
           - name: upload-snapshot1
             image: {{ $.Values.snapshot.image }}
             args:
+            - temp
             - $(APP_PROTOCOL_VERSION_KEY)
             - $(SLACK_WEBHOOK_URL)
             - $(CF_DISTRIBUTION_ID)
@@ -87,6 +88,7 @@ spec:
           - name: upload-snapshot2
             image: {{ $.Values.snapshot.image }}
             args:
+            - temp
             - $(APP_PROTOCOL_VERSION_KEY)
             - $(SLACK_WEBHOOK_URL)
             - $(CF_DISTRIBUTION_ID)


### PR DESCRIPTION
`Snapshot-partition-reset` needs to upload newly merged snapshots to `s3://9c-snapshots-v2/main/temp/partition/` before replacing them to `s3://9c-snapshot-v2/main/partition`. This fix adds the correct path.