### PR TITLE
hotfix

### DIFF
--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -330,7 +330,7 @@ bridgeService:
   enabled: true
 
   multiplanetary:
-    registryEndpoint: "https://planets.nine-chronicles.com/planets/"
+    registryEndpoint: "https://9c-dx.s3.ap-northeast-2.amazonaws.com/planets.json"
     upstream: "0x000000000000"
     downstream: "0x000000000001"
 
@@ -349,7 +349,7 @@ bridgeService:
     publicKey: "04ab9e31a20d8dbf5042bfc26ce9d9ed9a0e32ad787a1e5aa3ae8188fa5143861535acc7132cd8e74d4c1f0b94f843575e3add6988d3ccb1f54d7c59fb9535d789"
 
   txpool:
-    type: "local"
+    type: "headless"
 
   notification:
     slack:


### PR DESCRIPTION
- Use only full-state nodes with copy registry.
- Rollback to headless txpool.