### PR TITLE
refactor: download and extract snapshot files in parallel

### DIFF
--- a/9c-main/chart/scripts/download_snapshot.sh
+++ b/9c-main/chart/scripts/download_snapshot.sh
@@ -2,14 +2,12 @@
 
 cd /data
 
-until apt-get -y update
-do
-  echo "Try again"
+until apt-get -y update; do
+	echo "Try again"
 done
 
-until apt-get -y install jq wget aria2 sudo zip
-do
-  echo "Try again"
+until apt-get -y install jq wget aria2 sudo zip; do
+	echo "Try again"
 done
 
 base_url=${1:-https://snapshots.nine-chronicles.com/main/partition}
@@ -20,166 +18,150 @@ SLACK_WEBHOOK=$5
 complete_snapshot_reset=${6:-"false"}
 mainnet_snapshot_json_filename="latest.json"
 
-if [ $download_option = "true" ]
-then
-  echo "Start download snapshot"
-  if [ $service_name != "snapshot" ]
-  then
-    echo $service_name
-  fi
+if [ $download_option = "true" ]; then
+	echo "Start download snapshot"
+	if [ $service_name != "snapshot" ]; then
+		echo $service_name
+	fi
 
-  # strip tailing slash
-  base_url=${base_url%/}
+	# strip tailing slash
+	base_url=${base_url%/}
 
-  function get_snapshot_value() {
-      snapshot_json_url="$1"
-      snapshot_param="$2"
+	function get_snapshot_value() {
+		snapshot_json_url="$1"
+		snapshot_param="$2"
 
-      snapshot_param_return_value=$(curl --silent "$snapshot_json_url" | jq ".$snapshot_param")
-      echo "$snapshot_param_return_value"
-  }
+		snapshot_param_return_value=$(curl --silent "$snapshot_json_url" | jq ".$snapshot_param")
+		echo "$snapshot_param_return_value"
+	}
 
-  function download_unzip_partial_snapshot() {
-    snapshot_json_filename="latest.json"
-    snapshot_zip_filename="state_latest.zip"
-    snapshot_zip_filename_array=("$snapshot_zip_filename")
-    mainnet_snapshot_json_url="$base_url/$mainnet_snapshot_json_filename"
-    mainnet_snapshot_blockIndex=$(get_snapshot_value "$mainnet_snapshot_json_url" "Index")
+	function download_unzip_partial_snapshot() {
+		snapshot_json_filename="latest.json"
+		snapshot_zip_filename="state_latest.zip"
+		snapshot_zip_filename_array=("$snapshot_zip_filename")
+		mainnet_snapshot_json_url="$base_url/$mainnet_snapshot_json_filename"
+		mainnet_snapshot_blockIndex=$(get_snapshot_value "$mainnet_snapshot_json_url" "Index")
 
-    if [ "$mainnet_snapshot_blockIndex" -lt $2 ]
-    then
-        echo "Skip snapshot download because the local chain tip is greater than the snapshot tip."
-        return
-    fi
+		if [ "$mainnet_snapshot_blockIndex" -lt $2 ]; then
+			echo "Skip snapshot download because the local chain tip is greater than the snapshot tip."
+			return
+		fi
 
-    while :
-    do
-        snapshot_json_url="$base_url/$snapshot_json_filename"
-        BlockEpoch=$(get_snapshot_value "$snapshot_json_url" "BlockEpoch")
-        TxEpoch=$(get_snapshot_value "$snapshot_json_url" "TxEpoch")
-        PreviousBlockEpoch=$(get_snapshot_value "$snapshot_json_url" "PreviousBlockEpoch")
-        PreviousTxEpoch=$(get_snapshot_value "$snapshot_json_url" "PreviousTxEpoch")
+		while :; do
+			snapshot_json_url="$base_url/$snapshot_json_filename"
+			BlockEpoch=$(get_snapshot_value "$snapshot_json_url" "BlockEpoch")
+			TxEpoch=$(get_snapshot_value "$snapshot_json_url" "TxEpoch")
+			PreviousBlockEpoch=$(get_snapshot_value "$snapshot_json_url" "PreviousBlockEpoch")
+			PreviousTxEpoch=$(get_snapshot_value "$snapshot_json_url" "PreviousTxEpoch")
 
-        snapshot_zip_filename="snapshot-$BlockEpoch-$TxEpoch.zip"
-        snapshot_zip_filename_array+=("$snapshot_zip_filename")
+			snapshot_zip_filename="snapshot-$BlockEpoch-$TxEpoch.zip"
+			snapshot_zip_filename_array+=("$snapshot_zip_filename")
 
-        if [ $(("$PreviousBlockEpoch"+1)) -lt $1 ]
-        then
-            break
-        fi
+			if [ $(("$PreviousBlockEpoch" + 1)) -lt $1 ]; then
+				break
+			fi
 
-        snapshot_json_filename="snapshot-$PreviousBlockEpoch-$PreviousTxEpoch.json"
-    done
+			snapshot_json_filename="snapshot-$PreviousBlockEpoch-$PreviousTxEpoch.json"
+		done
 
-    if [[ ! -d "$save_dir" ]]
-    then
-        echo "[Info] The directory $save_dir does not exist and is created."
-        mkdir -p "$save_dir"
-    fi
+		if [[ ! -d "$save_dir" ]]; then
+			echo "[Info] The directory $save_dir does not exist and is created."
+			mkdir -p "$save_dir"
+		fi
 
-    for ((i=${#snapshot_zip_filename_array[@]}-1; i>=0; i--))
-    do
-        snapshot_zip_filename="${snapshot_zip_filename_array[$i]}"
-        rm "$snapshot_zip_filename" 2>/dev/null
+		for ((i = ${#snapshot_zip_filename_array[@]} - 1; i >= 0; i--)); do
+			snapshot_zip_filename="${snapshot_zip_filename_array[$i]}"
+			rm "$snapshot_zip_filename" 2>/dev/null
 
-        snapshot_zip_url="$base_url/$snapshot_zip_filename"
-        echo "$snapshot_zip_url"
+			snapshot_zip_url="$base_url/$snapshot_zip_filename"
+			echo "$snapshot_zip_url"
 
-        aria2c "$snapshot_zip_url" -j10 -x10 --continue=true
-        echo "Unzipping $snapshot_zip_filename"
-        unzip -o "$snapshot_zip_filename" -d "$save_dir"
-        rm "$snapshot_zip_filename"
-    done
+			aria2c "$snapshot_zip_url" -j10 -x10 --continue=true
+			echo "Unzipping $snapshot_zip_filename"
+			unzip -o "$snapshot_zip_filename" -d "$save_dir"
+			rm "$snapshot_zip_filename"
+		done
 
-    aria2c "$base_url/$mainnet_snapshot_json_filename" -d "$save_dir" -o "$mainnet_snapshot_json_filename" -j10 -x10 --continue=true
-  }
+		aria2c "$base_url/$mainnet_snapshot_json_filename" -d "$save_dir" -o "$mainnet_snapshot_json_filename" -j10 -x10 --continue=true
+	}
 
-  function download_unzip_full_snapshot() {
-      snapshot_json_filename="latest.json"
-      snapshot_zip_filename="state_latest.zip"
-      snapshot_zip_filename_array=("$snapshot_zip_filename")
+	function download_unzip_full_snapshot() {
+		snapshot_json_filename="latest.json"
+		snapshot_zip_filename="state_latest.zip"
+		snapshot_zip_filename_array=("$snapshot_zip_filename")
 
-      while :
-      do
-          snapshot_json_url="$base_url/$snapshot_json_filename"
-          echo "$snapshot_json_url"
+		while :; do
+			snapshot_json_url="$base_url/$snapshot_json_filename"
+			echo "$snapshot_json_url"
 
-          BlockEpoch=$(get_snapshot_value "$snapshot_json_url" "BlockEpoch")
-          TxEpoch=$(get_snapshot_value "$snapshot_json_url" "TxEpoch")
-          PreviousBlockEpoch=$(get_snapshot_value "$snapshot_json_url" "PreviousBlockEpoch")
-          PreviousTxEpoch=$(get_snapshot_value "$snapshot_json_url" "PreviousTxEpoch")
+			BlockEpoch=$(get_snapshot_value "$snapshot_json_url" "BlockEpoch")
+			TxEpoch=$(get_snapshot_value "$snapshot_json_url" "TxEpoch")
+			PreviousBlockEpoch=$(get_snapshot_value "$snapshot_json_url" "PreviousBlockEpoch")
+			PreviousTxEpoch=$(get_snapshot_value "$snapshot_json_url" "PreviousTxEpoch")
 
-          snapshot_zip_filename="snapshot-$BlockEpoch-$TxEpoch.zip"
-          snapshot_zip_filename_array+=("$snapshot_zip_filename")
+			snapshot_zip_filename="snapshot-$BlockEpoch-$TxEpoch.zip"
+			snapshot_zip_filename_array+=("$snapshot_zip_filename")
 
-          if [ "$PreviousBlockEpoch" -eq 0 ]
-          then
-              break
-          fi
+			if [ "$PreviousBlockEpoch" -eq 0 ]; then
+				break
+			fi
 
-          snapshot_json_filename="snapshot-$PreviousBlockEpoch-$PreviousTxEpoch.json"
-      done
+			snapshot_json_filename="snapshot-$PreviousBlockEpoch-$PreviousTxEpoch.json"
+		done
 
-      if [[ ! -d "$save_dir" ]]
-      then
-          echo "[Info] The directory $save_dir does not exist and is created."
-          mkdir -p "$save_dir"
-      fi
+		if [[ ! -d "$save_dir" ]]; then
+			echo "[Info] The directory $save_dir does not exist and is created."
+			mkdir -p "$save_dir"
+		fi
 
-      for ((i=${#snapshot_zip_filename_array[@]}-1; i>=0; i--))
-      do
-          snapshot_zip_filename="${snapshot_zip_filename_array[$i]}"
-          rm "$snapshot_zip_filename" 2>/dev/null
+		for ((i = ${#snapshot_zip_filename_array[@]} - 1; i >= 0; i--)); do
+			snapshot_zip_filename="${snapshot_zip_filename_array[$i]}"
+			rm "$snapshot_zip_filename" 2>/dev/null
 
-          snapshot_zip_url="$base_url/$snapshot_zip_filename"
-          echo "$snapshot_zip_url"
+			snapshot_zip_url="$base_url/$snapshot_zip_filename"
+			echo "$snapshot_zip_url"
 
-          aria2c "$snapshot_zip_url" -j10 -x10 --continue=true
-          echo "Unzipping $snapshot_zip_filename"
-          unzip -o "$snapshot_zip_filename" -d "$save_dir"
-          rm "$snapshot_zip_filename"
-      done
+			aria2c "$snapshot_zip_url" -j10 -x10 --continue=true
+			echo "Unzipping $snapshot_zip_filename"
+			unzip -o "$snapshot_zip_filename" -d "$save_dir"
+			rm "$snapshot_zip_filename"
+		done
 
-      aria2c "$base_url/$mainnet_snapshot_json_filename" -d "$save_dir" -o "$mainnet_snapshot_json_filename" -j10 -x10 --continue=true
-  }
+		aria2c "$base_url/$mainnet_snapshot_json_filename" -d "$save_dir" -o "$mainnet_snapshot_json_filename" -j10 -x10 --continue=true
+	}
 
-  if [ -f $save_dir/$mainnet_snapshot_json_filename ]
-  then
-    if [ $complete_snapshot_reset = "true" ]
-    then
-      echo "Completely delete the existing store and download a new snapshot"
-      rm -r "$save_dir"
-      mkdir -p "$save_dir"
-      download_unzip_full_snapshot
-    else
-      local_chain_tip_index="$($(/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
-      if [ -f $save_dir/$mainnet_snapshot_json_filename ]
-      then
-        local_previous_mainnet_blockEpoch=$(cat "$save_dir/$mainnet_snapshot_json_filename" | jq ".BlockEpoch")
-        download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
-      else
-        local_chain_tip_timestamp="$($(/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
-        epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
-        echo $epoch_seconds
-        local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))
-        echo $local_chain_tip_blockEpoch
-        download_unzip_partial_snapshot $local_chain_tip_blockEpoch $local_chain_tip_index
-      fi
-    fi
-  else
-    download_unzip_full_snapshot
-  fi
+	if [ -f $save_dir/$mainnet_snapshot_json_filename ]; then
+		if [ $complete_snapshot_reset = "true" ]; then
+			echo "Completely delete the existing store and download a new snapshot"
+			rm -r "$save_dir"
+			mkdir -p "$save_dir"
+			download_unzip_full_snapshot
+		else
+			local_chain_tip_index="$($(/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
+			if [ -f $save_dir/$mainnet_snapshot_json_filename ]; then
+				local_previous_mainnet_blockEpoch=$(cat "$save_dir/$mainnet_snapshot_json_filename" | jq ".BlockEpoch")
+				download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
+			else
+				local_chain_tip_timestamp="$($(/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
+				epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
+				echo $epoch_seconds
+				local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))
+				echo $local_chain_tip_blockEpoch
+				download_unzip_partial_snapshot $local_chain_tip_blockEpoch $local_chain_tip_index
+			fi
+		fi
+	else
+		download_unzip_full_snapshot
+	fi
 
-  # The return value for the program that calls this script
-  echo "$save_dir"
-  if [ $service_name != "snapshot" ]
-  then
-    echo $service_name
-  fi
+	# The return value for the program that calls this script
+	echo "$save_dir"
+	if [ $service_name != "snapshot" ]; then
+		echo $service_name
+	fi
 else
-  echo "Skip download snapshot"
-  if [ $service_name != "snapshot" ]
-  then
-    echo $service_name
-  fi
+	echo "Skip download snapshot"
+	if [ $service_name != "snapshot" ]; then
+		echo $service_name
+	fi
 fi

--- a/9c-main/chart/scripts/download_snapshot.sh
+++ b/9c-main/chart/scripts/download_snapshot.sh
@@ -152,13 +152,13 @@ then
       mkdir -p "$save_dir"
       download_unzip_full_snapshot
     else
-      local_chain_tip_index="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
+      local_chain_tip_index="$($(/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Index')"
       if [ -f $save_dir/$mainnet_snapshot_json_filename ]
       then
         local_previous_mainnet_blockEpoch=$(cat "$save_dir/$mainnet_snapshot_json_filename" | jq ".BlockEpoch")
         download_unzip_partial_snapshot $local_previous_mainnet_blockEpoch $local_chain_tip_index
       else
-        local_chain_tip_timestamp="$((/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
+        local_chain_tip_timestamp="$($(/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir") | jq -r '.Timestamp')"
         epoch_seconds=$(date -d "$local_chain_tip_timestamp" +%s)
         echo $epoch_seconds
         local_chain_tip_blockEpoch=$(($epoch_seconds / 86400))

--- a/9c-main/chart/scripts/download_snapshot.sh
+++ b/9c-main/chart/scripts/download_snapshot.sh
@@ -27,6 +27,9 @@ if [ $download_option = "true" ]; then
 	# strip tailing slash
 	base_url=${base_url%/}
 
+	export base_url
+	export save_dir
+
 	function get_snapshot_value() {
 		snapshot_json_url="$1"
 		snapshot_param="$2"
@@ -37,6 +40,7 @@ if [ $download_option = "true" ]; then
 
 	function download_unzip_single_snapshot() {
 		snapshot_zip_filename="$1"
+		echo "download_unzip_single_snapshot: download $snapshot_zip_filename"
 		rm "$snapshot_zip_filename" 2>/dev/null
 
 		snapshot_zip_url="$base_url/$snapshot_zip_filename"
@@ -47,6 +51,8 @@ if [ $download_option = "true" ]; then
 		unzip -o "$snapshot_zip_filename" -d "$save_dir"
 		rm "$snapshot_zip_filename"
 	}
+
+	export -f download_unzip_single_snapshot
 
 	function get_chain_tip_json() {
 		/app/NineChronicles.Headless.Executable chain tip "RocksDb" "$save_dir"
@@ -86,9 +92,7 @@ if [ $download_option = "true" ]; then
 			mkdir -p "$save_dir"
 		fi
 
-		for ((i = ${#snapshot_zip_filename_array[@]} - 1; i >= 0; i--)); do
-			download_unzip_single_snapshot "${snapshot_zip_filename_array[$i]}"
-		done
+		printf "%s\n" "${snapshot_zip_filename_array[@]}" | xargs -P 8 -I {} /bin/bash -c 'download_unzip_single_snapshot "$@"' -- {}
 
 		aria2c "$base_url/$mainnet_snapshot_json_filename" -d "$save_dir" -o "$mainnet_snapshot_json_filename" -j10 -x10 --continue=true
 	}
@@ -122,9 +126,7 @@ if [ $download_option = "true" ]; then
 			mkdir -p "$save_dir"
 		fi
 
-		for ((i = ${#snapshot_zip_filename_array[@]} - 1; i >= 0; i--)); do
-			download_unzip_single_snapshot "${snapshot_zip_filename_array[$i]}"
-		done
+		printf "%s\n" "${snapshot_zip_filename_array[@]}" | xargs -P 8 -I {} /bin/bash -c 'download_unzip_single_snapshot "$@"' -- {}
 
 		aria2c "$base_url/$mainnet_snapshot_json_filename" -d "$save_dir" -o "$mainnet_snapshot_json_filename" -j10 -x10 --continue=true
 	}


### PR DESCRIPTION
## Overview

This pull request resolves #595.

This pull request parallelizes downloading and extracting snapshot files with `xargs` command.

But... as you can see in the `Setting for test > Command` section, there was no surprising improvement. 😭 According to what I saw, only two files, the first partition snapshot file (65GB) and state snapshot file (22GB), spend almost the total running time. So there was no crazy improvement for a total running time even if it downloaded other files in parallel.

So. I think @planetarium/devops can decide whether to accept this pull request. Furthermore, there will be a crazy improvement if it can break the huge two files. 🤔 

## References

 - https://www.gnu.org/software/findutils/manual/html_node/find_html/xargs-options.html

## Settings for test

### Pod manifest

*assigned on m5.large instance.*

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: snapshot-test-headless
spec:
  containers:
  - name: snapshot-test-headless
    image: planetariumhq/ninechronicles-headless:git-0fa9313600b0064923657ccbe924a68b4471e26a
    command:
      - /bin/bash
      - "-c"
      - "sleep 1000"
    volumeMounts:
      - mountPath: "/data"
        name: snapshot-test-headless-data
  volumes:
    - name: snapshot-test-headless-data
      ephemeral:
        volumeClaimTemplate:
          spec:
            accessModes: [ "ReadWriteOnce" ]
            storageClassName: "9c-network-gp3"
            resources:
              requests:
                storage: 200Gi
```

### Command

```
time ./previous_download_snapshot.sh "https://snapshots.nine-chronicles.com/main/partition" "9c-main-snapshot_$(date +%Y%m%d_%H)" "true" "service-name" "no-webhook" "true"

real    46m35.459s
user    24m13.880s
sys     6m15.315s

time ./new_download_snapshot.sh "https://snapshots.nine-chronicles.com/main/partition" "9c-main-snapshot_$(date +%Y%m%d_%H)" "true" "service-name" "no-webhook" "true"

real    43m30.302s
user    24m30.004s
sys     6m49.456s
```