### PR TITLE
separate mainnet odin & heimdall versions

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -5,6 +5,11 @@ clusterName: "9c-main-v2"
 logLevel: "debug"
 
 global:
+  image:
+    repository: riemannulus/ninechronicles-headless
+    pullPolicy: Always
+    tag: "suho-20231213-04"
+
   appProtocolVersion: "200120/AB2da648b9154F2cCcAFBD85e0Bc3d51f97330Fc/MEUCIQDBpTmpmZkr1VsSwtYKKKaWSO7c2tr+kihvsmCPNvFaKgIgWtLZOpQYpFKPdOQGdc8QwqnfzRqKOBCugUT2XlrowL4=/ZHU5OnRpbWVzdGFtcHUxMDoyMDIzLTEyLTEyZQ=="
 
   validatorPath: "validator-5.9c-network.svc.cluster.local"
@@ -34,7 +39,7 @@ externalSecret:
 
 snapshot:
   slackChannel: "9c-mainnet"
-  image: "planetariumhq/ninechronicles-snapshot:git-e9fc57f2495c0d835697c3f491a93063267c0668"
+  image: "planetariumhq/ninechronicles-snapshot:git-d515403988343f7dce09d8c89e1cf278fd27c59e"
   path: "main/partition"
 
   fullSnapshot:
@@ -186,6 +191,12 @@ remoteHeadless:
 
 dataProvider:
   enabled: true
+
+  image:
+    repository: planetariumhq/ninechronicles-dataprovider
+    pullPolicy: Always
+    tag: 'git-3108fb7f5265008b69849e1f0d3d769435a052e2'
+
   rwMode: true
   render: true
 

--- a/9c-main/multiplanetary/network/general.yaml
+++ b/9c-main/multiplanetary/network/general.yaml
@@ -1,8 +1,8 @@
 global:
   image:
-    repository: riemannulus/ninechronicles-headless
+    repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
-    tag: "suho-20231213-04"
+    tag: "80"
 
 seed:
   image:


### PR DESCRIPTION
Heimdall to use official release (https://github.com/planetarium/NineChronicles.Headless/tree/80) and Odin to use reverted version(https://github.com/planetarium/NineChronicles.Headless/tree/test-4) along with adjusted DP and snapshot images.