### PR TITLE
Disable `ReducedStore` in full-state node

### DIFF
--- a/9c-main/chart/templates/full-state.yaml
+++ b/9c-main/chart/templates/full-state.yaml
@@ -45,6 +45,7 @@ spec:
         - --no-cors
         - --chain-tip-stale-behavior-type=reboot
         - --network-type={{ $.Values.networkType }}
+        - --no-reduce-store
         {{- with $.Values.fullState.extraArgs }}
           {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
SSIA. This pull request disables `ReducedStore` in the full-state node.

## What is `ReducedStore`?

The `ReducedStore` is an `IStore` proxy implementation to avoid storing `TxSuccess.UpdatedStates` because they were too big to store in users' local storage.

You can see the source at https://github.com/planetarium/NineChronicles.Headless/blob/c79127a8147e11b14985be7bf3fb3d841c3d3417/Libplanet.Headless/ReducedStore.cs.
To disable the `ReducedStore`, you can use [`--no-reduce-store`](https://github.com/planetarium/NineChronicles.Headless/blob/c79127a8147e11b14985be7bf3fb3d841c3d3417/NineChronicles.Headless.Executable/Program.cs#L105-L106).

## Why did you disable `ReducedStore`?

The reason that `ReducedStore` was introduced is clear. But it is the story of the days when users ran headless. Sadly, now, users don't commonly run headless in their local.

And when disabling the feature, `TxSuccess.UpdatedStates` will be stored again and they're very helpful to debug `InvalidBlockStateRootHashException`. It was hard to specify a transaction that occurred the exception, but it'll be easy with the `TxSuccess.UpdatedStates`. If transactions in a block updated shared address, it is hard to detect problem transactions 😢 