### PR TITLE
slightly fix mypy/pip errors in scripts

### DIFF
--- a/scripts/app/test_internal_chain.py
+++ b/scripts/app/test_internal_chain.py
@@ -8,10 +8,10 @@ from urllib.parse import urljoin
 from app.client import GithubClient
 from app.config import config
 
-Network = "odin-internal"
-Offset = 0
-Limit = 10
-Delay = 0
+Network = str
+Offset = int
+Limit = int
+Delay = int
 
 class InternalChainTester:
     def __init__(self) -> None:

--- a/scripts/app/update_apv.py
+++ b/scripts/app/update_apv.py
@@ -111,7 +111,7 @@ class ApvUpdater:
 
 def update_apv(contents: str, apv: Apv):
     yaml = YAML()
-    yaml.preserve_quotes = True  # type:ignore
+    yaml.preserve_quotes = True
     doc = yaml.load(contents)
 
     doc["global"]["appProtocolVersion"] = apv.raw

--- a/scripts/app/update_bridge_service.py
+++ b/scripts/app/update_bridge_service.py
@@ -1,6 +1,6 @@
 from tempfile import TemporaryFile
 from time import time
-from typing import List, Literal, NamedTuple
+from typing import Tuple, Literal
 
 import structlog
 import requests
@@ -131,7 +131,7 @@ def update_index(contents: str, stream: Literal["upstream", "downstream"], tip_i
                 update_index_recursively(item)
 
     yaml = YAML()
-    yaml.preserve_quotes = True  # type:ignore
+    yaml.preserve_quotes = True
     doc = yaml.load(contents)
     update_index_recursively(doc)
 
@@ -143,7 +143,7 @@ def update_index(contents: str, stream: Literal["upstream", "downstream"], tip_i
     return new_doc
 
 
-def get_endpoint_pair(network: Network, planet: Planet) -> (str, str):
+def get_endpoint_pair(network: Network, planet: Planet) -> Tuple[str, str]:
     match (network, planet):
         case ("9c-internal", "heimdall"):
             return (GQL_ENDPOINTS["9c-internal"]["odin"], GQL_ENDPOINTS["9c-internal"]["heimdall"])

--- a/scripts/app/update_values.py
+++ b/scripts/app/update_values.py
@@ -139,7 +139,7 @@ def update_image_tag(contents: str, *, manifest_key: str, repo_to_change: str, t
                 update_tag_recursively(item)
 
     yaml = YAML()
-    yaml.preserve_quotes = True  # type:ignore
+    yaml.preserve_quotes = True
     doc = yaml.load(contents)
     update_tag_recursively(doc)
 

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -28,24 +28,6 @@ def update_values(
     ValuesFileUpdater().update(file_path_at_github, sources)
 
 @k8s_app.command()
-def update_apv(
-    number: int,
-    dir_name: str = typer.Argument(
-        ...,
-        help="9c-internal or 9c-main",
-    ),
-    file_name: str = typer.Argument(
-        ...,
-        help="general, odin, heimdall, ...",
-    ),
-):
-    """
-    Run post deploy script
-    """
-
-    ApvUpdater().update(number, dir_name, file_name)  # type:ignore
-
-@k8s_app.command()
 def update_bridge_service(
     dir_name: str = typer.Argument(
         ...,
@@ -82,7 +64,7 @@ def test_internal_chain(
     Run post deploy script
     """
 
-    InternalChainTester().test(network, offset, limit, delay_interval)  # type:ignore
+    InternalChainTester().test(network, offset, limit, delay_interval)
 
 @k8s_app.command()
 def update_apv(
@@ -100,7 +82,7 @@ def update_apv(
     Run post deploy script
     """
 
-    ApvUpdater().update(number, dir_name, file_name)  # type:ignore
+    ApvUpdater().update(number, dir_name, file_name)
 
 @k8s_app.command()
 def update_paev(
@@ -118,7 +100,7 @@ def update_paev(
     Run post deploy script
     """
 
-    PluggableActionEvaluatorUpdater().update(paev_url, end_value, lib9c_plugin_url)  # type:ignore
+    PluggableActionEvaluatorUpdater().update(paev_url, end_value, lib9c_plugin_url)
 
 if __name__ == "__main__":
     k8s_app()

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "structlog >=16.1,<22.1",
     "boto3 ~=1.24",
     "PyYAML ==6.0",
-    "requests ==2.26.0",
+    "requests ==2.31.0",
     "typer[all] ~=0.6.1",
     "python-dotenv ~=0.19",
     "ruamel.yaml ~=0.17.21"


### PR DESCRIPTION
Supressing some errors from mypy lint/typechecking and pip installed dependencies.
Might be better to unify Network, Planet, whatever etc.. any literal types for further work
(there's still type:ignore exists for BridgeServiceUpdater which is typed properly, should narrow the types with args assertions to ditch out the type:ignore comments)