### PR TITLE
📝 PDX-207: Bump bridge-service-api image

### DIFF
--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -19,7 +19,7 @@ bridgeServiceApi:
   image:
     repository: planetariumhq/9c-bridge-api
     pullPolicy: Always
-    tag: "git-66993f4c7f5f83bcf7f90d4214143b4aaab7d3b4"
+    tag: "git-c3bb6dc8357fc1e86e46ed788ff851d1239d756e"
 
 dataProvider:
   image:

--- a/9c-main/multiplanetary/network/general.yaml
+++ b/9c-main/multiplanetary/network/general.yaml
@@ -57,4 +57,4 @@ bridgeServiceApi:
   image:
     repository: planetariumhq/9c-bridge-api
     pullPolicy: Always
-    tag: "git-66993f4c7f5f83bcf7f90d4214143b4aaab7d3b4"
+    tag: "git-c3bb6dc8357fc1e86e46ed788ff851d1239d756e"


### PR DESCRIPTION
It provides a `/swagger` endpoint to provide the swagger document.

You can see the diff at https://github.com/planetarium/NineChronicles.Bridge.API/compare/66993f4c7f5f83bcf7f90d4214143b4aaab7d3b4..c3bb6dc8357fc1e86e46ed788ff851d1239d756e

![image](https://github.com/planetarium/9c-infra/assets/26626194/1acc7619-92cd-4fd2-a5b6-f47b36ded748)
