### PR TITLE
update internal patrol reward service

### DIFF
--- a/9c-internal/9c-network/values.yaml
+++ b/9c-internal/9c-network/values.yaml
@@ -196,7 +196,7 @@ patrolRewardService:
   image:
     repository: planetariumhq/patrol-reward-service
     pullPolicy: Always
-    tag: "git-f26d63e433985058bb037974ceece136e0e5688e"
+    tag: "git-dd318d41186bc099855fd440c302a07d66f1ba37"
 
   nodeSelector:
     node.kubernetes.io/instance-type: m5d.xlarge

--- a/9c-internal/multiplanetary/global/patrolRewardService.yaml
+++ b/9c-internal/multiplanetary/global/patrolRewardService.yaml
@@ -3,7 +3,7 @@ patrolRewardService:
   image:
     repository: planetariumhq/patrol-reward-service
     pullPolicy: Always
-    tag: "git-f26d63e433985058bb037974ceece136e0e5688e"
+    tag: "git-dd318d41186bc099855fd440c302a07d66f1ba37"
 
   nodeSelector:
     node.kubernetes.io/instance-type: m5d.xlarge


### PR DESCRIPTION
Fix error:

```
fail: Microsoft.Extensions.Hosting.Internal.Host[9]
      BackgroundService failed
      HotChocolate.GraphQLException: Cannot query field 'exceptionName' on type 'TxResultType'. Did you mean 'exceptionNames'?

         at PatrolRewardService.GraphqlTypes.NineChroniclesClient.Result(TxId txId) in /src/PatrolRewardService/PatrolRewardService/GraphqlTypes/NineChroniclesClient.cs:line 133
         at PatrolRewardService.TransactionWorker.UpdateTx(RewardDbContext dbContext, NineChroniclesClient client, CancellationToken stoppingToken) in /src/PatrolRewardService/PatrolRewardService/TransactionWorker.cs:line 37
         at PatrolRewardService.TransactionWorker.ExecuteAsync(CancellationToken stoppingToken) in /src/PatrolRewardService/PatrolRewardService/TransactionWorker.cs:line 25
         at Microsoft.Extensions.Hosting.Internal.Host.TryExecuteBackgroundServiceAsync(BackgroundService backgroundService)
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Production
info: Microsoft.Hosting.Lifetime[0]
      Content root path: /app
crit: Microsoft.Extensions.Hosting.Internal.Host[10]
      The HostOptions.BackgroundServiceExceptionBehavior is configured to StopHost. A BackgroundService has thrown an unhandled exception, and the IHost instance is stopping. To avoid this behavior, configure this to Ignore; however the BackgroundService will not be restarted.
      HotChocolate.GraphQLException: Cannot query field 'exceptionName' on type 'TxResultType'. Did you mean 'exceptionNames'?

         at PatrolRewardService.GraphqlTypes.NineChroniclesClient.Result(TxId txId) in /src/PatrolRewardService/PatrolRewardService/GraphqlTypes/NineChroniclesClient.cs:line 133
         at PatrolRewardService.TransactionWorker.UpdateTx(RewardDbContext dbContext, NineChroniclesClient client, CancellationToken stoppingToken) in /src/PatrolRewardService/PatrolRewardService/TransactionWorker.cs:line 37
         at PatrolRewardService.TransactionWorker.ExecuteAsync(CancellationToken stoppingToken) in /src/PatrolRewardService/PatrolRewardService/TransactionWorker.cs:line 25
         at Microsoft.Extensions.Hosting.Internal.Host.TryExecuteBackgroundServiceAsync(BackgroundService backgroundService)
info: Microsoft.Hosting.Lifetime[0]
      Application is shutting down...
```