### PR TITLE
Introduce 9c-rudolf service in all-in-one chart

### DIFF
--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -5,9 +5,9 @@ metadata:
   annotations:
     eks.amazonaws.com/role-arn: {{ .Values.rudolfService.serviceAccount.roleArn }}
   labels:
-    app.kubernetes.io/instance: {{ $.Chart.Name }}
-  name: {{ $.Chart.Name }}-9c-rudolf-iam-role
-  namespace: {{ $.Chart.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+  name: {{ $.Release.Name }}-9c-rudolf-iam-role
+  namespace: {{ $.Release.Name }}
 
 ---
 
@@ -17,9 +17,9 @@ kind: Deployment
 metadata:
   labels:
     app: 9c-rudolf
-    app.kubernetes.io/instance: {{ $.Chart.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
   name: 9c-rudolf
-  namespace: {{ $.Chart.Name }}
+  namespace: {{ $.Release.Name }}
 spec:
   podManagementPolicy: OrderedReady
   replicas: 1
@@ -60,8 +60,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: Always
-      serviceAccount: {{ $.Chart.Name }}-9c-rudolf-iam-role
-      serviceAccountName: {{ $.Chart.Name }}-9c-rudolf-iam-role
+      serviceAccount: {{ $.Release.Name }}-9c-rudolf-iam-role
+      serviceAccountName: {{ $.Release.Name }}-9c-rudolf-iam-role
   updateStrategy:
     type: RollingUpdate
 
@@ -70,7 +70,7 @@ spec:
 apiVersion: vpcresources.k8s.aws/v1beta1
 kind: SecurityGroupPolicy
 metadata:
-  name: {{ $.Chart.Name }}-rudolf-service-sg-policy
+  name: {{ $.Release.Name }}-rudolf-service-sg-policy
 spec:
   podSelector:
     matchLabels:

--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -64,4 +64,18 @@ spec:
       serviceAccountName: {{ $.Chart.Name }}-9c-rudolf-iam-role
   updateStrategy:
     type: RollingUpdate
+
+---
+
+apiVersion: vpcresources.k8s.aws/v1beta1
+kind: SecurityGroupPolicy
+metadata:
+  name: {{ $.Chart.Name }}-rudolf-service-sg-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: 9c-rudolf
+  securityGroups:
+    groupIds:
+    - {{ $.Values.rudolfService.securityGroupId }}
 {{ end }}

--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -39,7 +39,7 @@ spec:
               valueFrom: 
                 secretKeyRef:
                   key: database-url
-                  name: 9c-rudolf-env
+                  name: rudolf-service
             - name: NCG_MINTER
               value: {{ .Values.rudolfService.config.ncgMinter }}
             - name: GQL_ENDPOINT

--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -1,0 +1,67 @@
+{{ if .Values.rudolfService.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.rudolfService.serviceAccount.roleArn }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
+  name: {{ $.Chart.Name }}-9c-rudolf-iam-role
+  namespace: {{ $.Chart.Name }}
+
+---
+
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: 9c-rudolf
+    app.kubernetes.io/instance: {{ $.Chart.Name }}
+  name: 9c-rudolf
+  namespace: {{ $.Chart.Name }}
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app: 9c-rudolf
+  serviceName: 9c-rudolf
+  template:
+    metadata:
+      labels:
+        app: 9c-rudolf
+    spec:
+      containers:
+        - name: 9c-rudolf
+          env:
+            - name: DATABASE_URL
+              valueFrom: 
+                secretKeyRef:
+                  key: database-url
+                  name: 9c-rudolf-env
+            - name: NCG_MINTER
+              value: {{ .Values.rudolfService.config.ncgMinter }}
+            - name: GQL_ENDPOINT
+              value: {{ .Values.rudolfService.config.graphqlEndpoint }}
+            - name: NC_GRAPHQL_ENDPOINT
+              value: {{ .Values.rudolfService.config.graphqlEndpoint }}
+            - name: AWS_KMS_KEY_ID
+              value: {{ .Values.rudolfService.kms.keyId }}
+            - name: AWS_KMS_PUBLIC_KEY
+              value: {{ .Values.rudolfService.kms.publicKey }}
+          image: {{ $.Values.rudolfService.image.repository }}:{{ $.Values.rudolfService.image.tag }}
+          ports:
+            - containerPort: 3000
+          resources:
+            {{- toYaml $.Values.rudolfService.resources | nindent 12 }}
+      {{- with $.Values.rudolfService.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always
+      serviceAccount: {{ $.Chart.Name }}-9c-rudolf-iam-role
+      serviceAccountName: {{ $.Chart.Name }}-9c-rudolf-iam-role
+  updateStrategy:
+    type: RollingUpdate
+{{ end }}

--- a/charts/all-in-one/templates/secret-rudolf-service.yaml
+++ b/charts/all-in-one/templates/secret-rudolf-service.yaml
@@ -1,0 +1,24 @@
+{{ if .Values.rudolfService.enabled }}
+apiVersion: "external-secrets.io/v1beta1"
+kind: ExternalSecret
+metadata:
+  name: rudolf-service
+  namespace: {{ $.Release.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: {{ $.Release.Name }}-secretsmanager
+    kind: SecretStore
+  target:
+    name: rudolf-service
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      {{- if .Values.externalSecret.prefix }}
+      key: {{ .Values.externalSecret.prefix }}/rudolf-service
+      {{- else }}
+      key: {{ .Values.clusterName }}/rudolf-service
+      {{- end }}
+{{ end }}

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -548,3 +548,25 @@ acc:
   resources: {}
 
   env: []
+
+rudolfService:
+  enabled: false
+  image:
+    repository: planetariumhq/9c-rudolf
+    pullPolicy: Always
+    tag: "TAG"
+
+  nodeSelector: {}
+
+  resources: {}
+
+  config:
+    ncgMinter: "NCG_MINTER"
+    graphqlEndpoint: "ENDPOINT"
+  
+  kms:
+    keyId: "KEY_ID"
+    publicKey: "PUBLIC_KEY"
+
+  serviceAccount:
+    roleArn: "ROLE_ARN"

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -570,3 +570,5 @@ rudolfService:
 
   serviceAccount:
     roleArn: "ROLE_ARN"
+
+  securityGroupId: 1234


### PR DESCRIPTION
This pull request introduces a new optional service in `all-in-one` chart. You can see the service's source code at https://github.com/planetarium/9c-rudolf.