### PR TITLE
[9c-internal] cover edge cases when downloading snapshot

### DIFF
--- a/charts/all-in-one/templates/configmap-download-snapshot.yaml
+++ b/charts/all-in-one/templates/configmap-download-snapshot.yaml
@@ -26,7 +26,8 @@ data:
     download_option=$3
     service_name=$4
     SLACK_WEBHOOK=$5
-    complete_snapshot_reset=${6:-"false"}
+    rollback_snapshot=${6:-"false"}
+    complete_snapshot_reset=${7:-"false"}
     mainnet_snapshot_json_filename="mainnet_latest.json"
 
     if [ $download_option = "true" ]
@@ -54,11 +55,15 @@ data:
         snapshot_zip_filename_array=("$snapshot_zip_filename")
         mainnet_snapshot_json_url="$base_url/$mainnet_snapshot_json_filename"
         mainnet_snapshot_blockIndex=$(get_snapshot_value "$mainnet_snapshot_json_url" "Index")
+        mainnet_snapshot_blockEpoch=$(get_snapshot_value "$mainnet_snapshot_json_url" "BlockEpoch")
 
-        if [ "$mainnet_snapshot_blockIndex" -lt $2 ]
-        then
-            echo "Skip snapshot download because the local chain tip is greater than the snapshot tip."
-            return
+        if [ "$mainnet_snapshot_blockEpoch" -le $1 ]; then
+            if [ $rollback_snapshot = "false" ]; then
+              if [ "$mainnet_snapshot_blockIndex" -le $2 ]; then
+                  echo "Skip snapshot download because the local chain tip is greater than the snapshot tip."
+                  return
+              fi
+            fi
         fi
 
         while :


### PR DESCRIPTION
Resolves https://github.com/planetarium/9c-infra/issues/660.

- `rollback_snapshot` option resets chain to the original snapshot tip.
- `complete_snapshot_reset` option deletes the store completely and downloads the entire snapshot.
- This PR takes care of the case when the internal network chain tip is greater than the new snapshot tip. Originally, the script just skipped downloading the snapshot but now it will download the new snapshot regardless of the tip difference.