### PR TITLE
인터널 테스트 헤드리스 이미지 업데이트

### DIFF
--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -234,7 +234,7 @@ testHeadless1:
   image:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
-    tag: "git-52fedb4a050d12fb5fd44e5e83c61ed4a50a9e2b"
+    tag: "git-eb2598f63cc92b2700d7a222257c1ad0b9e4a76b"
 
   hosts:
     - "heimdall-internal-test-1.nine-chronicles.com"


### PR DESCRIPTION
- 메시지팩압축효율이 기대보다 낮아 캐싱용 목록을 temp 경로에 생성해서 쓰고 읽도록 처리한 테스트 이미지를 적용합니다.