### PR TITLE
update rpc ip ban condition

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -178,9 +178,9 @@ remoteHeadless:
   - name: IpRateLimiting__GeneralRules__1__Limit
     value: "10"
   - name: IpRateLimiting__IpBanMinute
-    value: "10"
-  - name: IpRateLimiting__IpBanThresholdCount
     value: "5"
+  - name: IpRateLimiting__IpBanThresholdCount
+    value: "15"
   - name: MultiAccountManaging__EnableManaging
     value: "true"
   - name: IpRateLimiting__IpWhiteList__1

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -208,9 +208,9 @@ remoteHeadless:
   - name: IpRateLimiting__GeneralRules__1__Limit
     value: "10"
   - name: IpRateLimiting__IpBanMinute
-    value: "10"
-  - name: IpRateLimiting__IpBanThresholdCount
     value: "5"
+  - name: IpRateLimiting__IpBanThresholdCount
+    value: "15"
   - name: MultiAccountManaging__EnableManaging
     value: "true"
   - name: IpRateLimiting__IpWhiteList__1


### PR DESCRIPTION
- decrease ip ban time from 10min to 5min.
- increase ip ban tx staging threshold to `27 grpc tx per 1min` and `25 gql tx per 5min`. 