### PR TITLE
Bump 9c-rudolf image

### DIFF
--- a/9c-internal/9c-network/values.yaml
+++ b/9c-internal/9c-network/values.yaml
@@ -208,7 +208,7 @@ rudolfService:
   enabled: true
 
   image:
-    tag: "git-cda9ad1b4c5269a052a18ca3b0a3b94d48f51491"
+    tag: "git-e12f0131f9061bd90c0230867363573b96aae5f7"
 
   config:
     ncgMinter: "0x47D082a115c63E7b58B1532d20E631538eaFADde"

--- a/9c-internal/multiplanetary/global/rudolfService.yaml
+++ b/9c-internal/multiplanetary/global/rudolfService.yaml
@@ -2,7 +2,7 @@ rudolfService:
   enabled: true
 
   image:
-    tag: "git-cda9ad1b4c5269a052a18ca3b0a3b94d48f51491"
+    tag: "git-e12f0131f9061bd90c0230867363573b96aae5f7"
 
   config:
     ncgMinter: "0x4fa78AF2C9FB3391ef05F1F1F8FE9565137a00f9"


### PR DESCRIPTION
Currently, 9c-rudolf doesn't work well. It applies https://github.com/planetarium/9c-rudolf/commit/e12f0131f9061bd90c0230867363573b96aae5f7.

```
[31m[Nest] 99  - [39m11/14/2023, 8:41:45 AM [31m  ERROR[39m [38;5;3m[ExceptionsHandler] [39m[31mAdded label "url" is not included in initial labelset: [ 'method' ][39m
Error: Added label "url" is not included in initial labelset: [ 'method' ]
    at validateLabel (/app/node_modules/prom-client/lib/validation.js:20:10)
    at Counter.incWithoutExemplar (/app/node_modules/prom-client/lib/counter.js:44:4)
    at HttpResponseMiddleware.use (/app/dist/http-response.middleware.js:29:14)
    at /app/node_modules/@nestjs/core/router/router-proxy.js:9:23
    at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/app/node_modules/express/lib/router/index.js:328:13)
    at /app/node_modules/express/lib/router/index.js:286:9
    at param (/app/node_modules/express/lib/router/index.js:365:14)
    at param (/app/node_modules/express/lib/router/index.js:376:14)
    at Function.process_params (/app/node_modules/express/lib/router/index.js:421:3)
```