### PR TITLE
Correct namespace configuration to apply each chart

### DIFF
--- a/charts/all-in-one/templates/configmap-appsettings.yaml
+++ b/charts/all-in-one/templates/configmap-appsettings.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: appsettings
-  namespace: 9c-network
+  namespace: {{ $.Release.Name }}
   labels:
     app.kubernetes.io/instance: {{ $.Release.Name }}
 data:

--- a/charts/all-in-one/templates/configmap-data-provider.yaml
+++ b/charts/all-in-one/templates/configmap-data-provider.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: 9c-network-data-provider-script
-  namespace: 9c-network
+  namespace: {{ $.Release.Name }} 
   labels:
     app.kubernetes.io/instance: {{ $.Release.Name }}
 data:


### PR DESCRIPTION
On the current chart version, the chart doesn't work because 9c-headless cannot find appsettings.json from the `appsettings` ConfigMap resource. It was because the ConfigMap's namespace was fixed as `9c-network`. This pull request makes such resources use `Release.Name` as a namespace as other resources do.