### PR TITLE
lower tx quota per signer

### DIFF
--- a/9c-main/9c-network/values.yaml
+++ b/9c-main/9c-network/values.yaml
@@ -101,7 +101,7 @@ validator:
   loggingEnabled: true
 
   extraArgs:
-  - --tx-quota-per-signer=4
+  - --tx-quota-per-signer=1
   - --consensus-target-block-interval=8500
 
   consensusSeedStrings:


### PR DESCRIPTION
Multiple txs per signer seems to cause render issues in `PatrolReward` and `ClaimStakeReward`.