### PR TITLE
🌉 PDX-174: Support txpool feature in bridge-service, etc

### DIFF
--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -13,7 +13,7 @@ bridgeService:
   image:
     repository: planetariumhq/9c-bridge
     pullPolicy: Always
-    tag: "git-8851ed7c4e171dd083dc345be14f552e9256f541"
+    tag: "git-b234b949b37d720acc5bd72515dcea4de32a0485"
 
 dataProvider:
   image:

--- a/charts/all-in-one/templates/bridge-service.yaml
+++ b/charts/all-in-one/templates/bridge-service.yaml
@@ -78,6 +78,23 @@ spec:
           {{- else }}
           {{- fail "bridgeService.account.type must be either raw or kms" }}
           {{- end }}
+          {{- if eq $.Values.bridgeService.txpool.type "headless" }}
+          - name: NC_UPSTREAM__TXPOOL__TYPE
+            value: "HEADLESS"
+          - name: NC_DOWNSTREAM__TXPOOL__TYPE
+            value: "HEADLESS"
+          {{- else if eq $.Values.bridgeService.txpool.type "local" }}
+          - name: NC_UPSTREAM__TXPOOL__TYPE
+            value: "LOCAL"
+          - name: NC_DOWNSTREAM__TXPOOL__TYPE
+            value: "LOCAL"
+          - name: NC_UPSTREAM__LOCAL_TXPOOL__PATH
+            value: {{ .Values.bridgeService.txpool.upstream.path }}
+          - name: NC_DOWNSTREAM__LOCAL_TXPOOL__TYPE
+            value: {{ .Values.bridgeService.txpool.downstream.path }}
+          {{- else }}
+          {{- fail "bridgeService.txpool.type must be either headless or local" }}
+          {{- end }}
           - name: MONITOR_STATE_STORE_PATH
             valueFrom:
               secretKeyRef:

--- a/charts/all-in-one/templates/bridge-service.yaml
+++ b/charts/all-in-one/templates/bridge-service.yaml
@@ -119,6 +119,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: 60
       restartPolicy: Always
       serviceAccount: {{ $.Release.Name }}-bridge-service
       serviceAccountName: {{ $.Release.Name }}-bridge-service

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -588,6 +588,13 @@ bridgeService:
     repository: ""
     tag: ""
 
+  txpool:
+    type: "headless"
+    upstream:
+      path: "/data/upstream-txpool-journal"
+    downstream:
+      path: "/data/downstream-txpool-journal"
+
   storage:
     size: "50Gi"
 


### PR DESCRIPTION
- Support a new feature, `txpool`, for bridge-service. (local or headless)
- Bump bridge image in 9c-internal cluster. (for heimdall-internal)