### PR TITLE
Remove nodeSelector from empty-chronicle

### DIFF
--- a/9c-main/chart/templates/empty-chronicle.yaml
+++ b/9c-main/chart/templates/empty-chronicle.yaml
@@ -61,8 +61,6 @@ spec:
         configMap:
           defaultMode: 0700
           name: {{ $.Chart.Name }}-download-snapshot-script
-      nodeSelector:
-        eks.amazonaws.com/nodegroup: 9c-main-m7g_2xl_2c_test
   volumeClaimTemplates:
     - metadata:
         name: empty-chronicle-data


### PR DESCRIPTION
When applying the `empty-chronicle` statefulset resource, its pod couldn't be assigned to any node with the below message:

```
pod didn't trigger scale-up
6 node(s) didn't match Pod's node affinity,
4 node(s) had taint {dedicated: remote-headless-test}, that the pod didn't tolerate
1 node(s) had taint {dedicated: validator}, that the pod didn't tolerate,
1 max node group size reached
```

So I guessed there are not enough places to be assigned in the nodegroup. So it removes the nodeSelector and expects to be assigned dynamically.

If it can take other application's places so it can occur other applications an issue, please let me know it. 🙏🏻 @planetarium/devops 