### PR TITLE
Check all multiplanetary releases in CI

### DIFF
--- a/.github/scripts/validate-charts.sh
+++ b/.github/scripts/validate-charts.sh
@@ -5,3 +5,14 @@ do
     helm lint "$chart_dir" || exit 1
     helm template "$chart_dir" | ./kubeconform -summary -skip "ExternalSecret,SecretStore,Secret" -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' || exit 1
 done
+
+# Check multiplanetary networks manually
+CLUSTERS=("9c-main" "9c-internal")
+NETWORKS=("9c-network" "heimdall" "idun")
+for cluster in "${CLUSTERS[@]}"; do
+    for network in "${NETWORKS[@]}"; do
+        helm template --values "$cluster/multiplanetary/network/$network.yaml" \
+            --values "$cluster/multiplanetary/network/general.yaml" \
+            "charts/all-in-one" | ./kubeconform -summary -skip "ExternalSecret,SecretStore,Secret" -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' || exit 1s
+    done
+done

--- a/.github/workflows/validate-chart.yaml
+++ b/.github/workflows/validate-chart.yaml
@@ -11,4 +11,4 @@ jobs:
           tar -xvzf kubeconform-linux-amd64.tar.gz
       - name: Find and Validate Charts
         run: |
-          sh .github/scripts/validate-charts.sh
+          bash .github/scripts/validate-charts.sh


### PR DESCRIPTION
In the default `values.yaml` for each chart, many services are set to `enabled: false`, and each use case will have a different set of values, resulting in a different resource manifest. We'll just temporarily add a check for the Multiplanetary networks we're currently using.