### PR TITLE
Bump empty-chronicle image

### DIFF
--- a/9c-main/chart/templates/empty-chronicle.yaml
+++ b/9c-main/chart/templates/empty-chronicle.yaml
@@ -37,7 +37,7 @@ spec:
             name: empty-chronicle-data
           env:
           - name: RESET_SNAPSHOT_OPTION
-            value: "false"
+            value: "true"
           - name: SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:

--- a/9c-main/chart/values.yaml
+++ b/9c-main/chart/values.yaml
@@ -176,7 +176,7 @@ emptyChronicle:
   image:
     repository: planetariumhq/emptychronicle
     pullPolicy: Always
-    tag: "git-2a76d3c2352243d8e1aa6315a91f729305e00f63"
+    tag: "git-7bef02eb0105de7c14741e45282c63c7b40c70fb"
   ports:
     port: 5050
 


### PR DESCRIPTION
This pull request bumps `empty-chronicle`'s image to its latest and reset snapshot because its storage is staled.