### PR TITLE
🪐 PDX-96: Use minterless NCG in downstream networks' 9c-rudolf

### DIFF
--- a/9c-internal/9c-network/values.yaml
+++ b/9c-internal/9c-network/values.yaml
@@ -208,7 +208,7 @@ rudolfService:
   enabled: true
 
   image:
-    tag: "git-956eaac9e5742d8eb237fb133b841f7d2d91621e"
+    tag: "git-cda9ad1b4c5269a052a18ca3b0a3b94d48f51491"
 
   config:
     ncgMinter: "0x47D082a115c63E7b58B1532d20E631538eaFADde"

--- a/9c-internal/multiplanetary/global/rudolfService.yaml
+++ b/9c-internal/multiplanetary/global/rudolfService.yaml
@@ -2,7 +2,7 @@ rudolfService:
   enabled: true
 
   image:
-    tag: "git-956eaac9e5742d8eb237fb133b841f7d2d91621e"
+    tag: "git-cda9ad1b4c5269a052a18ca3b0a3b94d48f51491"
 
   config:
     ncgMinter: "0x4fa78AF2C9FB3391ef05F1F1F8FE9565137a00f9"

--- a/9c-internal/multiplanetary/values.yaml
+++ b/9c-internal/multiplanetary/values.yaml
@@ -73,7 +73,6 @@ multiplanetary:
       enabled: true
 
       config:
-        ncgMinter: "0x4fa78AF2C9FB3391ef05F1F1F8FE9565137a00f9"
         graphqlEndpoint: "http://heimdall-internal-rpc-1.nine-chronicles.com/graphql"
 
       kms:
@@ -150,7 +149,6 @@ multiplanetary:
       enabled: true
 
       config:
-        ncgMinter: "0x4fa78AF2C9FB3391ef05F1F1F8FE9565137a00f9"
         graphqlEndpoint: "https://idun-internal-rpc-1.nine-chronicles.com/graphql"
 
       kms:

--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -38,8 +38,10 @@ spec:
                 secretKeyRef:
                   key: database-url
                   name: rudolf-service
+{{- if .Values.rudolfService.config.ncgMinter }}
             - name: NCG_MINTER
               value: {{ .Values.rudolfService.config.ncgMinter }}
+{{- end }}
             - name: GQL_ENDPOINT
               value: {{ .Values.rudolfService.config.graphqlEndpoint }}
             - name: NC_GRAPHQL_ENDPOINT

--- a/charts/all-in-one/values.schema.json
+++ b/charts/all-in-one/values.schema.json
@@ -30,7 +30,7 @@
                 "description": "A GraphQL endpoint to query chain data and stage transactions"
               }
             },
-            "required": ["ncgMinter", "graphqlEndpoint"]
+            "required": ["graphqlEndpoint"]
           },
           "db": {
             "type": "object",


### PR DESCRIPTION
Subplanets like heimdall and idun use minterless NCGs taken from the bridge, and 9c-rudolf recently added the ability to use NCGs with `minters: null` unless the `NCG_MINTER` environment variable is present. This PR reflects that.