### PR TITLE
Remove security group policy from 9c-rudolf pod

### DIFF
--- a/9c-internal/9c-claim-items-test/values.yaml
+++ b/9c-internal/9c-claim-items-test/values.yaml
@@ -223,8 +223,3 @@ rudolfService:
     enabled: true
     securityGroupIds:
     - "sg-0c865006315f5b9f0"
-
-  securityGroupIds:
-    podToService: "sg-0f726b78db71de0b0"
-    extra:
-    - "sg-0eba3380bbea0a2c7"  # AllowAllDNSAccess

--- a/9c-internal/9c-network/values.yaml
+++ b/9c-internal/9c-network/values.yaml
@@ -226,8 +226,3 @@ rudolfService:
     enabled: true
     securityGroupIds:
     - "sg-0c865006315f5b9f0"
-
-  securityGroupIds:  # FIXME: Use different security ids with other networks.
-    podToService: "sg-0f726b78db71de0b0"
-    extra:
-    - "sg-0eba3380bbea0a2c7"  # AllowAllDNSAccess

--- a/9c-internal/argocd/bootstrap.yaml
+++ b/9c-internal/argocd/bootstrap.yaml
@@ -61,6 +61,17 @@ spec:
                       group: rpc
                 tls_config:
                   insecure_skip_verify: true
+              - job_name: scrape-9c-rudolf
+                metrics_path: /metrics
+                scrape_interval: 5s
+                scrape_timeout: 4s
+                static_configs:
+                  - targets:
+                    - rudolf-service.9c-claim-items-test.svc.cluster.local:3000
+                    labels:
+                      group: 9c-rudolf
+                tls_config:
+                  insecure_skip_verify: true
         loki:
           enabled: true
           bucketName: loki-dev.planetariumhq.com

--- a/9c-internal/multiplanetary/global/rudolfService.yaml
+++ b/9c-internal/multiplanetary/global/rudolfService.yaml
@@ -22,8 +22,3 @@ rudolfService:
     enabled: true
     securityGroupIds:
     - "sg-0c865006315f5b9f0"
-
-  securityGroupIds:  # FIXME: Use different security ids with other networks.
-    podToService: "sg-0f726b78db71de0b0"
-    extra:
-    - "sg-0eba3380bbea0a2c7"  # AllowAllDNSAccess

--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -87,22 +87,4 @@ spec:
     app: 9c-rudolf
 {{ end }}
 
----
-
-apiVersion: vpcresources.k8s.aws/v1beta1
-kind: SecurityGroupPolicy
-metadata:
-  name: {{ $.Release.Name }}-rudolf-service-sg-policy
-  namespace: {{ $.Release.Name }}
-spec:
-  podSelector:
-    matchLabels:
-      app: 9c-rudolf
-  securityGroups:
-    groupIds:
-{{ if not .Values.rudolfService.db.local }}
-    - {{ $.Values.rudolfService.db.securityGroupId }}
-{{ end }}
-    - {{ $.Values.rudolfService.securityGroupIds.podToService }}
-    {{- toYaml $.Values.rudolfService.securityGroupIds.extra | nindent 4 }}
 {{ end }}

--- a/charts/all-in-one/values.schema.json
+++ b/charts/all-in-one/values.schema.json
@@ -102,22 +102,6 @@
               }
             ]
           },
-          "securityGroupIds": {
-            "type": "object",
-            "properties": {
-              "extra": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "podToService": {
-                "type": "string"
-              }
-            },
-            "required": ["podToService"],
-            "additionalProperties": false
-          },
           "serviceAccount": {
             "type": "object",
             "properties": {
@@ -140,7 +124,7 @@
             "required": ["keyId", "publicKey"]
           }
         },
-        "required": ["config", "securityGroupIds", "serviceAccount"]
+        "required": ["config", "serviceAccount"]
       }
     }
   }


### PR DESCRIPTION
Originally, I had a lot of security groups because I was worried about other services in the same cluster getting hacked and accessing rudolf-service through that route. But after talking to my teammates, I realized that it was more important to make sure that didn't happen to each application, and I added authentication to rudolf-service, so I removed the security groups altogether, and as a bonus, I added a rule to get the metrics of rudolf-service from the Prometheus side.