### PR TITLE
Correct heimdall network NCG minter's address

### DIFF
--- a/9c-internal/9c-claim-items-test/values.yaml
+++ b/9c-internal/9c-claim-items-test/values.yaml
@@ -210,7 +210,7 @@ rudolfService:
     securityGroupId: "sg-0fd42d699fe71759f"
 
   config:
-    ncgMinter: "0x4fa78af2c9fb3391ef05f1f1f8fe9565137a00f9"
+    ncgMinter: "0x4fa78AF2C9FB3391ef05F1F1F8FE9565137a00f9"
     graphqlEndpoint: "http://k8s-9cclaimi-remotehe-a491fa26e4-b6e7e66fcd3d3e9a.elb.us-east-2.amazonaws.com/graphql"
   kms:
     keyId: "54436222-3b06-4ddb-b661-f2cd54456893"

--- a/9c-internal/9c-network/values.yaml
+++ b/9c-internal/9c-network/values.yaml
@@ -201,3 +201,33 @@ patrolRewardService:
 
   db:
     local: true
+
+rudolfService:
+  enabled: true
+
+  image:
+    tag: "git-64ad20a7abb298b1b4e1fdeca00be20780c14e91"
+
+  config:
+    ncgMinter: "0x47D082a115c63E7b58B1532d20E631538eaFADde"
+    graphqlEndpoint: "https://9c-internal-rpc-1.nine-chronicles.com/graphql"
+
+  db:
+    local: true
+
+  kms:
+    keyId: "54436222-3b06-4ddb-b661-f2cd54456893"
+    publicKey: "04ff006e2434dc04000971395e5e47012e4ec7570dfbbb87a02e4b12d33ec0c6ec329fdba089f7b5bfce7b8cbcdf3f9e662fade6a63066a9b1e17429687fbdb9de"
+
+  serviceAccount:
+    roleArn: "arn:aws:iam::319679068466:role/InternalRudolfSignerRole"
+  
+  service:
+    enabled: true
+    securityGroupIds:
+    - "sg-0c865006315f5b9f0"
+
+  securityGroupIds:  # FIXME: Use different security ids with other networks.
+    podToService: "sg-0f726b78db71de0b0"
+    extra:
+    - "sg-0eba3380bbea0a2c7"  # AllowAllDNSAccess

--- a/9c-internal/heimdall/values.yaml
+++ b/9c-internal/heimdall/values.yaml
@@ -275,7 +275,7 @@ rudolfService:
     tag: "git-64ad20a7abb298b1b4e1fdeca00be20780c14e91"
 
   config:
-    ncgMinter: "0x4fa78AF2C9FB3391ef05F1F1F8FE9565137a00f9"
+    ncgMinter: "0x9b9566dB35D5eFF2f0B0758C5aC4c354Debaf118"
     graphqlEndpoint: "http://heimdall-internal-rpc-1.nine-chronicles.com/graphql"
 
   db:


### PR DESCRIPTION
- Correct 9c-rudolf `config.ncgMinter` in Heimdall network.
- Correct 9c-rudolf `config.ncgMinter` checksum in 9c-claim-items-test network.
- Enable 9c-rudolf in 9c-internal(odin, a.k.a., mainnet) network.