### PR TITLE
Apply additional security group

### DIFF
--- a/9c-internal/9c-network/values.yaml
+++ b/9c-internal/9c-network/values.yaml
@@ -227,6 +227,7 @@ rudolfService:
     enabled: true
     securityGroupIds:
     - "sg-0c865006315f5b9f0"
+    - "sg-0343e5c4514681670"
 
 volumeRotator:
   enabled: true

--- a/9c-internal/multiplanetary/global/rudolfService.yaml
+++ b/9c-internal/multiplanetary/global/rudolfService.yaml
@@ -22,3 +22,4 @@ rudolfService:
     enabled: true
     securityGroupIds:
     - "sg-0c865006315f5b9f0"
+    - "sg-0343e5c4514681670"


### PR DESCRIPTION
It adds an additional security group to apply `9c-rudolf-elb-to-portal-backend-lambda` rules.