### PR TITLE
update spot nodegroup type

### DIFF
--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -324,7 +324,7 @@ testHeadless1:
   image:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
-    tag: "git-1747a921af14f8849b7a5b912b9662fe4188852b"
+    tag: "git-2e79a9ef0fbe926e55862a88266802f71e59d9d5"
 
   host: "heimdall-test-1.nine-chronicles.com"
 
@@ -342,7 +342,7 @@ testHeadless1:
       memory: 25Gi
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: heimdall-m7g_2xl_2c_spot
+    eks.amazonaws.com/nodegroup: heimdall-2c_spot
 
   loggingEnabled: true
 

--- a/9c-main/terraform/terraform.tfvars
+++ b/9c-main/terraform/terraform.tfvars
@@ -160,6 +160,22 @@ node_groups = {
     }]
   }
 
+  "heimdall-m7g_2xl_2c_validator" = {
+    instance_types    = ["m7g.2xlarge"]
+    availability_zone = "us-east-2c"
+    capacity_type     = "ON_DEMAND"
+    desired_size      = 1
+    min_size          = 1
+    max_size          = 6
+    ami_type          = "AL2_ARM_64"
+    disk_size         = 50
+    taints = [{
+      key    = "dedicated"
+      value  = "validator-test"
+      effect = "NO_SCHEDULE"
+    }]
+  }
+
   "heimdall-2c_spot" = {
     instance_types    = ["r7g.xlarge", "m7g.2xlarge", "r6g.xlarge"]
     availability_zone = "us-east-2c"

--- a/9c-main/terraform/terraform.tfvars
+++ b/9c-main/terraform/terraform.tfvars
@@ -160,24 +160,8 @@ node_groups = {
     }]
   }
 
-  "heimdall-m7g_2xl_2c_validator" = {
-    instance_types    = ["m7g.2xlarge"]
-    availability_zone = "us-east-2c"
-    capacity_type     = "ON_DEMAND"
-    desired_size      = 1
-    min_size          = 1
-    max_size          = 6
-    ami_type          = "AL2_ARM_64"
-    disk_size         = 50
-    taints = [{
-      key    = "dedicated"
-      value  = "validator-test"
-      effect = "NO_SCHEDULE"
-    }]
-  }
-
-  "heimdall-m7g_2xl_2c_spot" = {
-    instance_types    = ["m7g.2xlarge"]
+  "heimdall-2c_spot" = {
+    instance_types    = ["r7g.xlarge", "m7g.2xlarge", "r6g.xlarge"]
     availability_zone = "us-east-2c"
     capacity_type     = "SPOT"
     desired_size      = 2


### PR DESCRIPTION
Use multiple instance types in a spot nodegroup so when one type is unavailable, another type can be used.