### PR TITLE
Bump bridgeService image

### DIFF
--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -13,7 +13,7 @@ bridgeService:
   image:
     repository: planetariumhq/9c-bridge
     pullPolicy: Always
-    tag: "git-f7f102debef200f4e483672ac50c6482bc223746"
+    tag: "git-6b088538db029ee8ad4b778297defbd16ea1a4db"
 
 dataProvider:
   image:

--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -31,7 +31,12 @@ bridgeService:
 
   nodeSelector:
     node.kubernetes.io/instance-type: m5d.xlarge
-  
+
+  account:
+    type: "kms"
+    keyId: "7b912d9b-b682-4403-a794-2d6421d108c9"
+    publicKey: "04ab9e31a20d8dbf5042bfc26ce9d9ed9a0e32ad787a1e5aa3ae8188fa5143861535acc7132cd8e74d4c1f0b94f843575e3add6988d3ccb1f54d7c59fb9535d789"
+
   notification:
     slack:
       bot:


### PR DESCRIPTION
- It bumps bridgeService's image.
- It replaces heimdall bridgeService's account type as KMS.