### PR TITLE
add repository section (9c-main market-service & world-boss-service)

### DIFF
--- a/9c-main/9c-network/values.yaml
+++ b/9c-main/9c-network/values.yaml
@@ -214,6 +214,7 @@ marketService:
   enabled: true
   rwMode: true
   image:
+    repository: planetariumhq/market-service
     tag: "git-68e6bc82786506b6c89e71f78bafc8d9bed3f23c"
 
   env:
@@ -295,7 +296,8 @@ worldBoss:
   enabled: true
 
   image:
-    tag: "git-8e0ad33367fc8ef871981c95309325d3f7b3b6f2"
+    repository: planetariumhq/market-service
+    tag: "git-422222fe12d5e5860f23ab13581900c52e90b10a"
 
   nodeSelector:
     node.kubernetes.io/instance-type: m5.large


### PR DESCRIPTION
The `Update-Values` action doesn't work for `market-service`. A `repository` section is added to fix the CI.

P.S. World-Boss image is update to the latest.

- Option that currently doesn't work 
![image](https://github.com/planetarium/9c-infra/assets/42176649/32fbecf8-c253-41aa-b36c-c00c2ad79a76)
