### PR TITLE
Support 'public' option to expose rudolf-service

### DIFF
--- a/9c-dev/9c-odin-libplanet4-test-20240104/values.yaml
+++ b/9c-dev/9c-odin-libplanet4-test-20240104/values.yaml
@@ -229,6 +229,4 @@ rudolfService:
 
   service:
     enabled: true
-    securityGroupIds:
-    - "sg-0c865006315f5b9f0"
-    - "sg-0343e5c4514681670"
+    public: true

--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -76,6 +76,9 @@ metadata:
   labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
   annotations:
+    {{- if .Values.rudolfService.service.public }}
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+    {{- end }}
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
     {{- if .Values.rudolfService.service.securityGroupIds }}
     service.beta.kubernetes.io/aws-load-balancer-security-groups: {{ join "," .Values.rudolfService.service.securityGroupIds }}

--- a/charts/all-in-one/values.schema.json
+++ b/charts/all-in-one/values.schema.json
@@ -88,6 +88,10 @@
                     },
                     "uniqueItems": true,
                     "description": "Security Group Ids array to assign to the ELB resource."
+                  },
+                  "public": {
+                    "type": "boolean",
+                    "description": "Expose the service to the public."
                   }
                 },
                 "additionalProperties": false,

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -602,6 +602,7 @@ rudolfService:
 
   service:
     enabled: false
+    public: false
 
   nodeSelector: {}
 


### PR DESCRIPTION
- It begins to support `rudolfService.service.public` property to expose rudolf service if users want.
  - - Expose rudolf-service's endpoint in `9c-dev/9c-odin-libplanet4-test-20240104` network.
- Remove security groups from `9c-dev/9c-odin-libplanet4-test-20240104` network.