### PR TITLE
🔨 PDX-187: Bump bridge-service in heimdall-internal

### DIFF
--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -13,7 +13,7 @@ bridgeService:
   image:
     repository: planetariumhq/9c-bridge
     pullPolicy: Always
-    tag: "git-5a7abfb97d48fca24d95fca67df4a8fd62978927"
+    tag: "git-6ca05f8ac883a64693f9942be544687c793c793c"
 
 dataProvider:
   image:

--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -53,7 +53,7 @@ bridgeService:
     size: "10Gi"
 
   rdb:
-    enabled: true
+    enabled: false
     defaultStartBlockIndex:
       upstream: "8474190"
       downstream: "105195"


### PR DESCRIPTION
I found a bug while testing IAP, so I bumped the image, and the RDB functionality is not yet complete, so I temporarily disabled it for testing.