### PR TITLE
Correct fetching env from secretKeyRef

### DIFF
--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -13,7 +13,7 @@ bridgeService:
   image:
     repository: planetariumhq/9c-bridge
     pullPolicy: Always
-    tag: "git-6c560e11a8f6bb2625aa8f51e1a10c56e706a89f"
+    tag: "git-357d67484903a74c04746be934cf3e31052fdd06"
 
 dataProvider:
   image:

--- a/charts/all-in-one/templates/bridge-service.yaml
+++ b/charts/all-in-one/templates/bridge-service.yaml
@@ -43,8 +43,8 @@ spec:
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
-              name: DATABASE_URL
-              key: bridge-env
+              name: bridge-env
+              key: DATABASE_URL
       containers:
         - env:
           - name: NC_REGISTRY_ENDPOINT


### PR DESCRIPTION
In bridge-service's initContainers, there is a bug on the secretKeyRef for `DATABASE_URL`. This PR corrects it and bumps bridge-service's image in 9c-internal.