### PR TITLE
Fix 9c-network service annotations

### DIFF
--- a/charts/9c-network/templates/service.yaml
+++ b/charts/9c-network/templates/service.yaml
@@ -11,7 +11,6 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
 spec:
   externalTrafficPolicy: Local
   ports:
@@ -44,7 +43,6 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
 spec:
   externalTrafficPolicy: Local
   ports:
@@ -80,7 +78,6 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
 spec:
   ports:
   - port: {{ $.Values.validator.ports.headless }}


### PR DESCRIPTION
this annotation is causing quota limits
```
Error syncing load balancer: failed to ensure load balancer: error authorizing security group ingress: "RulesPerSecurityGroupLimitExceeded: The maximum number of rules per security group has been reached.\n\tstatus code: 400, request id: e42daf54-14a3-4ebd-88ba-52b22e4b66ba"
```