### PR TITLE
update rpc nodegroup

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -189,17 +189,19 @@ remoteHeadless:
     value: "redis"
   - name: Headless__AccessControlService__AccessControlServiceConnectionString
     value: "acc-redis-service.9c-network.svc.cluster.local:6379"
+  - name: DOTNET_gcServer
+    value: "1"
 
   extraArgs:
   - --tx-quota-per-signer=1
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-main-r7g_2xl_2c_test
+    eks.amazonaws.com/nodegroup: 9c-main-m7g_2xl_2c_test
 
   resources:
     requests:
-      cpu: '6'
-      memory: 50Gi
+      cpu: '5'
+      memory: 28Gi
 
   tolerations:
   - effect: NoSchedule

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -223,17 +223,19 @@ remoteHeadless:
     value: "redis"
   - name: Headless__AccessControlService__AccessControlServiceConnectionString
     value: "acc-redis-service.heimdall.svc.cluster.local:6379"
+  - name: DOTNET_gcServer
+    value: "1"
 
   extraArgs:
   - --tx-quota-per-signer=1
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: heimdall-r7g_2xl_2c_test
+    eks.amazonaws.com/nodegroup: heimdall-m7g_2xl_2c_test
 
   resources:
     requests:
-      cpu: '6'
-      memory: 50Gi
+      cpu: '5'
+      memory: 28Gi
 
   tolerations:
   - effect: NoSchedule
@@ -262,12 +264,12 @@ dataProvider:
   render: true
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: heimdall-r7g_2xl_2c
+    eks.amazonaws.com/nodegroup: heimdall-r7g_xl_2c
 
   resources:
     requests:
-      cpu: '6'
-      memory: 50Gi
+      cpu: '3'
+      memory: 26Gi
 
 explorer:
   enabled: false

--- a/terraform/environments/main/main.tf
+++ b/terraform/environments/main/main.tf
@@ -78,8 +78,8 @@ module "common" {
       instance_types    = ["m7g.2xlarge"]
       availability_zone = "us-east-2c"
       capacity_type     = "ON_DEMAND"
-      desired_size      = 1
-      min_size          = 1
+      desired_size      = 4
+      min_size          = 4
       max_size          = 15
       ami_type          = "AL2_ARM_64"
       disk_size         = 50
@@ -94,8 +94,8 @@ module "common" {
       instance_types    = ["r7g.2xlarge"]
       availability_zone = "us-east-2c"
       capacity_type     = "ON_DEMAND"
-      desired_size      = 3
-      min_size          = 3
+      desired_size      = 0
+      min_size          = 0
       max_size          = 15
       ami_type          = "AL2_ARM_64"
       disk_size         = 50
@@ -233,8 +233,8 @@ module "common" {
       instance_types    = ["m7g.2xlarge"]
       availability_zone = "us-east-2c"
       capacity_type     = "ON_DEMAND"
-      desired_size      = 1
-      min_size          = 1
+      desired_size      = 6
+      min_size          = 6
       max_size          = 15
       ami_type          = "AL2_ARM_64"
       disk_size         = 50
@@ -249,8 +249,8 @@ module "common" {
       instance_types    = ["r7g.2xlarge"]
       availability_zone = "us-east-2c"
       capacity_type     = "ON_DEMAND"
-      desired_size      = 5
-      min_size          = 5
+      desired_size      = 0
+      min_size          = 0
       max_size          = 15
       ami_type          = "AL2_ARM_64"
       disk_size         = 50


### PR DESCRIPTION
Enable `DOTNET_gcServer` and update rpc nodegroup to `m7g.2xl` instance type.