### PR TITLE
Bump bridge-service image

### DIFF
--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -13,7 +13,7 @@ bridgeService:
   image:
     repository: planetariumhq/9c-bridge
     pullPolicy: Always
-    tag: "git-357d67484903a74c04746be934cf3e31052fdd06"
+    tag: "git-fdc30095c69070c9051965aab2df41c2633791ad"
 
 dataProvider:
   image:

--- a/9c-main/multiplanetary/network/general.yaml
+++ b/9c-main/multiplanetary/network/general.yaml
@@ -51,4 +51,4 @@ bridgeService:
   image:
     repository: planetariumhq/9c-bridge
     pullPolicy: Always
-    tag: "git-0280624704cb544efc1c73aa0360fd4958f50cd7"
+    tag: "git-fdc30095c69070c9051965aab2df41c2633791ad"


### PR DESCRIPTION
This pull request bumps the bridge-service image to allow the `unload_from_my_garages`' `memo` field `null` value.

You can see the difference here, https://github.com/planetarium/NineChronicles.Bridge/compare/0280624704cb544efc1c73aa0360fd4958f50cd7..fdc30095c69070c9051965aab2df41c2633791ad.