### PR TITLE
Introduce bridge-service-api

### DIFF
--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -15,6 +15,12 @@ bridgeService:
     pullPolicy: Always
     tag: "git-7467985b018a9543e75d91b5583f749d31ff9daa"
 
+bridgeServiceApi:
+  image:
+    repository: planetariumhq/9c-bridge-api
+    pullPolicy: Always
+    tag: "git-f6340a8acccc63942b2ee3a6c84a93a47e63085b"
+
 dataProvider:
   image:
     repository: planetariumhq/ninechronicles-dataprovider

--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -58,6 +58,9 @@ bridgeService:
       upstream: "8501520"
       downstream: "132831"
 
+bridgeServiceApi:
+  enabled: true
+
 dataProvider:
   enabled: true
   rwMode: false

--- a/charts/all-in-one/templates/bridge-service-api.yaml
+++ b/charts/all-in-one/templates/bridge-service-api.yaml
@@ -1,0 +1,63 @@
+{{ if .Values.bridgeServiceApi.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: bridge-service-api
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+  name: bridge-service-api
+  namespace: {{ $.Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bridge-service-api
+  serviceName: bridge-service-api
+  template:
+    metadata:
+      labels:
+        app: bridge-service-api
+    spec:
+      containers:
+        - env:
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                key: DATABASE_URL
+                name: bridge-env
+          image: {{ $.Values.bridgeServiceApi.image.repository }}:{{ $.Values.bridgeServiceApi.image.tag }}
+          name: bridge-service-api
+      {{- with $.Values.bridgeServiceApi.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 60
+      restartPolicy: Always
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bridge-service-api
+  namespace: {{ $.Release.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+    service.beta.kubernetes.io/aws-load-balancer-type: "external"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: Environment={{- if eq $.Values.clusterName "9c-main-v2" }}production{{- else }}development{{- end }},Team=game,Owner=dogeon,Service=bridge-service-api,Name=bridge-service-api
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+    - name: https
+      port: 443
+      targetPort: 3000
+  selector:
+    app: bridge-service-api
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+{{ end }}

--- a/charts/all-in-one/templates/secret-bridge-service-api.yaml
+++ b/charts/all-in-one/templates/secret-bridge-service-api.yaml
@@ -1,0 +1,24 @@
+{{ if .Values.bridgeServiceApi.enabled }}
+apiVersion: "external-secrets.io/v1beta1"
+kind: ExternalSecret
+metadata:
+  name: bridge-service-api
+  namespace: {{ $.Release.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: {{ $.Release.Name }}-secretsmanager
+    kind: SecretStore
+  target:
+    name: bridge-service-api
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      {{- if .Values.externalSecret.prefix }}
+      key: {{ .Values.externalSecret.prefix }}/bridge-service-api
+      {{- else }}
+      key: {{ .Values.clusterName }}/bridge-service-api
+      {{- end }}
+{{ end }}

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -612,6 +612,8 @@ bridgeService:
     enabled: false
     size: "10Gi"
 
+bridgeServiceApi:
+  enabled: false
 
 testWorldBoss:
   enabled: false


### PR DESCRIPTION
It introduces a new service named [`NineChronicels.Bridge.API`](https://github.com/planetarium/NineChronicles.Bridge.API), a normal web service, which provides APIs to access bridge events histories. I expect it to be used by users and IAP developers.