### PR TITLE
fix liveness probe error

### DIFF
--- a/9c-internal-mead/chart/templates/explorer.yaml
+++ b/9c-internal-mead/chart/templates/explorer.yaml
@@ -96,7 +96,7 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/liveness_probe.sh {{ $.Values.global.validatorPath }}
+            - /bin/liveness_probe.sh
           failureThreshold: 3
           initialDelaySeconds: 1800
           periodSeconds: 30

--- a/9c-internal-mead/chart/templates/remote-headless.yaml
+++ b/9c-internal-mead/chart/templates/remote-headless.yaml
@@ -120,7 +120,7 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/liveness_probe.sh {{ $.Values.global.validatorPath }}
+            - /bin/liveness_probe.sh
           failureThreshold: 3
           initialDelaySeconds: 1800
           periodSeconds: 30

--- a/9c-internal-mead/chart/templates/snapshot-sync-headless.yaml
+++ b/9c-internal-mead/chart/templates/snapshot-sync-headless.yaml
@@ -87,7 +87,7 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/liveness_probe.sh {{ $.Values.global.validatorPath }}
+            - /bin/liveness_probe.sh
           failureThreshold: 3
           initialDelaySeconds: 1800
           periodSeconds: 30

--- a/charts/9c-network/templates/remote-headless.yaml
+++ b/charts/9c-network/templates/remote-headless.yaml
@@ -110,7 +110,7 @@ spec:
           exec:
             command:
             {{- if eq $.Values.global.networkType "Main"  }}
-            - /bin/liveness_probe.sh {{ $.Values.global.validatorPath }}
+            - /bin/liveness_probe.sh
             {{- else }}
             - /bin/liveness_probe.sh
             {{- end }}

--- a/charts/all-in-one/scripts/common/liveness_probe.sh
+++ b/charts/all-in-one/scripts/common/liveness_probe.sh
@@ -25,7 +25,7 @@ if [[ "$preloaded" = "true" ]]; then
     curl \
       -H 'Content-Type: application/json' \
       --data '{"query":"query{chainQuery{blockQuery{blocks(desc:true,limit:1){index}}}}"}' \
-      $1/graphql \
+      {{ $.Values.global.validatorPath }}/graphql \
     | jq -r '.data.chainQuery.blockQuery.blocks[0].index'
   )"
   echo $miner_tip

--- a/charts/all-in-one/templates/explorer.yaml
+++ b/charts/all-in-one/templates/explorer.yaml
@@ -123,7 +123,7 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/liveness_probe.sh {{ $.Values.global.validatorPath }}
+            - /bin/liveness_probe.sh
           failureThreshold: 3
           initialDelaySeconds: 1800
           periodSeconds: 30

--- a/charts/all-in-one/templates/full-state.yaml
+++ b/charts/all-in-one/templates/full-state.yaml
@@ -78,7 +78,7 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/liveness_probe.sh {{ $.Values.global.validatorPath }}
+            - /bin/liveness_probe.sh
           failureThreshold: 3
           initialDelaySeconds: 1800
           periodSeconds: 30

--- a/charts/all-in-one/templates/remote-headless.yaml
+++ b/charts/all-in-one/templates/remote-headless.yaml
@@ -144,7 +144,7 @@ spec:
           exec:
             command:
             {{- if eq $.Values.global.networkType "Main"  }}
-            - /bin/liveness_probe.sh {{ $.Values.global.validatorPath }}
+            - /bin/liveness_probe.sh
             {{- else }}
             - /bin/liveness_probe.sh
             {{- end }}

--- a/charts/all-in-one/templates/test-headless-1.yaml
+++ b/charts/all-in-one/templates/test-headless-1.yaml
@@ -78,7 +78,7 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/liveness_probe.sh {{ $.Values.global.validatorPath }}
+            - /bin/liveness_probe.sh
           failureThreshold: 3
           initialDelaySeconds: 1800
           periodSeconds: 30

--- a/charts/all-in-one/templates/test-headless-2.yaml
+++ b/charts/all-in-one/templates/test-headless-2.yaml
@@ -78,7 +78,7 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /bin/liveness_probe.sh {{ $.Values.global.validatorPath }}
+            - /bin/liveness_probe.sh
           failureThreshold: 3
           initialDelaySeconds: 1800
           periodSeconds: 30


### PR DESCRIPTION
Apparently, setting up the livenessprobe like `/bin/liveness_probe.sh validator-5.9c-network.svc.cluster.local` directly in the YAML file has been causing the following error:

```
Warning  Unhealthy  47s  kubelet  Liveness probe errored: rpc error: code = Unknown desc = failed to exec
in container: failed to start exec "f358106b44bbca67b018c18882e775875f77bd6d27987e90234a667b370a66e5": 
OCI runtime exec failed: exec failed: unable to start container process: exec:
"/bin/liveness_probe.sh validator-5.9c-network.svc.cluster.local":
stat /bin/liveness_probe.sh validator-5.9c-network.svc.cluster.local: no such file or directory: unknown
  ```
  
To avoid such error, this PR puts the `{{ $.Values.global.validatorPath }}` value directly inside `charts/all-in-one/scripts/common/liveness_probe.sh`.