### PR TITLE
Specify namespace of rudolf-service's sg policy

### DIFF
--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -67,6 +67,7 @@ apiVersion: vpcresources.k8s.aws/v1beta1
 kind: SecurityGroupPolicy
 metadata:
   name: {{ $.Release.Name }}-rudolf-service-sg-policy
+  namespace: {{ $.Release.Name }}
 spec:
   podSelector:
     matchLabels:


### PR DESCRIPTION
Currently the `9c-rudolf` doesn't work and I guess it is because the SecurityGroupPolicy doesn't have correct namespace configuration