### PR TITLE
🔨 PDX-94: Attach SSL annotation for rudolf-service ELB

### DIFF
--- a/9c-internal/9c-network/values.yaml
+++ b/9c-internal/9c-network/values.yaml
@@ -225,9 +225,6 @@ rudolfService:
     roleArn: "arn:aws:iam::319679068466:role/InternalRudolfSignerRole"
   service:
     enabled: true
-    securityGroupIds:
-    - "sg-0c865006315f5b9f0"
-    - "sg-0343e5c4514681670"
 
 volumeRotator:
   enabled: true

--- a/9c-internal/multiplanetary/values.yaml
+++ b/9c-internal/multiplanetary/values.yaml
@@ -70,6 +70,10 @@ multiplanetary:
     explorer: {}
     blockIntervalNotifier: {}
     rudolfService:
+      enabled: true
+      image:
+        tag: "git-956eaac9e5742d8eb237fb133b841f7d2d91621e"
+
       config:
         ncgMinter: "0x4fa78AF2C9FB3391ef05F1F1F8FE9565137a00f9"
         graphqlEndpoint: "http://heimdall-internal-rpc-1.nine-chronicles.com/graphql"
@@ -80,6 +84,12 @@ multiplanetary:
 
       serviceAccount:
         roleArn: "arn:aws:iam::319679068466:role/heimdall-internal-9c-rudolf-signer"
+
+      service:
+        enabled: true
+
+      db:
+        local: true
 
   - name: "idun"
 
@@ -142,6 +152,10 @@ multiplanetary:
     explorer: {}
     blockIntervalNotifier: {}
     rudolfService:
+      enabled: true
+      image:
+        tag: "git-956eaac9e5742d8eb237fb133b841f7d2d91621e"
+
       config:
         ncgMinter: "0x4fa78AF2C9FB3391ef05F1F1F8FE9565137a00f9"
         graphqlEndpoint: "https://idun-internal-rpc-1.nine-chronicles.com/graphql"
@@ -152,6 +166,13 @@ multiplanetary:
 
       serviceAccount:
         roleArn: "arn:aws:iam::319679068466:role/idun-internal-9c-rudolf-signer"
+
+      service:
+        enabled: true
+
+      db:
+        local: true
+
 
 global:
   image:

--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -74,7 +74,9 @@ metadata:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    {{- if .Values.rudolfService.service.securityGroupIds }}
     service.beta.kubernetes.io/aws-load-balancer-security-groups: {{ join "," .Values.rudolfService.service.securityGroupIds }}
+    {{- end }}
     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-2:319679068466:certificate/2481ac9e-2037-4331-9234-4b3f86d50ad3
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
     service.beta.kubernetes.io/aws-load-balancer-type: external

--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -75,6 +75,8 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
     service.beta.kubernetes.io/aws-load-balancer-security-groups: {{ join "," .Values.rudolfService.service.securityGroupIds }}
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-2:319679068466:certificate/2481ac9e-2037-4331-9234-4b3f86d50ad3
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
     service.beta.kubernetes.io/aws-load-balancer-type: external
 spec:
   externalTrafficPolicy: Local
@@ -83,6 +85,9 @@ spec:
   - port: 3000
     targetPort: 3000
     name: http
+  - port: 443
+    targetPort: 3000
+    name: https
   selector:
     app: 9c-rudolf
 {{ end }}


### PR DESCRIPTION
Some variables were added to `multiplanetary/values.yaml` because the `multiplanetary/global/rudolfService.yaml` doesn't work as default values 🤔 Maybe the file should be removed

This pull request makes the 9c-rudolf's ELB support HTTPS. And it gives up security group features.