### PR TITLE
Add peerStrings to appsettings

### DIFF
--- a/charts/all-in-one/scripts/common/appsettings.json
+++ b/charts/all-in-one/scripts/common/appsettings.json
@@ -127,7 +127,17 @@
         "StorePath": "",
         "Port": 31234,
         "IceServerStrings": [],
-        "PeerStrings": [],
+        "PeerStrings": [
+        {{- $result := "" -}}
+        {{- range $index, $item := $.Values.global.peerStrings -}}
+          {{- if ne $index 0 -}}
+            {{- $result = printf "%s, \"%s\"" $result $item -}}
+          {{- else -}}
+            {{- $result = printf "\"%s\"" $item -}}
+          {{- end -}}
+        {{- end -}}
+        {{- $result -}}
+        ],
         "TrustedAppProtocolVersionSignerStrings": [
             "{{ $.Values.global.trustedAppProtocolVersionSigner }}"
         ],


### PR DESCRIPTION
because [volume-rotator](https://github.com/planetarium/NineChronicles.VolumeRotator) fetches options from appsettings, it needs peerstrings filled in appsettings.