### PR TITLE
Add 9cutil-backend service

### DIFF
--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -592,3 +592,13 @@ guildService:
   db:
     local: false
     size: "10Gi"
+
+
+ninechroniclesUtilBackend:
+  enabled: true
+
+  image:
+    repository: planetariumhq/9cutil-backend
+    tag: git-17b9c812e11630d8b9c3d451ecfd0b74b235d31f
+  
+  headlessEndpoint: "https://heimdall-full-state.nine-chronicles.com/graphql"

--- a/charts/all-in-one/templates/ninechronicles-util-backend.yaml
+++ b/charts/all-in-one/templates/ninechronicles-util-backend.yaml
@@ -1,0 +1,59 @@
+{{ if .Values.ninechroniclesUtilBackend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ninechronicles-util-backend
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+  name: ninechronicles-util-backend
+  namespace: {{ $.Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ninechronicles-util-backend
+  template:
+    metadata:
+      labels:
+        app: ninechronicles-util-backend
+    spec:
+      containers:
+        - image: {{ $.Values.ninechroniclesUtilBackend.image.repository }}:{{ $.Values.ninechroniclesUtilBackend.image.tag }}
+          name: ninechronicles-util-backend
+          env:
+            - name: StateService__HeadlessEndpoint
+              value: {{ $.Values.ninechroniclesUtilBackend.headlessEndpoint }}
+            - name: ASPNETCORE_URLS
+              value: http://*:3000
+      {{- with $.Values.ninechroniclesUtilBackend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 60
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ninechronicles-util-backend
+  namespace: {{ $.Release.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+    service.beta.kubernetes.io/aws-load-balancer-type: "external"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: Environment={{- if eq $.Values.clusterName "9c-main-v2" }}production{{- else }}development{{- end }},Team=game,Owner=dogeon,Service=ninechronicles-util-backend,Name=ninechronicles-util-backend
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+    - name: https
+      port: 443
+      targetPort: 3000
+  selector:
+    app: ninechronicles-util-backend
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+{{ end }}

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -684,3 +684,6 @@ testWorldBoss:
     sentryDsn: ""
 
   nodeSelector: {}
+
+ninechroniclesUtilBackend:
+  enabled: false


### PR DESCRIPTION
I added https://github.com/planetarium/9cutil-backend to the all-in-one chart to bring up the project. This is the backend service required to create mods for the DX Team. There was a suggestion to add it to ECS, but due to lack of personal skills, we decided to run it on EKS Cluster due to work priorities. It may be rolled back to move it to ECS after talking to the team.