### PR TITLE
Use internal domain host

### DIFF
--- a/9c-internal/9c-network/values.yaml
+++ b/9c-internal/9c-network/values.yaml
@@ -61,10 +61,10 @@ validator:
   - 033369e95dbfd970dd9a7b4df31dcf5004d7cfd63289d26cc42bbdd01e25675b6f,tcp-seed-1,31235
 
   hosts:
-  - "9c-internal-validator-5.nine-chronicles.com"
-  - "9c-internal-validator-6.nine-chronicles.com"
-  - "9c-internal-validator-7.nine-chronicles.com"
-  - "9c-internal-validator-8.nine-chronicles.com"
+  - "validator-5"
+  - "validator-6"
+  - "validator-7"
+  - "validator-8"
 
   storage:
     data: 500Gi
@@ -86,7 +86,7 @@ remoteHeadless:
     pullPolicy: Always
 
   hosts:
-  - "9c-internal-rpc-1.nine-chronicles.com"
+  - "remote-headless-1"
 
   ports:
     headless: 31234


### PR DESCRIPTION
Avoid node isolation when internal cluster deploy