### PR TITLE
Update 9cutil-backend image

### DIFF
--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -599,6 +599,6 @@ ninechroniclesUtilBackend:
 
   image:
     repository: planetariumhq/9cutil-backend
-    tag: git-17b9c812e11630d8b9c3d451ecfd0b74b235d31f
+    tag: git-29bd49051cca9a11ca4684f1f16ca3ebafde34e1
   
   headlessEndpoint: "https://heimdall-full-state.nine-chronicles.com/graphql"


### PR DESCRIPTION
In my last PR, I confidently said that I supported both arm64 and amd64, but I was not able to use it properly because it supported arm/v8 instead of arm64. Update with a docker image that fixes this issue.