### PR TITLE
increase odin interval

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -117,7 +117,7 @@ validator:
   extraArgs:
   - --tx-quota-per-signer=1
   - --tx-life-time=10
-  - --consensus-target-block-interval=5000
+  - --consensus-target-block-interval=6000
 
   consensusSeedStrings:
   - "027bd36895d68681290e570692ad3736750ceaab37be402442ffb203967f98f7b6,9c-main-tcp-seed-1.planetarium.dev,31235"


### PR DESCRIPTION
After updating odin validator from `r7g.xl` to `m7g.2xl`, the eval time has significantly improved and so the delay interval no longer needs to be 5 secs.