### PR TITLE
Update start block index for bridge-service

### DIFF
--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -59,8 +59,8 @@ bridgeService:
   rdb:
     enabled: true
     defaultStartBlockIndex:
-      upstream: "8569731"
-      downstream: "190562"
+      upstream: "8873874"
+      downstream: "494671"
 
 bridgeServiceApi:
   enabled: true


### PR DESCRIPTION
I fetched the indexes from https://snapshots.nine-chronicles.com/internal/latest.json and https://snapshots.nine-chronicles.com/internal/heimdall/latest.json.