### PR TITLE
Use `*.planetarium.dev` domain in `9c-claim-items-test` network

### DIFF
--- a/9c-internal/9c-claim-items-test/values.yaml
+++ b/9c-internal/9c-claim-items-test/values.yaml
@@ -8,10 +8,10 @@ logLevel: "debug"
 global:
   image:
     repository: planetariumhq/ninechronicles-headless
-    tag: "git-8a2f6852e3a98406fbb500a4a150729df1a51539"
+    tag: "git-cade52b7bf01ef2e09fb52c703204a0df3f08468"
 
   appProtocolVersion: "1/54684Ac4ee5B933e72144C4968BEa26056880d71/MEUCIQDFvvGTtUSSRj524xJf0EcxmmU6UaXVDAfp3fsb7P6fkwIgdSicMlCnEUZwsPr+W6VLg+2ReY4+FIRC2vB1Yssz7EU=/ZHU5OnRpbWVzdGFtcHUxMDoyMDIzLTA1LTE5ZQ=="
-  genesisBlockPath: "https://release.nine-chronicles.com/genesis-block-9c-main"
+  genesisBlockPath: "https://9c-dx.s3.ap-northeast-2.amazonaws.com/rudolf-genesis-block"
   trustedAppProtocolVersionSigner: "02529a61b9002ba8f21c858224234af971e962cac9bd7e6b365e71e125c6463478"
   peerStrings:
   - "033369e95dbfd970dd9a7b4df31dcf5004d7cfd63289d26cc42bbdd01e25675b6f,9c-internal-claim-items-tcp.planetarium.dev,31234"
@@ -21,12 +21,12 @@ global:
   networkType: Internal
   consensusType: pbft
 
-  resetSnapshot: true
+  resetSnapshot: false
   rollbackSnapshot: false
   useExternalSecret: true
 
 snapshot:
-  downloadSnapshot: true
+  downloadSnapshot: false
   slackChannel: "9c-internal-claim-items"
   image: "planetariumhq/ninechronicles-snapshot:git-708a18d12e951f1c4275c5137eb577123dd81715"
   partition:
@@ -52,7 +52,7 @@ seed:
     node.kubernetes.io/instance-type: m5d.xlarge
 
 validator:
-  count: 4
+  count: 1
   image:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
@@ -61,10 +61,7 @@ validator:
   - 033369e95dbfd970dd9a7b4df31dcf5004d7cfd63289d26cc42bbdd01e25675b6f,tcp-seed-1,31235
 
   hosts:
-  - "9c-internal-claim-items-validator-5.planetarium.dev"
-  - "9c-internal-claim-items-validator-6.planetarium.dev"
-  - "9c-internal-claim-items-validator-7.planetarium.dev"
-  - "9c-internal-claim-items-validator-8.planetarium.dev"
+  - "9c-internal-claim-items-validator.planetarium.dev"
 
   storage:
     data: 500Gi

--- a/9c-internal/9c-claim-items-test/values.yaml
+++ b/9c-internal/9c-claim-items-test/values.yaml
@@ -61,10 +61,10 @@ validator:
   - 033369e95dbfd970dd9a7b4df31dcf5004d7cfd63289d26cc42bbdd01e25675b6f,tcp-seed-1,31235
 
   hosts:
-  - "9c-internal-claim-items-validator-5.nine-chronicles.com"
-  - "9c-internal-claim-items-validator-6.nine-chronicles.com"
-  - "9c-internal-claim-items-validator-7.nine-chronicles.com"
-  - "9c-internal-claim-items-validator-8.nine-chronicles.com"
+  - "9c-internal-claim-items-validator-5.planetarium.dev"
+  - "9c-internal-claim-items-validator-6.planetarium.dev"
+  - "9c-internal-claim-items-validator-7.planetarium.dev"
+  - "9c-internal-claim-items-validator-8.planetarium.dev"
 
   storage:
     data: 500Gi
@@ -86,7 +86,7 @@ remoteHeadless:
     pullPolicy: Always
 
   hosts:
-  - "9c-internal-claim-items-rpc-1.nine-chronicles.com"
+  - "9c-internal-claim-items-rpc-1.planetarium.dev"
 
   ports:
     headless: 31234
@@ -178,7 +178,7 @@ marketService:
   - name: DOTNET_gcServer
     value: "1"
   - name: RpcConfig__Host
-    value: 9c-internal-claim-items-rpc-1.nine-chronicles.com
+    value: 9c-internal-claim-items-rpc-1.planetarium.dev
   - name: RpcConfig__Port
     value: "31238"
   - name: WorkerConfig__SyncShop

--- a/charts/all-in-one/templates/service.yaml
+++ b/charts/all-in-one/templates/service.yaml
@@ -199,6 +199,9 @@ spec:
   - name: headless
     port: {{ $.Values.explorer.ports.headless }}
     targetPort: {{ $.Values.explorer.ports.headless }}
+  - name: https
+    port: 443
+    targetPort: {{ $.Values.explorer.ports.graphql }}
   selector:
     app: explorer
   type: LoadBalancer


### PR DESCRIPTION
## What this pull request changes:

### 1. Use `*.planetarium.dev` instead of `*.nine-chronicles.com` domain

It is just because I don't have permission to update the zone.

### ~~2. Remove SSL configuration from `tcp-seed-*` services' configuration~~

~~There are SSL configurations in the `tcp-seed-*` services of the `charts/all-in-one` chart. But they don't have any ports for SSL (i.e., HTTPS). So the LB controller causes an error, `Failed build model due to Unused port in ssl-ports annotation [443]` because of such reason.~~

~~You can reference the source code too: https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/eacb0c370c0fbe6abcd15b00b7e7e35ca039c2ed/pkg/service/model_build_listener.go#L122-L145~~

Since https://github.com/planetarium/9c-infra/commit/606ded231e05f389194983943ee97b2176abae6a, the seed became to have SSL port. So the commit was dropped.

### 3. Add `https` port to explorer services' configration

The explorers were failing because of the same reason above. But they have accessible HTTP port so I added an HTTPS port like other remote-headlesses do.

### 4. Make `9c-claim-items-test` network to independent network from mainnet, internal network.

SSIA.