### PR TITLE
use snapshot path as an env

### DIFF
--- a/9c-dev/9c-odin-libplanet4-test-20240104/values.yaml
+++ b/9c-dev/9c-odin-libplanet4-test-20240104/values.yaml
@@ -35,9 +35,8 @@ snapshot:
   slackChannel: "9c-internal"
   image: "planetariumhq/ninechronicles-snapshot:git-5045cdd4b11d8ce880bd44f8feb5c2014da330a1"
   partition:
-    enabled: true
-    suspend: true
-  path: 9c-dev-v2
+    enabled: false
+  path: 9c-internal
   nodeSelector:
     eks.amazonaws.com/nodegroup: general-m7g_2xl_2c
 

--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -43,7 +43,7 @@ snapshot:
     suspend: false
 
   partitionReset:
-    enabled: true
+    enabled: false
 
   partition:
     enabled: true

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -42,7 +42,7 @@ snapshot:
     suspend: false
 
   partitionReset:
-    enabled: true
+    enabled: false
 
   partition:
     enabled: true

--- a/charts/all-in-one/scripts/snapshots/partition/upload_snapshot.sh
+++ b/charts/all-in-one/scripts/snapshots/partition/upload_snapshot.sh
@@ -24,10 +24,11 @@ APP_PROTOCOL_VERSION=$1
 VERSION_NUMBER="${APP_PROTOCOL_VERSION:0:6}"
 SLACK_WEBHOOK=$2
 CF_DISTRIBUTION_ID=$3
+SNAPSHOT_PATH=$4
 
 function senderr() {
   echo "$1"
-  curl -X POST -H 'Content-type: application/json' --data '{"text":"[K8S] '$1'. Check snapshot in {{ $.Values.clusterName }} cluster at upload_snapshot.sh."}' $2
+  curl -X POST -H 'Content-type: application/json' --data '{"text":"[K8S] '$1'. Check snapshot in {{ $.Values.clusterName }} cluster at upload_snapshot.sh."}' $SLACK_WEBHOOK
 }
 
 function make_and_upload_snapshot() {
@@ -47,7 +48,7 @@ function make_and_upload_snapshot() {
   fi
 
   if ! "$SNAPSHOT" --output-directory "$OUTPUT_DIR" --store-path "$STORE_PATH"  --block-before 0 --apv "$1" --snapshot-type "partition"; then
-    senderr "Snapshot creation failed."
+    senderr "Snapshot creation failed." "$SLACK_WEBHOOK"
     exit 1
   fi
 
@@ -147,4 +148,4 @@ function invalidate_cf() {
 
 trap '' HUP
 
-make_and_upload_snapshot $1
+make_and_upload_snapshot "$APP_PROTOCOL_VERSION" "$SNAPSHOT_PATH"

--- a/charts/all-in-one/templates/snapshot-full.yaml
+++ b/charts/all-in-one/templates/snapshot-full.yaml
@@ -49,7 +49,7 @@ spec:
             - $(APP_PROTOCOL_VERSION_KEY)
             - $(SLACK_WEBHOOK_URL)
             - $(CF_DISTRIBUTION_ID)
-            - $(SLACK_TOKEN)
+            - {{ $.Values.snapshot.path }}
             command:
             - /bin/upload_snapshot.sh
             env:

--- a/charts/all-in-one/templates/snapshot-partition-reset.yaml
+++ b/charts/all-in-one/templates/snapshot-partition-reset.yaml
@@ -49,7 +49,7 @@ spec:
             - $(APP_PROTOCOL_VERSION_KEY)
             - $(SLACK_WEBHOOK_URL)
             - $(CF_DISTRIBUTION_ID)
-            - $(SLACK_TOKEN)
+            - {{ $.Values.snapshot.path }}
             command:
             - /bin/upload_snapshot.sh
             env:

--- a/charts/all-in-one/templates/snapshot-partition.yaml
+++ b/charts/all-in-one/templates/snapshot-partition.yaml
@@ -82,7 +82,7 @@ spec:
             - $(APP_PROTOCOL_VERSION_KEY)
             - $(SLACK_WEBHOOK_URL)
             - $(CF_DISTRIBUTION_ID)
-            - $(SLACK_TOKEN)
+            - {{ $.Values.snapshot.path }}
             command:
             - /bin/upload_snapshot.sh
             env:


### PR DESCRIPTION
Modify the snapshot scripts to accept {{ $.Values.snapshot.path }} as a variable, instead of hardcoding it directly into the manifest file.