### PR TITLE
Correct 9cutil-backend image tag

### DIFF
--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -598,7 +598,7 @@ ninechroniclesUtilBackend:
 
   image:
     repository: planetariumhq/9cutil-backend
-    tag: git-c788d2c64d664e5d4e150f6f9e8f81fed9ea4f9d
+    tag: git-a90defd240cc9d468130cd391c0195e6fb66cd64
 
   headlessEndpoint: "http://main-full-state.heimdall.svc.cluster.local/graphql"
   dataProviderEndpoint: "http://heimdall-dp.9c.gg/graphql"


### PR DESCRIPTION
There is no image with `git-c788d2c64d664e5d4e150f6f9e8f81fed9ea4f9d` tag.