### PR TITLE
Bump bridge-serivce image

### DIFF
--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -13,7 +13,7 @@ bridgeService:
   image:
     repository: planetariumhq/9c-bridge
     pullPolicy: Always
-    tag: "git-7467985b018a9543e75d91b5583f749d31ff9daa"
+    tag: "git-740f8625287c8d26cd092124510195b05ae73703"
 
 dataProvider:
   image:

--- a/9c-main/multiplanetary/network/general.yaml
+++ b/9c-main/multiplanetary/network/general.yaml
@@ -51,4 +51,4 @@ bridgeService:
   image:
     repository: planetariumhq/9c-bridge
     pullPolicy: Always
-    tag: "git-7467985b018a9543e75d91b5583f749d31ff9daa"
+    tag: "git-740f8625287c8d26cd092124510195b05ae73703"


### PR DESCRIPTION
See https://github.com/planetarium/NineChronicles.Bridge/commit/740f8625287c8d26cd092124510195b05ae73703

It prevents to give too much stress to full-state node.