### PR TITLE
update heimdall snapshot nodegroup

### DIFF
--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -58,11 +58,11 @@ snapshot:
 
   resources:
     requests:
-      cpu: '5'
-      memory: 50Gi
+      cpu: '3'
+      memory: 28Gi
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: heimdall-r7g_2xl_2c
+    eks.amazonaws.com/nodegroup: heimdall-r7g_xl_2c
 
 # if you want to delete PVC with the volume provisioned together, set this value "Delete"
 volumeReclaimPolicy: "Retain"


### PR DESCRIPTION
heimdall snapshot nodes no longer need to use `r7g.2xl`.