### PR TITLE
Update remote-action-evaluator-headless

### DIFF
--- a/9c-main/chart/templates/remote-action-evaluator-headless.yaml
+++ b/9c-main/chart/templates/remote-action-evaluator-headless.yaml
@@ -359,7 +359,7 @@ data:
         "StateServiceManagerService": {
           "StateServices": [
             {
-              "path": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/lib9c-stateservices/07fad34fa36e03af8cf317938812eb2667592b85/linux-x64.zip",
+              "path": "https://9c-dx.s3.ap-northeast-2.amazonaws.com/lib9c-stateservices/279166ddf7ae05967d8887a20179816712632d39/linux-x64.zip",
               "port": 11110
             },
             {
@@ -368,7 +368,7 @@ data:
             }
           ],
           "StateServicesDownloadPath": "/tmp/lib9c-stateservices",
-          "RemoteBlockChainStatesEndpoint": "http://localhost:{{ $.Values.lib9cStateService.ports.http }}/graphql/explorer"
+          "RemoteBlockChainStatesEndpoint": "http://localhost:{{ $.Values.remoteActionEvaluatorHeadless.ports.graphql }}/graphql/explorer"
         }
       }
     }

--- a/9c-main/chart/values.yaml
+++ b/9c-main/chart/values.yaml
@@ -488,7 +488,7 @@ remoteActionEvaluatorHeadless:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "git-464d506caba9ab17e52d2fc84abafeeee35fd51e"
+    tag: "git-258c6aa5d2a260302c285e55f2bbca1b45699525"
 
   loggingEnabled: true
 


### PR DESCRIPTION
This fixes a bug in remote-action-evaluator-headless' template.