### PR TITLE
fix: using default aev when block is latest version

### DIFF
--- a/9c-main/chart/templates/remote-action-evaluator-headless.yaml
+++ b/9c-main/chart/templates/remote-action-evaluator-headless.yaml
@@ -363,6 +363,14 @@ data:
               },
               "range": {
                 "start": 7520001,
+                "end": 7528200
+              },
+            {
+              "actionEvaluator": {
+                "type": "Default"
+              },
+              "range": {
+                "start": 7528201,
                 "end": 9223372036854775807
               }
             }


### PR DESCRIPTION
SSIA