### PR TITLE
[snapshot download script] add option to completely reset snapshot

### DIFF
--- a/9c-internal-mead/chart/templates/configmap-snapshot.yaml
+++ b/9c-internal-mead/chart/templates/configmap-snapshot.yaml
@@ -19,6 +19,7 @@ data:
     download_option=$3
     service_name=$4
     SLACK_WEBHOOK=$5
+    complete_snapshot_reset=${6:-"false"}
 
     if $download_option
     then
@@ -146,11 +147,29 @@ data:
           aria2c "$base_url/$mainnet_snapshot_json_filename" -d "$save_dir" -o "$mainnet_snapshot_json_filename" -j10 -x10 --continue=true
       }
 
-      if [ -f $save_dir/mainnet_latest.json ]
+      if [ -f $save_dir/$mainnet_snapshot_json_filename ]
       then
-        local_previous_mainnet_blockEpoch=$(cat "$save_dir/mainnet_latest.json" | jq ".BlockEpoch")
-        local_previous_mainnet_blockIndex=$(cat "$save_dir/mainnet_latest.json" | jq ".Index")
-        download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_previous_mainnet_blockIndex
+        if [ $complete_snapshot_reset = "true" ]
+        then
+          echo "Completely delete the existing store and download a new snapshot"
+          rm -r "$save_dir"
+          mkdir -p "$save_dir"
+          download_unzip_full_snapshot
+        else
+          local_chain_tip_index="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
+          if [ -f $save_dir/$mainnet_snapshot_json_filename ]
+          then
+            local_previous_mainnet_blockEpoch=$(cat "$save_dir/$mainnet_snapshot_json_filename" | jq ".BlockEpoch")
+            download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
+          else
+            local_chain_tip_timestamp="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
+            epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
+            echo $epoch_seconds
+            local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))
+            echo $local_chain_tip_blockEpoch
+            download_unzip_partial_snapshot $local_chain_tip_blockEpoch $local_chain_tip_index
+          fi
+        fi
       else
         download_unzip_full_snapshot
       fi

--- a/9c-main/chart/templates/configmap-download-snapshot.yaml
+++ b/9c-main/chart/templates/configmap-download-snapshot.yaml
@@ -26,6 +26,7 @@ data:
     download_option=$3
     service_name=$4
     SLACK_WEBHOOK=$5
+    complete_snapshot_reset=${6:-"false"}
 
     if [ $download_option = "true" ]
     then
@@ -48,7 +49,7 @@ data:
 
       function download_unzip_partial_snapshot() {
         snapshot_json_filename="latest.json"
-        mainnet_snapshot_json_filename="latest.json"
+        mainnet_snapshot_json_filename="mainnet_latest.json"
         snapshot_zip_filename="state_latest.zip"
         snapshot_zip_filename_array=("$snapshot_zip_filename")
         mainnet_snapshot_json_url="$base_url/$mainnet_snapshot_json_filename"
@@ -104,7 +105,7 @@ data:
 
       function download_unzip_full_snapshot() {
           snapshot_json_filename="latest.json"
-          mainnet_snapshot_json_filename="latest.json"
+          mainnet_snapshot_json_filename="mainnet_latest.json"
           snapshot_zip_filename="state_latest.zip"
           snapshot_zip_filename_array=("$snapshot_zip_filename")
 
@@ -152,22 +153,29 @@ data:
           aria2c "$base_url/$mainnet_snapshot_json_filename" -d "$save_dir" -o "$mainnet_snapshot_json_filename" -j10 -x10 --continue=true
       }
 
-      if [[ -d "$save_dir" ]]
+      if [ -f $save_dir/$mainnet_snapshot_json_filename ]
       then
-        local_chain_tip_index="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
-        if [ -f $save_dir/latest.json ]
+        if [ $complete_snapshot_reset = "true" ]
         then
-          local_previous_mainnet_blockEpoch=$(cat "$save_dir/latest.json" | jq ".BlockEpoch")
-          download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
+          echo "Completely delete the existing store and download a new snapshot"
+          rm -r "$save_dir"
+          mkdir -p "$save_dir"
+          download_unzip_full_snapshot
         else
-          local_chain_tip_timestamp="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
-          epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
-          echo $epoch_seconds
-          local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))
-          echo $local_chain_tip_blockEpoch
-          download_unzip_partial_snapshot $local_chain_tip_blockEpoch $local_chain_tip_index
+          local_chain_tip_index="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
+          if [ -f $save_dir/$mainnet_snapshot_json_filename ]
+          then
+            local_previous_mainnet_blockEpoch=$(cat "$save_dir/$mainnet_snapshot_json_filename" | jq ".BlockEpoch")
+            download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
+          else
+            local_chain_tip_timestamp="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
+            epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
+            echo $epoch_seconds
+            local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))
+            echo $local_chain_tip_blockEpoch
+            download_unzip_partial_snapshot $local_chain_tip_blockEpoch $local_chain_tip_index
+          fi
         fi
-
       else
         download_unzip_full_snapshot
       fi

--- a/charts/9c-network/templates/configmap-download-snapshot.yaml
+++ b/charts/9c-network/templates/configmap-download-snapshot.yaml
@@ -19,6 +19,7 @@ data:
     download_option=$3
     service_name=$4
     SLACK_WEBHOOK=$5
+    complete_snapshot_reset=${6:-"false"}
 
     if [ $download_option = "true" ]
     then
@@ -41,7 +42,7 @@ data:
 
       function download_unzip_partial_snapshot() {
         snapshot_json_filename="latest.json"
-        mainnet_snapshot_json_filename="latest.json"
+        mainnet_snapshot_json_filename="mainnet_latest.json"
         snapshot_zip_filename="state_latest.zip"
         snapshot_zip_filename_array=("$snapshot_zip_filename")
         mainnet_snapshot_json_url="$base_url/$mainnet_snapshot_json_filename"
@@ -97,7 +98,7 @@ data:
 
       function download_unzip_full_snapshot() {
           snapshot_json_filename="latest.json"
-          mainnet_snapshot_json_filename="latest.json"
+          mainnet_snapshot_json_filename="mainnet_latest.json"
           snapshot_zip_filename="state_latest.zip"
           snapshot_zip_filename_array=("$snapshot_zip_filename")
 
@@ -145,22 +146,29 @@ data:
           aria2c "$base_url/$mainnet_snapshot_json_filename" -d "$save_dir" -o "$mainnet_snapshot_json_filename" -j10 -x10 --continue=true
       }
 
-      if [[ -d "$save_dir" ]]
+      if [ -f $save_dir/$mainnet_snapshot_json_filename ]
       then
-        local_chain_tip_index="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
-        if [ -f $save_dir/latest.json ]
+        if [ $complete_snapshot_reset = "true" ]
         then
-          local_previous_mainnet_blockEpoch=$(cat "$save_dir/latest.json" | jq ".BlockEpoch")
-          download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
+          echo "Completely delete the existing store and download a new snapshot"
+          rm -r "$save_dir"
+          mkdir -p "$save_dir"
+          download_unzip_full_snapshot
         else
-          local_chain_tip_timestamp="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
-          epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
-          echo $epoch_seconds
-          local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))
-          echo $local_chain_tip_blockEpoch
-          download_unzip_partial_snapshot $local_chain_tip_blockEpoch $local_chain_tip_index
+          local_chain_tip_index="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
+          if [ -f $save_dir/$mainnet_snapshot_json_filename ]
+          then
+            local_previous_mainnet_blockEpoch=$(cat "$save_dir/$mainnet_snapshot_json_filename" | jq ".BlockEpoch")
+            download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
+          else
+            local_chain_tip_timestamp="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
+            epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
+            echo $epoch_seconds
+            local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))
+            echo $local_chain_tip_blockEpoch
+            download_unzip_partial_snapshot $local_chain_tip_blockEpoch $local_chain_tip_index
+          fi
         fi
-
       else
         download_unzip_full_snapshot
       fi

--- a/charts/all-in-one/templates/configmap-download-snapshot.yaml
+++ b/charts/all-in-one/templates/configmap-download-snapshot.yaml
@@ -26,6 +26,7 @@ data:
     download_option=$3
     service_name=$4
     SLACK_WEBHOOK=$5
+    complete_snapshot_reset=${6:-"false"}
 
     if [ $download_option = "true" ]
     then
@@ -48,7 +49,7 @@ data:
 
       function download_unzip_partial_snapshot() {
         snapshot_json_filename="latest.json"
-        mainnet_snapshot_json_filename="latest.json"
+        mainnet_snapshot_json_filename="mainnet_latest.json"
         snapshot_zip_filename="state_latest.zip"
         snapshot_zip_filename_array=("$snapshot_zip_filename")
         mainnet_snapshot_json_url="$base_url/$mainnet_snapshot_json_filename"
@@ -104,7 +105,7 @@ data:
 
       function download_unzip_full_snapshot() {
           snapshot_json_filename="latest.json"
-          mainnet_snapshot_json_filename="latest.json"
+          mainnet_snapshot_json_filename="mainnet_latest.json"
           snapshot_zip_filename="state_latest.zip"
           snapshot_zip_filename_array=("$snapshot_zip_filename")
 
@@ -152,22 +153,29 @@ data:
           aria2c "$base_url/$mainnet_snapshot_json_filename" -d "$save_dir" -o "$mainnet_snapshot_json_filename" -j10 -x10 --continue=true
       }
 
-      if [[ -d "$save_dir" ]]
+      if [ -f $save_dir/$mainnet_snapshot_json_filename ]
       then
-        local_chain_tip_index="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
-        if [ -f $save_dir/latest.json ]
+        if [ $complete_snapshot_reset = "true" ]
         then
-          local_previous_mainnet_blockEpoch=$(cat "$save_dir/latest.json" | jq ".BlockEpoch")
-          download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
+          echo "Completely delete the existing store and download a new snapshot"
+          rm -r "$save_dir"
+          mkdir -p "$save_dir"
+          download_unzip_full_snapshot
         else
-          local_chain_tip_timestamp="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
-          epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
-          echo $epoch_seconds
-          local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))
-          echo $local_chain_tip_blockEpoch
-          download_unzip_partial_snapshot $local_chain_tip_blockEpoch $local_chain_tip_index
+          local_chain_tip_index="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
+          if [ -f $save_dir/$mainnet_snapshot_json_filename ]
+          then
+            local_previous_mainnet_blockEpoch=$(cat "$save_dir/$mainnet_snapshot_json_filename" | jq ".BlockEpoch")
+            download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
+          else
+            local_chain_tip_timestamp="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
+            epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
+            echo $epoch_seconds
+            local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))
+            echo $local_chain_tip_blockEpoch
+            download_unzip_partial_snapshot $local_chain_tip_blockEpoch $local_chain_tip_index
+          fi
         fi
-
       else
         download_unzip_full_snapshot
       fi

--- a/charts/data-provider/templates/configmap-snapshot.yaml
+++ b/charts/data-provider/templates/configmap-snapshot.yaml
@@ -19,6 +19,7 @@ data:
     download_option=$3
     service_name=$4
     SLACK_WEBHOOK=$5
+    complete_snapshot_reset=${6:-"false"}
 
     if $download_option
     then
@@ -146,11 +147,29 @@ data:
           aria2c "$base_url/$mainnet_snapshot_json_filename" -d "$save_dir" -o "$mainnet_snapshot_json_filename" -j10 -x10 --continue=true
       }
 
-      if [ -f $save_dir/mainnet_latest.json ]
+      if [ -f $save_dir/$mainnet_snapshot_json_filename ]
       then
-        local_previous_mainnet_blockEpoch=$(cat "$save_dir/mainnet_latest.json" | jq ".BlockEpoch")
-        local_previous_mainnet_blockIndex=$(cat "$save_dir/mainnet_latest.json" | jq ".Index")
-        download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_previous_mainnet_blockIndex
+        if [ $complete_snapshot_reset = "true" ]
+        then
+          echo "Completely delete the existing store and download a new snapshot"
+          rm -r "$save_dir"
+          mkdir -p "$save_dir"
+          download_unzip_full_snapshot
+        else
+          local_chain_tip_index="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
+          if [ -f $save_dir/$mainnet_snapshot_json_filename ]
+          then
+            local_previous_mainnet_blockEpoch=$(cat "$save_dir/$mainnet_snapshot_json_filename" | jq ".BlockEpoch")
+            download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
+          else
+            local_chain_tip_timestamp="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
+            epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
+            echo $epoch_seconds
+            local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))
+            echo $local_chain_tip_blockEpoch
+            download_unzip_partial_snapshot $local_chain_tip_blockEpoch $local_chain_tip_index
+          fi
+        fi
       else
         download_unzip_full_snapshot
       fi

--- a/charts/remote-headless/templates/configmap-download-snapshot.yaml
+++ b/charts/remote-headless/templates/configmap-download-snapshot.yaml
@@ -48,7 +48,7 @@ data:
 
       function download_unzip_partial_snapshot() {
         snapshot_json_filename="latest.json"
-        mainnet_snapshot_json_filename="latest.json"
+        mainnet_snapshot_json_filename="mainnet_latest.json"
         snapshot_zip_filename="state_latest.zip"
         snapshot_zip_filename_array=("$snapshot_zip_filename")
         mainnet_snapshot_json_url="$base_url/$mainnet_snapshot_json_filename"
@@ -104,7 +104,7 @@ data:
 
       function download_unzip_full_snapshot() {
           snapshot_json_filename="latest.json"
-          mainnet_snapshot_json_filename="latest.json"
+          mainnet_snapshot_json_filename="mainnet_latest.json"
           snapshot_zip_filename="state_latest.zip"
           snapshot_zip_filename_array=("$snapshot_zip_filename")
 
@@ -152,22 +152,29 @@ data:
           aria2c "$base_url/$mainnet_snapshot_json_filename" -d "$save_dir" -o "$mainnet_snapshot_json_filename" -j10 -x10 --continue=true
       }
 
-      if [[ -d "$save_dir" ]]
+      if [ -f $save_dir/$mainnet_snapshot_json_filename ]
       then
-        local_chain_tip_index="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
-        if [ -f $save_dir/latest.json ]
+        if [ $complete_snapshot_reset = "true" ]
         then
-          local_previous_mainnet_blockEpoch=$(cat "$save_dir/latest.json" | jq ".BlockEpoch")
-          download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
+          echo "Completely delete the existing store and download a new snapshot"
+          rm -r "$save_dir"
+          mkdir -p "$save_dir"
+          download_unzip_full_snapshot
         else
-          local_chain_tip_timestamp="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
-          epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
-          echo $epoch_seconds
-          local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))
-          echo $local_chain_tip_blockEpoch
-          download_unzip_partial_snapshot $local_chain_tip_blockEpoch $local_chain_tip_index
+          local_chain_tip_index="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
+          if [ -f $save_dir/$mainnet_snapshot_json_filename ]
+          then
+            local_previous_mainnet_blockEpoch=$(cat "$save_dir/$mainnet_snapshot_json_filename" | jq ".BlockEpoch")
+            download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
+          else
+            local_chain_tip_timestamp="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
+            epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
+            echo $epoch_seconds
+            local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))
+            echo $local_chain_tip_blockEpoch
+            download_unzip_partial_snapshot $local_chain_tip_blockEpoch $local_chain_tip_index
+          fi
         fi
-
       else
         download_unzip_full_snapshot
       fi

--- a/charts/snapshot/templates/configmap-download-snapshot.yaml
+++ b/charts/snapshot/templates/configmap-download-snapshot.yaml
@@ -19,6 +19,7 @@ data:
     download_option=$3
     service_name=$4
     SLACK_WEBHOOK=$5
+    complete_snapshot_reset=${6:-"false"}
 
     if [ $download_option = "true" ]
     then
@@ -41,7 +42,7 @@ data:
 
       function download_unzip_partial_snapshot() {
         snapshot_json_filename="latest.json"
-        mainnet_snapshot_json_filename="latest.json"
+        mainnet_snapshot_json_filename="mainnet_latest.json"
         snapshot_zip_filename="state_latest.zip"
         snapshot_zip_filename_array=("$snapshot_zip_filename")
         mainnet_snapshot_json_url="$base_url/$mainnet_snapshot_json_filename"
@@ -97,7 +98,7 @@ data:
 
       function download_unzip_full_snapshot() {
           snapshot_json_filename="latest.json"
-          mainnet_snapshot_json_filename="latest.json"
+          mainnet_snapshot_json_filename="mainnet_latest.json"
           snapshot_zip_filename="state_latest.zip"
           snapshot_zip_filename_array=("$snapshot_zip_filename")
 
@@ -145,22 +146,29 @@ data:
           aria2c "$base_url/$mainnet_snapshot_json_filename" -d "$save_dir" -o "$mainnet_snapshot_json_filename" -j10 -x10 --continue=true
       }
 
-      if [[ -d "$save_dir" ]]
+      if [ -f $save_dir/$mainnet_snapshot_json_filename ]
       then
-        local_chain_tip_index="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
-        if [ -f $save_dir/latest.json ]
+        if [ $complete_snapshot_reset = "true" ]
         then
-          local_previous_mainnet_blockEpoch=$(cat "$save_dir/latest.json" | jq ".BlockEpoch")
-          download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
+          echo "Completely delete the existing store and download a new snapshot"
+          rm -r "$save_dir"
+          mkdir -p "$save_dir"
+          download_unzip_full_snapshot
         else
-          local_chain_tip_timestamp="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
-          epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
-          echo $epoch_seconds
-          local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))
-          echo $local_chain_tip_blockEpoch
-          download_unzip_partial_snapshot $local_chain_tip_blockEpoch $local_chain_tip_index
+          local_chain_tip_index="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
+          if [ -f $save_dir/$mainnet_snapshot_json_filename ]
+          then
+            local_previous_mainnet_blockEpoch=$(cat "$save_dir/$mainnet_snapshot_json_filename" | jq ".BlockEpoch")
+            download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
+          else
+            local_chain_tip_timestamp="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
+            epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
+            echo $epoch_seconds
+            local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))
+            echo $local_chain_tip_blockEpoch
+            download_unzip_partial_snapshot $local_chain_tip_blockEpoch $local_chain_tip_index
+          fi
         fi
-
       else
         download_unzip_full_snapshot
       fi

--- a/charts/validator/templates/configmap-download-snapshot.yaml
+++ b/charts/validator/templates/configmap-download-snapshot.yaml
@@ -26,6 +26,7 @@ data:
     download_option=$3
     service_name=$4
     SLACK_WEBHOOK=$5
+    complete_snapshot_reset=${6:-"false"}
 
     if [ $download_option = "true" ]
     then
@@ -48,7 +49,7 @@ data:
 
       function download_unzip_partial_snapshot() {
         snapshot_json_filename="latest.json"
-        mainnet_snapshot_json_filename="latest.json"
+        mainnet_snapshot_json_filename="mainnet_latest.json"
         snapshot_zip_filename="state_latest.zip"
         snapshot_zip_filename_array=("$snapshot_zip_filename")
         mainnet_snapshot_json_url="$base_url/$mainnet_snapshot_json_filename"
@@ -104,7 +105,7 @@ data:
 
       function download_unzip_full_snapshot() {
           snapshot_json_filename="latest.json"
-          mainnet_snapshot_json_filename="latest.json"
+          mainnet_snapshot_json_filename="mainnet_latest.json"
           snapshot_zip_filename="state_latest.zip"
           snapshot_zip_filename_array=("$snapshot_zip_filename")
 
@@ -152,22 +153,29 @@ data:
           aria2c "$base_url/$mainnet_snapshot_json_filename" -d "$save_dir" -o "$mainnet_snapshot_json_filename" -j10 -x10 --continue=true
       }
 
-      if [[ -d "$save_dir" ]]
+      if [ -f $save_dir/$mainnet_snapshot_json_filename ]
       then
-        local_chain_tip_index="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
-        if [ -f $save_dir/latest.json ]
+        if [ $complete_snapshot_reset = "true" ]
         then
-          local_previous_mainnet_blockEpoch=$(cat "$save_dir/latest.json" | jq ".BlockEpoch")
-          download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
+          echo "Completely delete the existing store and download a new snapshot"
+          rm -r "$save_dir"
+          mkdir -p "$save_dir"
+          download_unzip_full_snapshot
         else
-          local_chain_tip_timestamp="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
-          epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
-          echo $epoch_seconds
-          local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))
-          echo $local_chain_tip_blockEpoch
-          download_unzip_partial_snapshot $local_chain_tip_blockEpoch $local_chain_tip_index
+          local_chain_tip_index="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
+          if [ -f $save_dir/$mainnet_snapshot_json_filename ]
+          then
+            local_previous_mainnet_blockEpoch=$(cat "$save_dir/$mainnet_snapshot_json_filename" | jq ".BlockEpoch")
+            download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
+          else
+            local_chain_tip_timestamp="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
+            epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
+            echo $epoch_seconds
+            local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))
+            echo $local_chain_tip_blockEpoch
+            download_unzip_partial_snapshot $local_chain_tip_blockEpoch $local_chain_tip_index
+          fi
         fi
-
       else
         download_unzip_full_snapshot
       fi


### PR DESCRIPTION
I've added a `complete_snapshot_reset` option(`false` in default) in the script to completely delete a pod's store and download a new snapshot when necessary. This feature will mostly be used in an internal network setting when frequent store reset in the network is needed during tests.

I've also combined the scripts used by `9c-main` and `9c-internal` (they were somewhat different) for consistency purposes.