### PR TITLE
update validator service externalTrafficPolicy

### DIFF
--- a/charts/all-in-one/templates/service.yaml
+++ b/charts/all-in-one/templates/service.yaml
@@ -445,6 +445,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: Environment={{- if eq $.Values.clusterName "9c-main-v2" }}production{{- else }}development{{- end }},Team=game,Owner=jihyung,Service={{ $.Release.Name }},Name=validator-{{ $index }}
 spec:
+  externalTrafficPolicy: Local
   ports:
   - port: {{ $.Values.validator.ports.headless }}
     targetPort: {{ $.Values.validator.ports.headless }}


### PR DESCRIPTION
```
[07:19:56 INF] [GRAPHQL-REQUEST-CAPTURE] IP: ::ffff:10.0.39.123 Method: POST Endpoint: /graphql {"variables":{"offset":0},"query":"\n        query getBlock($offset: Int!) {\n          chainQuery {\n
  blockQuery {\n              blocks(offset: $offset, limit: 1, desc:true) {\n                index\n              }\n            }\n          }\n        }\n        "}
[07:19:57 INF] [GRAPHQL-REQUEST-CAPTURE] IP: ::ffff:10.0.32.226 Method: POST Endpoint: /graphql {"variables":{"offset":0},"query":"\n        query getBlock($offset: Int!) {\n          chainQuery {\n
  blockQuery {\n              blocks(offset: $offset, limit: 1, desc:true) {\n
```

Update validator services' externalTrafficPolicy from `Cluster` to `Local` so that remote IP is logged.