### PR TITLE
update `9c-perf-test` & `9c-perf-test-origin` nodegroup

### DIFF
--- a/9c-internal/9c-perf-test-origin/values.yaml
+++ b/9c-internal/9c-perf-test-origin/values.yaml
@@ -78,7 +78,7 @@ remoteHeadless:
     name: "9c-perf-test-origin-rpc"
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m7g_2xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m7g_2xl_2c_on_demand
 
 validator:
   count: 4
@@ -118,4 +118,4 @@ validator:
       memory: 20Gi
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m7g_2xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m7g_2xl_2c_on_demand

--- a/9c-internal/9c-perf-test/values.yaml
+++ b/9c-internal/9c-perf-test/values.yaml
@@ -86,7 +86,7 @@ remoteHeadless:
       memory: 12Gi
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m7g_2xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m7g_2xl_2c_on_demand
 
 validator:
   count: 4
@@ -126,4 +126,4 @@ validator:
       memory: 12Gi
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m7g_2xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m7g_2xl_2c_on_demand


### PR DESCRIPTION
Temporarily use `on_demand` instance type for stability.