### PR TITLE
Fix 9c-network service not to bind sg

### DIFF
--- a/charts/9c-network/templates/service.yaml
+++ b/charts/9c-network/templates/service.yaml
@@ -11,6 +11,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules: "false"
 spec:
   externalTrafficPolicy: Local
   ports:
@@ -43,6 +44,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules: "false"
 spec:
   externalTrafficPolicy: Local
   ports:
@@ -78,6 +80,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: "external"
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules: "false"
 spec:
   ports:
   - port: {{ $.Values.validator.ports.headless }}


### PR DESCRIPTION
Trying to prevent following error
```
RulesPerSecurityGroupLimitExceeded: The maximum number of rules per security group has been reached
```