### PR TITLE
Make test-headless-1 image tag overiddable

### DIFF
--- a/charts/all-in-one/templates/test-headless-1.yaml
+++ b/charts/all-in-one/templates/test-headless-1.yaml
@@ -65,11 +65,7 @@ spec:
         {{- end }}
         command:
         - dotnet
-        {{- if and $.Values.testHeadless1.image.repository $.Values.testHeadless1.image.tag }}
-        image: {{ $.Values.testHeadless1.image.repository }}:{{ $.Values.testHeadless1.image.tag }}
-        {{- else }}
-        image: {{ $.Values.global.image.repository }}:{{ $.Values.global.image.tag }}
-        {{- end }}
+        image: {{ $.Values.testHeadless1.image.repository | default $.Values.global.image.repository }}:{{ $.Values.testHeadless1.image.tag | default $.Values.global.image.tag }}
         imagePullPolicy: Always
         name: test-headless-1
         ports:


### PR DESCRIPTION
When I saw a comment in `charts/all-in-one/values.yaml`, it seems able to override image's tag. But it should specify repository and tag both in the same time. I think that is not expected behaviour. So I make test-headless-1's tag can be updated alone without specifying image repository. If it is okay, this suggestion can be applied to other resources too.