### PR TITLE
fix validator tx-lifetime customization

### DIFF
--- a/charts/all-in-one/templates/validator.yaml
+++ b/charts/all-in-one/templates/validator.yaml
@@ -100,8 +100,8 @@ spec:
         {{- end }}
         {{- if eq $.Values.global.networkType "Main"  }}
         - --network-type={{ $.Values.global.networkType }}
-        {{- end }}
         - --tx-life-time=10
+        {{- end }}
         {{- if $.Values.global.headlessAppsettingsPath }}
         - --config={{ $.Values.global.headlessAppsettingsPath }}
         {{- end }}


### PR DESCRIPTION
Only hardcode `- --tx-life-time=10` when the network-type is `Main`.