### PR TITLE
인터널 헤드리스 업데이트

### DIFF
--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -1,7 +1,7 @@
 global:
   image:
     repository: planetariumhq/ninechronicles-headless
-    tag: "git-f1f8d037e99dedbefe9de59ca3f69371beedbcaf"
+    tag: "git-e403672215ac2f15489b218a7d8145e521b26fc5"
 
 seed:
   image:
@@ -25,7 +25,7 @@ dataProvider:
   image:
     repository: planetariumhq/ninechronicles-dataprovider
     pullPolicy: Always
-    tag: "git-740d4bbf0de25e6633c65a6db4050fd0760b05d9"
+    tag: "git-76cbb7d79ed477bf5740ec9db5367e88753285bf"
 
 worldBoss:
   image:

--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -234,7 +234,7 @@ testHeadless1:
   image:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
-    tag: "git-f1f8d037e99dedbefe9de59ca3f69371beedbcaf"
+    tag: "git-52fedb4a050d12fb5fd44e5e83c61ed4a50a9e2b"
 
   hosts:
     - "heimdall-internal-test-1.nine-chronicles.com"


### PR DESCRIPTION
- release/80 tx전파 이미지로 교체
- test-headless-1 캐싱 압축 적용