### PR TITLE
Disable arena sync without rpc node

### DIFF
--- a/9c-internal/multiplanetary/network/9c-network.yaml
+++ b/9c-internal/multiplanetary/network/9c-network.yaml
@@ -77,6 +77,7 @@ validator:
   extraArgs:
   - --tx-quota-per-signer=1
   - --config=https://9c-cluster-config.s3.us-east-2.amazonaws.com/9c-internal/odin/appsettings.json
+  - --arena-participants-sync=false
 
 remoteHeadless:
   image:
@@ -154,6 +155,7 @@ explorer:
 
   extraArgs:
   - --tx-quota-per-signer=1
+  - --arena-participants-sync=false
 
 marketService:
   enabled: true

--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -1,7 +1,7 @@
 global:
   image:
     repository: planetariumhq/ninechronicles-headless
-    tag: "git-b6453d19679aa71d133dcd67c555e76324149d31"
+    tag: "git-1a376cc6c54df1650cba36b09a5a847797d52490"
 
 seed:
   image:
@@ -25,7 +25,7 @@ dataProvider:
   image:
     repository: planetariumhq/ninechronicles-dataprovider
     pullPolicy: Always
-    tag: "git-a7ee8ad8e6d56e1c4358e0ed44df6be546257a81"
+    tag: "git-c775213322ee38c021d5319f86c3bdde899f7cd2"
 
 worldBoss:
   image:

--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -230,11 +230,11 @@ worldBoss:
     node.kubernetes.io/instance-type: m5d.xlarge
 
 testHeadless1:
-  enabled: true
+  enabled: false
   image:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
-    tag: "git-baaa84c514ce41856de3dfc521f2a6ef202d46a1"
+    tag: "git-1a376cc6c54df1650cba36b09a5a847797d52490"
 
   host: "heimdall-internal-test-1.nine-chronicles.com"
 


### PR DESCRIPTION
- 메모리 사용량을 줄이기 위해 rpc노드를 제외하고 아레나 목록 동기화 워커를 비활성화하도록 처리합니다.