### PR TITLE
Update rudolf-service & bridge-service

### DIFF
--- a/9c-main/argocd/bootstrap.yaml
+++ b/9c-main/argocd/bootstrap.yaml
@@ -107,6 +107,19 @@ spec:
                       group: heimdall-explorer
                 tls_config:
                   insecure_skip_verify: true
+              - job_name: scrape-9c-rudolf
+                metrics_path: /metrics
+                scrape_interval: 5s
+                scrape_timeout: 4s
+                static_configs:
+                  - targets:
+                    - rudolf-service.9c-network.svc.cluster.local:3000
+                    - rudolf-service.heimdall.svc.cluster.local:3000
+                    - rudolf-service.idun.svc.cluster.local:3000
+                    labels:
+                      group: 9c-rudolf
+                tls_config:
+                  insecure_skip_verify: true
         loki:
           enabled: true
           bucketName: loki.planetariumhq.com

--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -412,7 +412,6 @@ rudolfService:
   
   db:
     local: false
-    securityGroupId: "sg-0fd42d699fe71759f"
 
   kms:
     keyId: "edebbede-fbc9-4200-bb64-8c040a3c2f75"

--- a/9c-main/multiplanetary/network/general.yaml
+++ b/9c-main/multiplanetary/network/general.yaml
@@ -48,3 +48,9 @@ emptyChronicle:
 rudolfService:
   image:
     tag: "git-b2eec60aa0771222103f8598a3aaaf6ed5c36102"
+
+bridgeService:
+  image:
+    repository: planetariumhq/9c-bridge
+    pullPolicy: Always
+    tag: "git-6feff0900c4d1fccf6f5157d6afef633a5a4e327"

--- a/9c-main/multiplanetary/network/general.yaml
+++ b/9c-main/multiplanetary/network/general.yaml
@@ -53,4 +53,4 @@ bridgeService:
   image:
     repository: planetariumhq/9c-bridge
     pullPolicy: Always
-    tag: "git-6feff0900c4d1fccf6f5157d6afef633a5a4e327"
+    tag: "git-06bd0d5b8384a53def5ce7d966190298f7457abe"

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -336,6 +336,11 @@ bridge:
 bridgeService:
   enabled: false
 
+  multiplanetary:
+    registryEndpoint: "https://planets.nine-chronicles.com/planets/"
+    upstream: "0x000000000000"
+    downstream: "0x000000000001"
+
   serviceAccount:
     roleArn: "arn:aws:iam::319679068466:role/9c-main-v2-bridge-service"
 
@@ -344,6 +349,17 @@ bridgeService:
 
   nodeSelector:
     eks.amazonaws.com/nodegroup: heimdall-m5_l_2c
+
+  account:
+    type: "kms"
+    keyId: "7b912d9b-b682-4403-a794-2d6421d108c9"
+    publicKey: "04ab9e31a20d8dbf5042bfc26ce9d9ed9a0e32ad787a1e5aa3ae8188fa5143861535acc7132cd8e74d4c1f0b94f843575e3add6988d3ccb1f54d7c59fb9535d789"
+
+  notification:
+    slack:
+      bot:
+        username: "Relay Bridge (Odin ↔ Heimdall)"
+      channel: "9c-relay-bridge-bot"
 
 testHeadless1:
   enabled: false

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -336,11 +336,6 @@ bridge:
 bridgeService:
   enabled: false
 
-  image:
-    repository: planetariumhq/9c-bridge
-    pullPolicy: Always
-    tag: "git-6feff0900c4d1fccf6f5157d6afef633a5a4e327"
-
   serviceAccount:
     roleArn: "arn:aws:iam::319679068466:role/9c-main-v2-bridge-service"
 

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -413,7 +413,6 @@ rudolfService:
 
   db:
     local: false
-    securityGroupId: "sg-0fd42d699fe71759f"
 
   kms:
     keyId: "8a959850-46d4-4dda-bf1c-058ef6975b63"

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -409,7 +409,7 @@ rudolfService:
   enabled: true
 
   config:
-    graphqlEndpoint: "http://heimdall-rpc-1.nine-chronicles.com/graphql"
+    graphqlEndpoint: "https://heimdall-rpc-1.nine-chronicles.com/graphql"
 
   db:
     local: false
@@ -417,7 +417,7 @@ rudolfService:
 
   kms:
     keyId: "8a959850-46d4-4dda-bf1c-058ef6975b63"
-    publicKey: "04d237239d672698c89fc0788918b4c8610de8b65c5d02ebf3e1f31dcb891683410a97b51f59c05c41c141ad3a05324ba2c5afe32d5e4909e63fd4a700cd36cc53"
+    publicKey: "0441319181d5e47bce52402f46502dacf5ba63ee7e3f81271c2e266e3086c31a5e56d999857f69b9db132810f69ede7cc2b3e832ff61759ce101e2e5d86c702938"
 
   serviceAccount:
     roleArn: "arn:aws:iam::319679068466:role/heimdall-main-9c-rudolf-signer"

--- a/9c-main/multiplanetary/network/idun.yaml
+++ b/9c-main/multiplanetary/network/idun.yaml
@@ -336,6 +336,11 @@ bridge:
 bridgeService:
   enabled: false
 
+  multiplanetary:
+    registryEndpoint: "https://planets.nine-chronicles.com/planets/"
+    upstream: "0x000000000000"
+    downstream: "0x000000000002"
+
   serviceAccount:
     roleArn: "arn:aws:iam::319679068466:role/9c-main-v2-bridge-service"
 
@@ -344,6 +349,17 @@ bridgeService:
 
   nodeSelector:
     eks.amazonaws.com/nodegroup: idun-m5_l_2c
+
+  account:
+    type: "kms"
+    keyId: "722200cf-4f40-44e9-b227-9b82977a8ca2"
+    publicKey: "042dac446982ff1320be59fd516c128bbfb9b87c9ed71a30b7d3d6ea550fe912198a909558ae5ff132bc66199ed057922b3d76fdce18db1ed96af44e9969fe8846"
+
+  notification:
+    slack:
+      bot:
+        username: "Relay Bridge (Odin ↔ Idun)"
+      channel: "9c-relay-bridge-bot"
 
 testHeadless1:
   enabled: false

--- a/9c-main/multiplanetary/network/idun.yaml
+++ b/9c-main/multiplanetary/network/idun.yaml
@@ -336,11 +336,6 @@ bridge:
 bridgeService:
   enabled: false
 
-  image:
-    repository: planetariumhq/9c-bridge
-    pullPolicy: Always
-    tag: "git-6feff0900c4d1fccf6f5157d6afef633a5a4e327"
-
   serviceAccount:
     roleArn: "arn:aws:iam::319679068466:role/9c-main-v2-bridge-service"
 

--- a/9c-main/multiplanetary/network/idun.yaml
+++ b/9c-main/multiplanetary/network/idun.yaml
@@ -409,20 +409,20 @@ rudolfService:
   enabled: false
 
   config:
-    graphqlEndpoint: "http://idun-rpc-1.nine-chronicles.com/graphql"
+    graphqlEndpoint: "https://idun-rpc-1.nine-chronicles.com/graphql"
 
   db:
     local: false
 
   kms:
-    keyId: "8a959850-46d4-4dda-bf1c-058ef6975b63"
-    publicKey: "04d237239d672698c89fc0788918b4c8610de8b65c5d02ebf3e1f31dcb891683410a97b51f59c05c41c141ad3a05324ba2c5afe32d5e4909e63fd4a700cd36cc53"
+    keyId: "b9ff8478-a8fe-44af-bf4d-a450978cbb50"
+    publicKey: "04ed8adebec625e464f8fff1f81ae84aa70117d73608ce48522372e7a08176ed672eaf9a9bfbae7ee7d782ebb601354b8f14d07e7f9d3ab7b164d2bb15ca95f1d6"
 
   serviceAccount:
-    roleArn: "arn:aws:iam::319679068466:role/idun-main-9c-rudolf-signer"
+    roleArn: "arn:aws:iam::319679068466:role/idun-mainnet-9c-rudolf-signer"
 
   service:
     enabled: true
     securityGroupIds:
-    - "sg-0c865006315f5b9f0"
-    - "sg-0343e5c4514681670"
+    - "sg-0f0bf654f2ff02289"
+    - "sg-033602a010bce902e"

--- a/charts/all-in-one/values.schema.json
+++ b/charts/all-in-one/values.schema.json
@@ -58,14 +58,7 @@
               "required": ["size"]
             },
             "else": {
-              "description": "Enabled database with RDS connection.",
-              "properties": {
-                "securityGroupId": {
-                  "type": "string",
-                  "description": "SecurityGroup's id for RDS connection."
-                }
-              },
-              "required": ["securityGroupId"]
+              "description": "Enabled database with RDS connection."
             }
           },
           "service": {


### PR DESCRIPTION
- rudolf-service
  - Correct incorrect rudolf-service's variables.
  - Make prometheus scrape rudolf-services.
  - Remove unused `.rudolfService.db.securityGroupId` from variables, schema.
- bridge-service
  - Make bridge image with `general.yaml`.
  - Bump 9c-main bridge image.
  - Prepare 9c-main bridge service. (not enabled yet)