### PR TITLE
Fix missed one

### DIFF
--- a/9c-internal/multiplanetary/network/9c-network.yaml
+++ b/9c-internal/multiplanetary/network/9c-network.yaml
@@ -198,6 +198,7 @@ rudolfService:
   config:
     ncgMinter: "0x47D082a115c63E7b58B1532d20E631538eaFADde"
     graphqlEndpoint: "https://9c-internal-rpc-1.nine-chronicles.com/graphql"
+    genesisBlockHash: "4582250d0da33b06779a8475d283d5dd210c683b9b999d74d03fac4f58fa6bce"
 
   db:
     local: true

--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -13,7 +13,7 @@ bridgeService:
   image:
     repository: planetariumhq/9c-bridge
     pullPolicy: Always
-    tag: "git-6b088538db029ee8ad4b778297defbd16ea1a4db"
+    tag: "git-06bd0d5b8384a53def5ce7d966190298f7457abe"
 
 dataProvider:
   image:

--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -119,6 +119,7 @@ rudolfService:
 
   config:
     graphqlEndpoint: "http://heimdall-internal-rpc-1.nine-chronicles.com/graphql"
+    genesisBlockHash: "729fa26958648a35b53e8e3905d11ec53b1b4929bf5f499884aed7df616f5913"
 
   db:
     local: true

--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -408,6 +408,7 @@ rudolfService:
   enabled: true
 
   config:
+    ncgMinter: "0x47D082a115c63E7b58B1532d20E631538eaFADde"
     graphqlEndpoint: "http://9c-main-full-state.nine-chronicles.com/graphql"
     genesisBlockHash: "4582250d0da33b06779a8475d283d5dd210c683b9b999d74d03fac4f58fa6bce"
   

--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -409,6 +409,7 @@ rudolfService:
 
   config:
     graphqlEndpoint: "http://9c-main-full-state.nine-chronicles.com/graphql"
+    genesisBlockHash: "4582250d0da33b06779a8475d283d5dd210c683b9b999d74d03fac4f58fa6bce"
   
   db:
     local: false

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -423,6 +423,7 @@ rudolfService:
 
   config:
     graphqlEndpoint: "https://heimdall-rpc-1.nine-chronicles.com/graphql"
+    genesisBlockHash: "729fa26958648a35b53e8e3905d11ec53b1b4929bf5f499884aed7df616f5913"
 
   db:
     local: false

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -419,7 +419,7 @@ volumeRotator:
   nodeSelectorValue: "heimdall-r7g_xl_2c"
 
 rudolfService:
-  enabled: true
+  enabled: false
 
   config:
     graphqlEndpoint: "https://heimdall-rpc-1.nine-chronicles.com/graphql"

--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -38,6 +38,8 @@ spec:
                 secretKeyRef:
                   key: database-url
                   name: rudolf-service
+            - name: GENESIS_BLOCK_HASH
+              value: {{ quote .Values.rudolfService.config.genesisBlockHash }}
 {{- if .Values.rudolfService.config.ncgMinter }}
             - name: NCG_MINTER
               value: {{ .Values.rudolfService.config.ncgMinter }}


### PR DESCRIPTION
- Bump 9c-internal bridge-service image
- Set missed `GENESIS_BLOCK_HASH`, required env
- Set missed `NCG_MINTER` for 9c-main odin
- Disable heimdall mainnet rudolf-service. It will be enabled after chain reset.