### PR TITLE
Make reset-bridge-service workflow update blockindex as string type

### DIFF
--- a/scripts/app/update_bridge_service.py
+++ b/scripts/app/update_bridge_service.py
@@ -107,7 +107,7 @@ def update_upstream_index(contents: str, tip_index: str):
             for key, value in data.items():
                 if key == "defaultStartBlockIndex":
                     if "upstream" in data[key]:
-                        data[key]["upstream"] = tip_index
+                        data[key]["upstream"] = str(tip_index)
                 else:
                     update_index_recursively(value)
         elif isinstance(data, list):


### PR DESCRIPTION
Fixing Helm might be a better option, but this is what we did for now.