### PR TITLE
organize mainnet service

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -375,10 +375,10 @@ testHeadless2:
     eks.amazonaws.com/nodegroup: 9c-main-r6g_xl_2c
 
 emptyChronicle:
-  enabled: true
+  enabled: false
 
 remoteActionEvaluatorHeadless:
-  enabled: true
+  enabled: false
 
   loggingEnabled: true
 

--- a/charts/all-in-one/templates/service.yaml
+++ b/charts/all-in-one/templates/service.yaml
@@ -78,7 +78,7 @@ spec:
 ---
 {{ end }}
 
-{{ if $.Values.dataProvider.rwMode }}
+{{- if eq $.Values.clusterName "9c-main-v2" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -98,29 +98,6 @@ spec:
     targetPort: 80
   selector:
     app: data-provider-write
-  type: LoadBalancer
-
----
-
-apiVersion: v1
-kind: Service
-metadata:
-  name: data-provider-read
-  namespace: {{ $.Release.Name }}
-  labels:
-    app.kubernetes.io/instance: {{ $.Release.Name }}
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
-    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
-    service.beta.kubernetes.io/aws-load-balancer-type: external
-    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: Environment={{- if eq $.Values.clusterName "9c-main-v2" }}production{{- else }}development{{- end }},Team=game,Owner=kidon,Service={{ $.Release.Name }},Name=data-provider-read
-spec:
-  ports:
-  - name: graphql
-    port: 80
-    targetPort: 80
-  selector:
-    app: data-provider-read
   type: LoadBalancer
 
 {{ else }}


### PR DESCRIPTION
Disable `emptyChronicles`, `remoteActionEvaluatorHeadless` and don't use `data-provider-read` in `mainnet`.