### PR TITLE
add livenessprobe condition

### DIFF
--- a/charts/9c-network/templates/remote-headless.yaml
+++ b/charts/9c-network/templates/remote-headless.yaml
@@ -109,7 +109,11 @@ spec:
         livenessProbe:
           exec:
             command:
+            {{- if eq $.Values.global.networkType "Main"  }}
             - /bin/liveness_probe.sh {{ $.Values.global.validatorPath }}
+            {{- else }}
+            - /bin/liveness_probe.sh
+            {{- end }}
           failureThreshold: 3
           initialDelaySeconds: 1800
           periodSeconds: 30

--- a/charts/all-in-one/templates/remote-headless.yaml
+++ b/charts/all-in-one/templates/remote-headless.yaml
@@ -143,7 +143,11 @@ spec:
         livenessProbe:
           exec:
             command:
+            {{- if eq $.Values.global.networkType "Main"  }}
             - /bin/liveness_probe.sh {{ $.Values.global.validatorPath }}
+            {{- else }}
+            - /bin/liveness_probe.sh
+            {{- end }}
           failureThreshold: 3
           initialDelaySeconds: 1800
           periodSeconds: 30


### PR DESCRIPTION
Maintain original livenessprobe setting if the `networkType` is not `Main`.