### PR TITLE
Bump rudolf-service image for internal multiplanetary

### DIFF
--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -41,4 +41,4 @@ patrolRewardService:
 
 rudolfService:
   image:
-    tag: "git-197ae6b270cc45a907e474e84364c29a07769a07"
+    tag: "git-b2eec60aa0771222103f8598a3aaaf6ed5c36102"


### PR DESCRIPTION
It applies https://github.com/planetarium/9c-rudolf/commit/b2eec60aa0771222103f8598a3aaaf6ed5c36102 patch.