### PR TITLE
Update odin test-headless-1 for GQL testing

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -309,7 +309,7 @@ testHeadless1:
 
   image:
     repository: planetariumhq/ninechronicles-headless
-    tag: "git-663192396151d46eb54cc959c13ded9fca3da67a"
+    tag: "git-fe322126096a1785224c3c1f9b2ba46bc7ce651b"
 
   loggingEnabled: true
 


### PR DESCRIPTION
Fix for `TxResult` query. Didn't realize changes had to be made on 9c-headless side. 🙄