### PR TITLE
인터널 헤드리스 디버깅용 이미지 업데이트

### DIFF
--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -1,7 +1,7 @@
 global:
   image:
     repository: planetariumhq/ninechronicles-headless
-    tag: "git-3901aabccb65d1e8d311e867ec227481f554a181"
+    tag: "git-f1f8d037e99dedbefe9de59ca3f69371beedbcaf"
 
 seed:
   image:

--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -230,11 +230,11 @@ worldBoss:
     node.kubernetes.io/instance-type: m5d.xlarge
 
 testHeadless1:
-  enabled: false
+  enabled: true
   image:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
-    tag: "git-b9522002b24635475fda4b19534e3c4a43dffc3b"
+    tag: "git-f1f8d037e99dedbefe9de59ca3f69371beedbcaf"
 
   hosts:
     - "heimdall-internal-test-1.nine-chronicles.com"
@@ -259,3 +259,4 @@ testHeadless1:
 
   extraArgs:
     - --tx-quota-per-signer=1
+    - --arena-participants-sync=false


### PR DESCRIPTION
- 아레나 전체목록 갯수 파악용 로그 추가
- 캐싱 유무에 따른 비교를 위해 테스트헤드리스에선 캐싱옵션을 끄고 배포