### PR TITLE
Add rudolf-service Service resource

### DIFF
--- a/9c-internal/9c-claim-items-test/values.yaml
+++ b/9c-internal/9c-claim-items-test/values.yaml
@@ -219,8 +219,12 @@ rudolfService:
   serviceAccount:
     roleArn: "arn:aws:iam::319679068466:role/InternalRudolfSignerRole"
 
+  service:
+    enabled: true
+    securityGroupIds:
+    - "sg-0c865006315f5b9f0"
+
   securityGroupIds:
     podToService: "sg-0f726b78db71de0b0"
-    serviceToPod: "sg-0c865006315f5b9f0"
     extra:
     - "sg-0eba3380bbea0a2c7"  # AllowAllDNSAccess

--- a/9c-internal/9c-claim-items-test/values.yaml
+++ b/9c-internal/9c-claim-items-test/values.yaml
@@ -205,6 +205,10 @@ rudolfService:
   image:
     tag: "git-64ad20a7abb298b1b4e1fdeca00be20780c14e91"
 
+  db:
+    local: false
+    securityGroupId: "sg-0fd42d699fe71759f"
+
   config:
     ncgMinter: "0x4fa78af2c9fb3391ef05f1f1f8fe9565137a00f9"
     graphqlEndpoint: "http://k8s-9cclaimi-remotehe-a491fa26e4-b6e7e66fcd3d3e9a.elb.us-east-2.amazonaws.com/graphql"
@@ -216,7 +220,6 @@ rudolfService:
     roleArn: "arn:aws:iam::319679068466:role/InternalRudolfSignerRole"
 
   securityGroupIds:
-    podToDb: "sg-0fd42d699fe71759f"
     podToService: "sg-0f726b78db71de0b0"
     serviceToPod: "sg-0c865006315f5b9f0"
     extra:

--- a/9c-internal/9c-claim-items-test/values.yaml
+++ b/9c-internal/9c-claim-items-test/values.yaml
@@ -216,6 +216,8 @@ rudolfService:
     roleArn: "arn:aws:iam::319679068466:role/InternalRudolfSignerRole"
 
   securityGroupIds:
-    podToDb: "sg-0da48b995c583c6e8"
+    podToDb: "sg-0fd42d699fe71759f"
+    podToService: "sg-0f726b78db71de0b0"
+    serviceToPod: "sg-0c865006315f5b9f0"
     extra:
     - "sg-0eba3380bbea0a2c7"  # AllowAllDNSAccess

--- a/9c-internal/9c-claim-items-test/values.yaml
+++ b/9c-internal/9c-claim-items-test/values.yaml
@@ -217,3 +217,5 @@ rudolfService:
 
   securityGroupIds:
     podToDb: "sg-0da48b995c583c6e8"
+    extra:
+    - "sg-0eba3380bbea0a2c7"  # AllowAllDNSAccess

--- a/9c-internal/9c-claim-items-test/values.yaml
+++ b/9c-internal/9c-claim-items-test/values.yaml
@@ -215,4 +215,5 @@ rudolfService:
   serviceAccount:
     roleArn: "arn:aws:iam::319679068466:role/InternalRudolfSignerRole"
 
-  securityGroupId: "sg-0da48b995c583c6e8"
+  securityGroupIds:
+    podToDb: "sg-0da48b995c583c6e8"

--- a/9c-internal/heimdall/values.yaml
+++ b/9c-internal/heimdall/values.yaml
@@ -289,3 +289,5 @@ rudolfService:
 
   securityGroupIds:
     podToDb: "sg-0da48b995c583c6e8"
+    extra:
+    - "sg-0eba3380bbea0a2c7"  # AllowAllDNSAccess

--- a/9c-internal/heimdall/values.yaml
+++ b/9c-internal/heimdall/values.yaml
@@ -287,7 +287,9 @@ rudolfService:
   serviceAccount:
     roleArn: "arn:aws:iam::319679068466:role/InternalRudolfSignerRole"
 
-  securityGroupIds:
-    podToDb: "sg-0da48b995c583c6e8"
+  securityGroupIds:  # FIXME: Use different security ids with other networks.
+    podToDb: "sg-0fd42d699fe71759f"
+    podToService: "sg-0f726b78db71de0b0"
+    serviceToPod: "sg-0c865006315f5b9f0"
     extra:
     - "sg-0eba3380bbea0a2c7"  # AllowAllDNSAccess

--- a/9c-internal/heimdall/values.yaml
+++ b/9c-internal/heimdall/values.yaml
@@ -287,9 +287,13 @@ rudolfService:
 
   serviceAccount:
     roleArn: "arn:aws:iam::319679068466:role/InternalRudolfSignerRole"
+  
+  service:
+    enabled: true
+    securityGroupIds:
+    - "sg-0c865006315f5b9f0"
 
   securityGroupIds:  # FIXME: Use different security ids with other networks.
     podToService: "sg-0f726b78db71de0b0"
-    serviceToPod: "sg-0c865006315f5b9f0"
     extra:
     - "sg-0eba3380bbea0a2c7"  # AllowAllDNSAccess

--- a/9c-internal/heimdall/values.yaml
+++ b/9c-internal/heimdall/values.yaml
@@ -288,7 +288,6 @@ rudolfService:
     roleArn: "arn:aws:iam::319679068466:role/InternalRudolfSignerRole"
 
   securityGroupIds:  # FIXME: Use different security ids with other networks.
-    podToDb: "sg-0fd42d699fe71759f"
     podToService: "sg-0f726b78db71de0b0"
     serviceToPod: "sg-0c865006315f5b9f0"
     extra:

--- a/9c-internal/heimdall/values.yaml
+++ b/9c-internal/heimdall/values.yaml
@@ -287,4 +287,5 @@ rudolfService:
   serviceAccount:
     roleArn: "arn:aws:iam::319679068466:role/InternalRudolfSignerRole"
 
-  securityGroupId: "sg-0da48b995c583c6e8"
+  securityGroupIds:
+    podToDb: "sg-0da48b995c583c6e8"

--- a/9c-internal/heimdall/values.yaml
+++ b/9c-internal/heimdall/values.yaml
@@ -276,10 +276,11 @@ rudolfService:
 
   config:
     ncgMinter: "0x4fa78AF2C9FB3391ef05F1F1F8FE9565137a00f9"
+    graphqlEndpoint: "http://heimdall-internal-rpc-1.nine-chronicles.com/graphql"
+
   db:
     local: true
 
-    graphqlEndpoint: "http://heimdall-internal-rpc-1.nine-chronicles.com/graphql"
   kms:
     keyId: "54436222-3b06-4ddb-b661-f2cd54456893"
     publicKey: "04ff006e2434dc04000971395e5e47012e4ec7570dfbbb87a02e4b12d33ec0c6ec329fdba089f7b5bfce7b8cbcdf3f9e662fade6a63066a9b1e17429687fbdb9de"

--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -63,6 +63,7 @@ spec:
 
 ---
 
+{{ if .Values.rudolfService.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -73,7 +74,7 @@ metadata:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
-    service.beta.kubernetes.io/aws-load-balancer-security-groups: {{ .Values.rudolfService.securityGroupIds.serviceToPod }}
+    service.beta.kubernetes.io/aws-load-balancer-security-groups: {{ join "," .Values.rudolfService.service.securityGroupIds }}
     service.beta.kubernetes.io/aws-load-balancer-type: external
 spec:
   externalTrafficPolicy: Local
@@ -84,6 +85,7 @@ spec:
     name: http
   selector:
     app: 9c-rudolf
+{{ end }}
 
 ---
 

--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -99,7 +99,7 @@ spec:
   securityGroups:
     groupIds:
 {{ if not .Values.rudolfService.db.local }}
-    - {{ $.Values.rudolfService.securityGroupIds.podToDb }}
+    - {{ $.Values.rudolfService.db.securityGroupId }}
 {{ end }}
     - {{ $.Values.rudolfService.securityGroupIds.podToService }}
     {{- toYaml $.Values.rudolfService.securityGroupIds.extra | nindent 4 }}

--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -87,7 +87,6 @@ spec:
 
 ---
 
-{{ if not .Values.rudolfService.db.local }}
 apiVersion: vpcresources.k8s.aws/v1beta1
 kind: SecurityGroupPolicy
 metadata:
@@ -99,7 +98,8 @@ spec:
       app: 9c-rudolf
   securityGroups:
     groupIds:
+{{ if not .Values.rudolfService.db.local }}
     - {{ $.Values.rudolfService.securityGroupIds.podToDb }}
-    - {{ $.Values.rudolfService.securityGroupIds.podToService }}
 {{ end }}
+    - {{ $.Values.rudolfService.securityGroupIds.podToService }}
 {{ end }}

--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -99,7 +99,7 @@ spec:
       app: 9c-rudolf
   securityGroups:
     groupIds:
-    - {{ $.Values.rudolfService.securityGroupId }}
+    - {{ $.Values.rudolfService.securityGroupIds.podToDb }}
     - {{ $.Values.rudolfService.securityGroupIds.podToService }}
 {{ end }}
 {{ end }}

--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -63,6 +63,30 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  name: rudolf-service
+  namespace: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    service.beta.kubernetes.io/aws-load-balancer-security-groups: {{ .Values.rudolfService.securityGroupIds.serviceToPod }}
+    service.beta.kubernetes.io/aws-load-balancer-type: external
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  ports:
+  - port: 3000
+    targetPort: 3000
+    name: http
+  selector:
+    app: 9c-rudolf
+
+---
+
 {{ if not .Values.rudolfService.db.local }}
 apiVersion: vpcresources.k8s.aws/v1beta1
 kind: SecurityGroupPolicy
@@ -76,5 +100,6 @@ spec:
   securityGroups:
     groupIds:
     - {{ $.Values.rudolfService.securityGroupId }}
+    - {{ $.Values.rudolfService.securityGroupIds.podToService }}
 {{ end }}
 {{ end }}

--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -102,4 +102,5 @@ spec:
     - {{ $.Values.rudolfService.securityGroupIds.podToDb }}
 {{ end }}
     - {{ $.Values.rudolfService.securityGroupIds.podToService }}
+    {{- toYaml $.Values.rudolfService.securityGroupIds.extra | nindent 4 }}
 {{ end }}

--- a/charts/all-in-one/values.schema.json
+++ b/charts/all-in-one/values.schema.json
@@ -68,6 +68,40 @@
               "required": ["securityGroupId"]
             }
           },
+          "service": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "const": false,
+                    "description": "Whether to create external endpoint."
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["enabled"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "const": true,
+                    "description": "Whether to create external endpoint."
+                  },
+                  "securityGroupIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "description": "Security Group Ids array to assign to the ELB resource."
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["enabled"]
+              }
+            ]
+          },
           "securityGroupIds": {
             "type": "object",
             "properties": {
@@ -77,14 +111,11 @@
                   "type": "string"
                 }
               },
-              "serviceToPod": {
-                "type": "string"
-              },
               "podToService": {
                 "type": "string"
               }
             },
-            "required": ["podToService", "serviceToPod"],
+            "required": ["podToService"],
             "additionalProperties": false
           },
           "serviceAccount": {

--- a/charts/all-in-one/values.schema.json
+++ b/charts/all-in-one/values.schema.json
@@ -1,0 +1,116 @@
+{
+  "type": "object",
+  "properties": {
+    "rudolfService": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "if": {
+        "properties": {
+          "enabled": {
+            "const": true
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "config": {
+            "type": "object",
+            "properties": {
+              "ncgMinter": {
+                "type": "string",
+                "description": "An address of NCG minter of the network connected by 'graphqlEndpoint'."
+              },
+              "graphqlEndpoint": {
+                "type": "string",
+                "description": "A GraphQL endpoint to query chain data and stage transactions"
+              }
+            },
+            "required": ["ncgMinter", "graphqlEndpoint"]
+          },
+          "db": {
+            "type": "object",
+            "properties": {
+              "local": {
+                "type": "boolean",
+                "default": false
+              }
+            },
+            "if": {
+              "properties": {
+                "local": {
+                  "const": true
+                }
+              }
+            },
+            "then": {
+              "description": "Enable database with cluster-local database.",
+              "properties": {
+                "size": {
+                  "type": "string",
+                  "description": "Database's size. (e.g., 1000Gi)"
+                }
+              },
+              "required": ["size"]
+            },
+            "else": {
+              "description": "Enabled database with RDS connection.",
+              "properties": {
+                "securityGroupId": {
+                  "type": "string",
+                  "description": "SecurityGroup's id for RDS connection."
+                }
+              },
+              "required": ["securityGroupId"]
+            }
+          },
+          "securityGroupIds": {
+            "type": "object",
+            "properties": {
+              "extra": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "serviceToPod": {
+                "type": "string"
+              },
+              "podToService": {
+                "type": "string"
+              }
+            },
+            "required": ["podToService", "serviceToPod"],
+            "additionalProperties": false
+          },
+          "serviceAccount": {
+            "type": "object",
+            "properties": {
+              "roleArn": {
+                "type": "string"
+              }
+            },
+            "required": ["roleArn"]
+          },
+          "kms": {
+            "type": "object",
+            "properties": {
+              "keyId": {
+                "type": "string"
+              },
+              "publicKey": {
+                "type": "string"
+              }
+            },
+            "required": ["keyId", "publicKey"]
+          }
+        },
+        "required": ["config", "securityGroupIds", "serviceAccount"]
+      }
+    }
+  }
+}

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -578,6 +578,5 @@ rudolfService:
   securityGroupIds:
     serviceToPod: "sg-"
     podToService: "sg-"
-    podToDb: "sg-"
     extra:
     - "sg-"

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -560,23 +560,6 @@ rudolfService:
 
   resources: {}
 
-  config:
-    ncgMinter: "NCG_MINTER"
-    graphqlEndpoint: "ENDPOINT"
-
   db:
     local: false
     size: 20Gi
-  
-  kms:
-    keyId: "KEY_ID"
-    publicKey: "PUBLIC_KEY"
-
-  serviceAccount:
-    roleArn: "ROLE_ARN"
-
-  securityGroupIds:
-    serviceToPod: "sg-"
-    podToService: "sg-"
-    extra:
-    - "sg-"

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -556,6 +556,9 @@ rudolfService:
     pullPolicy: Always
     tag: "TAG"
 
+  service:
+    enabled: false
+
   nodeSelector: {}
 
   resources: {}

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -576,3 +576,6 @@ rudolfService:
     roleArn: "ROLE_ARN"
 
   securityGroupId: 1234
+  securityGroupIds:
+    serviceToPod: "sg-"
+    podToService: "sg-"

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -575,7 +575,7 @@ rudolfService:
   serviceAccount:
     roleArn: "ROLE_ARN"
 
-  securityGroupId: 1234
   securityGroupIds:
     serviceToPod: "sg-"
     podToService: "sg-"
+    podToDb: "sg-"

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -579,3 +579,5 @@ rudolfService:
     serviceToPod: "sg-"
     podToService: "sg-"
     podToDb: "sg-"
+    extra:
+    - "sg-"


### PR DESCRIPTION
## Tasks

- [x] Add `rudolf-service`-named `Service` resource
- [x] Rename security group id variable name for db.
- [x] Support extra security group ids.
- [x] Fill values for heimdall release.
- [x] Provide `values.schema.json`

## About `values.schema.json`

The `values.schema.json` file in the Chart's directory, is used by these below commands to validate `values.yaml`.

> From https://helm.sh/docs/topics/charts/#schema-files
> 
> helm install
> helm upgrade
> helm lint
> helm template

For instance, if the user uses `rudolfService.securityGroupIds.extra` as `"string"`, not array, it will show you error like below:

```bash
$ helm template . --values ../../9c-internal/9c-claim-items-test/values.yaml
Error: values don't meet the specifications of the schema(s) in the following chart(s):
9c-network:
- rudolfService.securityGroupIds.extra: Invalid type. Expected: array, given: string
```

With this feature, we can guide how users should use this package.