### PR TITLE
Remove updateStrategy from Deployment

### DIFF
--- a/.github/scripts/validate-charts.sh
+++ b/.github/scripts/validate-charts.sh
@@ -3,7 +3,7 @@ do
     chart_dir=$(dirname "$dir")
     echo "Validating $chart_dir..."
     helm lint "$chart_dir" || exit 1
-    helm template "$chart_dir" | ./kubeconform -summary -skip "ExternalSecret,SecretStore,Secret" -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' || exit 1
+    helm template "$chart_dir" | ./kubeconform -strict -summary -skip "ExternalSecret,SecretStore,Secret" -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' || exit 1
 done
 
 # Check multiplanetary networks manually
@@ -13,6 +13,6 @@ for cluster in "${CLUSTERS[@]}"; do
     for network in "${NETWORKS[@]}"; do
         helm template --values "$cluster/multiplanetary/network/$network.yaml" \
             --values "$cluster/multiplanetary/network/general.yaml" \
-            "charts/all-in-one" | ./kubeconform -summary -skip "ExternalSecret,SecretStore,Secret" -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' || exit 1s
+            "charts/all-in-one" | ./kubeconform -strict -summary -skip "ExternalSecret,SecretStore,Secret" -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' || exit 1s
     done
 done

--- a/charts/all-in-one/templates/block-interval-notifier.yaml
+++ b/charts/all-in-one/templates/block-interval-notifier.yaml
@@ -35,6 +35,4 @@ spec:
                   name: slack
                   key: slack-webhook-url
           restartPolicy: OnFailure
-  successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 1
 {{ end }}

--- a/charts/all-in-one/templates/bridge-service-api.yaml
+++ b/charts/all-in-one/templates/bridge-service-api.yaml
@@ -12,7 +12,6 @@ spec:
   selector:
     matchLabels:
       app: bridge-service-api
-  serviceName: bridge-service-api
   template:
     metadata:
       labels:

--- a/charts/all-in-one/templates/bridge-service-api.yaml
+++ b/charts/all-in-one/templates/bridge-service-api.yaml
@@ -33,8 +33,6 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: 60
       restartPolicy: Always
-  updateStrategy:
-    type: RollingUpdate
 ---
 apiVersion: v1
 kind: Service

--- a/charts/all-in-one/templates/rudolf-currency-notifier.yaml
+++ b/charts/all-in-one/templates/rudolf-currency-notifier.yaml
@@ -32,7 +32,7 @@ spec:
             volumeMounts:
             - mountPath: /bin/rudolf-currency-notifier.js
               name: rudolf-currency-notifier
-              readonly: true
+              readOnly: true
               subPath: rudolf-currency-notifier.js
           restartPolicy: OnFailure
           volumes:

--- a/charts/all-in-one/templates/snapshot-full.yaml
+++ b/charts/all-in-one/templates/snapshot-full.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: {{ $.Release.Name }}
 spec:
-  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:

--- a/charts/all-in-one/templates/snapshot-partition-reset.yaml
+++ b/charts/all-in-one/templates/snapshot-partition-reset.yaml
@@ -7,7 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: {{ $.Release.Name }}
 spec:
-  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:

--- a/charts/all-in-one/templates/snapshot-partition.yaml
+++ b/charts/all-in-one/templates/snapshot-partition.yaml
@@ -5,7 +5,6 @@ metadata:
   name: snapshot-partition
   namespace: {{ $.Release.Name }}
 spec:
-  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:

--- a/charts/snapshot/templates/snapshot-full.yaml
+++ b/charts/snapshot/templates/snapshot-full.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
-  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:
@@ -28,7 +27,7 @@ spec:
                   name: slack
                   key: slack-webhook-url
             resources:
-              {{- toYaml . | nindent 14 }}
+              {{- toYaml .Values.resources | nindent 14 }}
             volumeMounts:
             - name: script-volume
               mountPath: /bin/preload_headless.sh

--- a/charts/snapshot/templates/snapshot-partition-reset.yaml
+++ b/charts/snapshot/templates/snapshot-partition-reset.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: {{ $.Chart.Name }}
 spec:
-  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:

--- a/charts/snapshot/templates/snapshot-partition.yaml
+++ b/charts/snapshot/templates/snapshot-partition.yaml
@@ -4,7 +4,6 @@ metadata:
   name: snapshot-partition
   namespace: {{ $.Values.namespace }}
 spec:
-  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
A coworker told me that after applying bridge-service-api several times, the updateStrategy part still showed up as a diff. This is because updateStrategy is not a value in the Deployment spec. I was able to check this in kubeconform by giving it the `-strict` option. I've found issues elsewhere as well, and will post them along with the fixes.