### PR TITLE
Use 'raw' as default account type of bridgeService

### DIFF
--- a/charts/all-in-one/templates/bridge-service.yaml
+++ b/charts/all-in-one/templates/bridge-service.yaml
@@ -47,7 +47,7 @@ spec:
             value: {{ $.Values.bridgeService.notification.slack.bot.username }}
           - name: SLACK__CHANNEL
             value: {{ $.Values.bridgeService.notification.slack.channel }}
-          {{- if or $.Values.bridgeService.account.type (eq $.Values.bridgeService.account.type "raw") }}
+          {{- if eq $.Values.bridgeService.account.type "raw" }}
           - name: NC_UPSTREAM_ACCOUNT_TYPE
             value: "RAW"
           - name: NC_UPSTREAM_PRIVATE_KEY

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -575,6 +575,10 @@ volumeRotator:
 
 bridgeService:
   enabled: false
+
+  account:
+    type: "raw"
+
   serviceAccount:
     roleArn: ""
 


### PR DESCRIPTION
I tested with the below command

```
helm template --values 9c-internal/multiplanetary/network/general.yaml --values 9c-internal/multiplanetary/network/heimdall.yaml charts/all-in-one > tmp.yaml
```