### PR TITLE
update validator nodegroup

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -127,7 +127,12 @@ validator:
     value: validator-test
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-main-r7g_xl_2c_validator
+    eks.amazonaws.com/nodegroup: 9c-main-m7g_2xl_2c_validator
+
+  resources:
+    requests:
+      cpu: '6'
+      memory: 25Gi
 
 remoteHeadless:
   count: 3

--- a/terraform/environments/main/main.tf
+++ b/terraform/environments/main/main.tf
@@ -126,8 +126,8 @@ module "common" {
       instance_types    = ["r7g.xlarge"]
       availability_zone = "us-east-2c"
       capacity_type     = "ON_DEMAND"
-      desired_size      = 4
-      min_size          = 4
+      desired_size      = 0
+      min_size          = 0
       max_size          = 10
       ami_type          = "AL2_ARM_64"
       disk_size         = 50
@@ -142,8 +142,8 @@ module "common" {
       instance_types    = ["m7g.2xlarge"]
       availability_zone = "us-east-2c"
       capacity_type     = "ON_DEMAND"
-      desired_size      = 0
-      min_size          = 0
+      desired_size      = 4
+      min_size          = 4
       max_size          = 10
       ami_type          = "AL2_ARM_64"
       disk_size         = 50


### PR DESCRIPTION
`r7g.xl` => `m7g.2xl` (odin validator's action evaluation time is too slow).