### PR TITLE
customize nodeSelector for rudolfCurrencyNotifier

### DIFF
--- a/9c-internal/multiplanetary/network/9c-network.yaml
+++ b/9c-internal/multiplanetary/network/9c-network.yaml
@@ -226,6 +226,9 @@ rudolfCurrencyNotifier:
     targetAddress: "0xB5AF28837b28A9C768e9849d90646E3D6078311c"
     serverName: "9c-internal"
 
+  nodeSelector:
+    node.kubernetes.io/instance-type: m5d.xlarge
+
 volumeRotator:
   enabled: true
 

--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -539,6 +539,9 @@ rudolfCurrencyNotifier:
     graphqlEndpoint: "https://9c-main-full-state.nine-chronicles.com/graphql"
     targetAddress: "0x4c35e816c9e13628615581a436a0df38F57A08cc"
     serverName: "odin"
+  
+  nodeSelector:
+    eks.amazonaws.com/nodegroup: 9c-main-m5_l_2c
 
 testWorldBoss:
   enabled: false

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -582,6 +582,9 @@ rudolfCurrencyNotifier:
     graphqlEndpoint: "https://heimdall-full-state.nine-chronicles.com/graphql"
     targetAddress: "0xec48c68198dA91e89d6CA4eff93C23441e167358"
     serverName: "heimdall"
+  
+  nodeSelector:
+      eks.amazonaws.com/nodegroup: heimdall-m5_l_2c
 
 guildService:
   enabled: false

--- a/charts/all-in-one/templates/rudolf-currency-notifier.yaml
+++ b/charts/all-in-one/templates/rudolf-currency-notifier.yaml
@@ -38,8 +38,10 @@ spec:
               name: rudolf-currency-notifier
               readOnly: true
               subPath: rudolf-currency-notifier.ts
+          {{- with $.Values.rudolfCurrencyNotifier.nodeSelector }}
           nodeSelector:
-            node.kubernetes.io/instance-type: m5d.xlarge
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
           restartPolicy: OnFailure
           volumes:
           - name: rudolf-currency-notifier


### PR DESCRIPTION
Current configuration doesn't work in mainnet odin and heimdall because they do not have an m5d.xlarge instance type.