### PR TITLE
Disable rudolf-currency-notifier in odin-internal

### DIFF
--- a/9c-internal/multiplanetary/network/9c-network.yaml
+++ b/9c-internal/multiplanetary/network/9c-network.yaml
@@ -218,7 +218,7 @@ rudolfService:
     - "sg-0343e5c4514681670"
 
 rudolfCurrencyNotifier:
-  enabled: true
+  enabled: false
 
   config:
     schedule: "0 0 * * *"


### PR DESCRIPTION
Since there are no assets on the target address in odin-internal, I disabled the notifier to reduce noise.