### PR TITLE
🔨 PDX-201: Enable bridge-service-api in heimdall

### DIFF
--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -19,7 +19,7 @@ bridgeServiceApi:
   image:
     repository: planetariumhq/9c-bridge-api
     pullPolicy: Always
-    tag: "git-f6340a8acccc63942b2ee3a6c84a93a47e63085b"
+    tag: "git-66993f4c7f5f83bcf7f90d4214143b4aaab7d3b4"
 
 dataProvider:
   image:

--- a/9c-main/multiplanetary/network/general.yaml
+++ b/9c-main/multiplanetary/network/general.yaml
@@ -52,3 +52,9 @@ bridgeService:
     repository: planetariumhq/9c-bridge
     pullPolicy: Always
     tag: "git-740f8625287c8d26cd092124510195b05ae73703"
+
+bridgeServiceApi:
+  image:
+    repository: planetariumhq/9c-bridge-api
+    pullPolicy: Always
+    tag: "git-66993f4c7f5f83bcf7f90d4214143b4aaab7d3b4"

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -324,6 +324,9 @@ bridgeService:
       upstream: "8521305"
       downstream: "134016"
 
+bridgeServiceApi:
+  enabled: true
+
 testHeadless1:
   enabled: true
   replicas: 2

--- a/charts/all-in-one/templates/bridge-service-api.yaml
+++ b/charts/all-in-one/templates/bridge-service-api.yaml
@@ -24,7 +24,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 key: DATABASE_URL
-                name: bridge-env
+                name: bridge-service-api
           image: {{ $.Values.bridgeServiceApi.image.repository }}:{{ $.Values.bridgeServiceApi.image.tag }}
           name: bridge-service-api
       {{- with $.Values.bridgeServiceApi.nodeSelector }}


### PR DESCRIPTION
- `/charts/all-in-one`
	- Correct bridge-service-api secret source
- heidmall-internal
	- Bump image.
- heimdall
	- Enable bridge-service-api.