### PR TITLE
increase internal validator tx-life-time

### DIFF
--- a/9c-internal/multiplanetary/network/9c-network.yaml
+++ b/9c-internal/multiplanetary/network/9c-network.yaml
@@ -91,6 +91,7 @@ validator:
   extraArgs:
   - --tx-quota-per-signer=1
   - --arena-participants-sync=false
+  - --tx-life-time=2000000000
   - --planet=OdinInternal
 
 remoteHeadless:

--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -224,6 +224,7 @@ validator:
   loggingEnabled: true
 
   extraArgs:
+  - --tx-life-time=2000000000
   - --planet=HeimdallInternal
 
 worldBoss:


### PR DESCRIPTION
This update is for importing mainnet tx to the internal network.