### PR TITLE
Fix env name

### DIFF
--- a/charts/volume-rotator/templates/deployment.yaml
+++ b/charts/volume-rotator/templates/deployment.yaml
@@ -22,9 +22,9 @@ spec:
         ports:
         - containerPort: 80
         env:
-        - name: Headless:SnapshotPath
+        - name: Headless_SnapshotPath
           value: {{ $.Values.headless.snapshotPath }}
-        - name: Headless:NodeSelector
+        - name: Headless_NodeSelector
           value: {{ $.Values.headless.nodeSelectorValue }}
       {{- with $.Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
we cannot use `:` for k8s env