### PR TITLE
mothership: fix node rpc url defaulting node-0

### DIFF
--- a/charts/mothership/templates/blockscout.yaml
+++ b/charts/mothership/templates/blockscout.yaml
@@ -61,9 +61,9 @@ spec:
             - name: EMISSION_FORMAT
               value: DEFAULT
             - name: ETHEREUM_JSONRPC_HTTP_URL
-              value: http://node:{{ .Values.node.opGeth.port.rpc }}/
+              value: http://node-0:{{ .Values.node.opGeth.port.rpc }}/
             - name: ETHEREUM_JSONRPC_TRACE_URL
-              value: http://node:{{ .Values.node.opGeth.port.rpc }}/
+              value: http://node-0:{{ .Values.node.opGeth.port.rpc }}/
             - name: ETHEREUM_JSONRPC_VARIANT
               value: geth
             - name: EXTERNAL_APPS

--- a/charts/mothership/templates/op-batcher.yaml
+++ b/charts/mothership/templates/op-batcher.yaml
@@ -24,8 +24,8 @@ spec:
               op-batcher \
                 --private-key=$(BATCHER_KEY) \
                 --l1-eth-rpc=$(L1_RPC) \
-                --l2-eth-rpc=http://node:{{ .Values.node.opGeth.port.rpc }} \
-                --rollup-rpc=http://node:{{ .Values.node.opNode.port.rpc }} \
+                --l2-eth-rpc=http://node-0:{{ .Values.node.opGeth.port.rpc }} \
+                --rollup-rpc=http://node-0:{{ .Values.node.opNode.port.rpc }} \
                 --rpc.port={{ .Values.opBatcher.port.rpc }} \
                 --rpc.addr=0.0.0.0 \
                 --rpc.enable-admin \

--- a/charts/mothership/templates/op-proposer.yaml
+++ b/charts/mothership/templates/op-proposer.yaml
@@ -40,7 +40,7 @@ spec:
               op-proposer \
                 --private-key=$(PROPOSER_KEY) \
                 --l1-eth-rpc=$(L1_RPC) \
-                --rollup-rpc=http://node:{{ .Values.node.opNode.port.rpc }} \
+                --rollup-rpc=http://node-0:{{ .Values.node.opNode.port.rpc }} \
                 --rpc.port={{ .Values.opProposer.port.rpc }} \
                 --l2oo-address=$(cat /genesis/L2OutputOracleProxyAddress) \
                 --poll-interval=12s


### PR DESCRIPTION
service name changed from node to node-n in #1503 