### PR TITLE
ci(gh-actions): validate JSON files having `$schema`

### DIFF
--- a/.github/scripts/validate-json-schema.sh
+++ b/.github/scripts/validate-json-schema.sh
@@ -1,0 +1,24 @@
+set -exv
+
+function random_str() {
+  echo $RANDOM | md5sum | head -c 20; echo
+}
+
+regex='https?://[-[:alnum:]\+&@#/%?=~_|!:,.;]*[-[:alnum:]\+&@#/%=~_|]'
+FILES=`find . -type f -name '*.json'`
+for file in "${FILES[@]}"; do
+  echo "Try $file"
+  schema=`jq  -r '.["$schema"]' "$file"`
+  if [[ "$schema" != "" ]]; then
+    echo "Schema of $file was $schema"
+    if [[ "$schema" =~ $regex ]]; then
+      schema_file="/tmp/`random_str`.json"
+      wget "$schema" -O "$schema_file"
+    else
+      schema_file="$schema"
+    fi
+    ajv validate -s "$schema_file" -d "$file" --verbose
+  else
+    echo "Skip $file"
+  fi
+done

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,14 @@
+name: lint
+
+on: [push, pull_request]
+
+jobs:
+  validate-json-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install ajv-cli
+        run: yarn global add ajv-cli
+      - name: Validate JSON files having schema
+        run: |
+          .github/scripts/validate-json-schema.sh

--- a/9c-main/chart/scripts/common/appsettings.json
+++ b/9c-main/chart/scripts/common/appsettings.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "./appsettings-schema.json",
+    "$schema": "https://raw.githubusercontent.com/planetarium/NineChronicles.Headless/main/NineChronicles.Headless.Executable/appsettings-schema.json",
     "Serilog": {
         "Using": [
             "Serilog.Expressions",


### PR DESCRIPTION
Sometimes, it uses the `appsettings.json` of the `NineChronicles.Headless.Executable` project but there was no step to validate those configurations. This pull request introduces GitHub Actions to validate JSON files having a `$schema` field. 👀 