### PR TITLE
Update fullstate & validator images

### DIFF
--- a/9c-main/9c-network/values.yaml
+++ b/9c-main/9c-network/values.yaml
@@ -78,7 +78,7 @@ validator:
   count: 4
   image:
     repository: planetariumhq/ninechronicles-headless
-    tag: "git-68f1b33cb1445b2e2f24ce1dfa859c02d8733760"
+    tag: "git-6a931307d2f146232baf7271ae93353bd3ea84df"
 
   env:
   - name: IpRateLimiting__EnableEndpointRateLimiting
@@ -248,7 +248,7 @@ marketService:
 fullState:
   image:
     repository: planetariumhq/ninechronicles-headless
-    tag: "git-68f1b33cb1445b2e2f24ce1dfa859c02d8733760"
+    tag: "git-6a931307d2f146232baf7271ae93353bd3ea84df"
   enabled: true
 
   loggingEnabled: true

--- a/9c-main/9c-network/values.yaml
+++ b/9c-main/9c-network/values.yaml
@@ -101,7 +101,7 @@ validator:
   loggingEnabled: true
 
   extraArgs:
-  - --tx-quota-per-signer=10
+  - --tx-quota-per-signer=4
   - --consensus-target-block-interval=8500
 
   consensusSeedStrings:


### PR DESCRIPTION
SSIA

P.S. The validators' `--tx-quota-per-signer` is reduced back to `4` because increasing it to `10` seems to cause issues regarding the recent bot attacks with failed `RegisterProducts` txs.