### PR TITLE
suspend bridge observer cronjob

### DIFF
--- a/9c-main/chart/templates/bridge.yaml
+++ b/9c-main/chart/templates/bridge.yaml
@@ -93,5 +93,6 @@ spec:
             node.kubernetes.io/instance-type: m5.large
           restartPolicy: OnFailure
   schedule: 30 * * * *
+  suspend: true
   successfulJobsHistoryLimit: 1
 {{ end }}


### PR DESCRIPTION
The `bridge-observer` cronjob is currently not being used.