### PR TITLE
Bump bridge-service for heimdall

### DIFF
--- a/9c-main/multiplanetary/network/general.yaml
+++ b/9c-main/multiplanetary/network/general.yaml
@@ -51,4 +51,4 @@ bridgeService:
   image:
     repository: planetariumhq/9c-bridge
     pullPolicy: Always
-    tag: "git-034ca4c7747663315fa03b593843621297ff9b3b"
+    tag: "git-6ca05f8ac883a64693f9942be544687c793c793c"


### PR DESCRIPTION
Apply patches to mainnet to support IAP new product items.