### PR TITLE
update mainnet snapshot nodegroup

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -59,11 +59,11 @@ snapshot:
 
   resources:
     requests:
-      cpu: '2'
-      memory: 20Gi
+      cpu: '5'
+      memory: 50Gi
 
   nodeSelector:
-    node.kubernetes.io/instance-type: r6g.xlarge
+    eks.amazonaws.com/nodegroup: 9c-main-r7g_2xl_2c
 
 # if you want to delete PVC with the volume provisioned together, set this value "Delete"
 volumeReclaimPolicy: "Retain"

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -58,11 +58,11 @@ snapshot:
 
   resources:
     requests:
-      cpu: '2'
-      memory: 20Gi
+      cpu: '5'
+      memory: 50Gi
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: heimdall-r7g_xl_2c
+    eks.amazonaws.com/nodegroup: heimdall-r7g_2xl_2c
 
 # if you want to delete PVC with the volume provisioned together, set this value "Delete"
 volumeReclaimPolicy: "Retain"

--- a/terraform/environments/main/main.tf
+++ b/terraform/environments/main/main.tf
@@ -106,6 +106,17 @@ module "common" {
       }]
     }
 
+    "9c-main-r7g_2xl_2c" = {
+      instance_types    = ["r7g.2xlarge"]
+      availability_zone = "us-east-2c"
+      capacity_type     = "ON_DEMAND"
+      desired_size      = 0
+      min_size          = 0
+      max_size          = 10
+      ami_type          = "AL2_ARM_64"
+      disk_size         = 50
+    }
+
     "9c-main-c7g_4xl_2c_test" = {
       instance_types    = ["c7g.4xlarge"]
       availability_zone = "us-east-2c"
@@ -248,6 +259,17 @@ module "common" {
         value  = "remote-headless-test"
         effect = "NO_SCHEDULE"
       }]
+    }
+
+    "heimdall-r7g_2xl_2c" = {
+      instance_types    = ["r7g.2xlarge"]
+      availability_zone = "us-east-2c"
+      capacity_type     = "ON_DEMAND"
+      desired_size      = 0
+      min_size          = 0
+      max_size          = 10
+      ami_type          = "AL2_ARM_64"
+      disk_size         = 50
     }
 
     "heimdall-m7g_2xl_2c_validator" = {


### PR DESCRIPTION
Upgrade mainnet snapshot instance type from `r7g.xl` => `r7g.2xl` because `OOMKilled` events often occur during preloading stages after the v200140 update.