### PR TITLE
update heimdall rpc nodegroup

### DIFF
--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -231,11 +231,11 @@ remoteHeadless:
   - --tx-quota-per-signer=1
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: heimdall-r7g_2xl_2c_test
+    eks.amazonaws.com/nodegroup: heimdall-m7g_4xl_2c_test
 
   resources:
     requests:
-      cpu: '6'
+      cpu: '10'
       memory: 50Gi
 
   tolerations:

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -235,7 +235,7 @@ remoteHeadless:
 
   resources:
     requests:
-      cpu: '10'
+      cpu: '12'
       memory: 50Gi
 
   tolerations:

--- a/terraform/environments/main/main.tf
+++ b/terraform/environments/main/main.tf
@@ -249,6 +249,22 @@ module "common" {
       instance_types    = ["r7g.2xlarge"]
       availability_zone = "us-east-2c"
       capacity_type     = "ON_DEMAND"
+      desired_size      = 0
+      min_size          = 0
+      max_size          = 15
+      ami_type          = "AL2_ARM_64"
+      disk_size         = 50
+      taints = [{
+        key    = "dedicated"
+        value  = "remote-headless-test"
+        effect = "NO_SCHEDULE"
+      }]
+    }
+
+    "heimdall-m7g_4xl_2c_test" = {
+      instance_types    = ["m7g.4xlarge"]
+      availability_zone = "us-east-2c"
+      capacity_type     = "ON_DEMAND"
       desired_size      = 3
       min_size          = 3
       max_size          = 15


### PR DESCRIPTION
heimdall nodes cpu usage is too high and keeps restarting. Upgrade instance type from r7g.2xlarge(8CPU, 64GB RAM) to m7g.4xlarge(16CPU, 64GB RAM).