### PR TITLE
terraform: Add variable for VPC availibility zone

### DIFF
--- a/terraform/environments/srdg/main.tf
+++ b/terraform/environments/srdg/main.tf
@@ -20,6 +20,8 @@ module "common" {
 
   create_vpc = true
 
+  availability_zone = "ap-northeast-2c"
+
   addon_versions = {
     "coredns"            = "v1.10.1-eksbuild.6"
     "kube-proxy"         = "v1.28.1-eksbuild.1"

--- a/terraform/environments/srdg/main.tf
+++ b/terraform/environments/srdg/main.tf
@@ -20,7 +20,7 @@ module "common" {
 
   create_vpc = true
 
-  availability_zone = "ap-northeast-2c"
+  nat_availability_zone = "ap-northeast-2c"
 
   addon_versions = {
     "coredns"            = "v1.10.1-eksbuild.6"

--- a/terraform/modules/root/main.tf
+++ b/terraform/modules/root/main.tf
@@ -6,3 +6,8 @@ terraform {
     }
   }
 }
+
+variable "availability_zone" {
+  type    = string
+  default = "us-east-2c"
+}

--- a/terraform/modules/root/main.tf
+++ b/terraform/modules/root/main.tf
@@ -7,7 +7,7 @@ terraform {
   }
 }
 
-variable "availability_zone" {
+variable "nat_availability_zone" {
   type    = string
   default = "us-east-2c"
 }

--- a/terraform/modules/root/vpc.tf
+++ b/terraform/modules/root/vpc.tf
@@ -33,7 +33,7 @@ resource "aws_nat_gateway" "nat" {
 
   allocation_id = aws_eip.nat[0].id
 
-  subnet_id = aws_subnet.public["us-east-2c"].id
+  subnet_id = aws_subnet.public[var.availability_zone].id
 
   tags = {
     Name = "NAT-GW${count.index}-${var.vpc_name}"

--- a/terraform/modules/root/vpc.tf
+++ b/terraform/modules/root/vpc.tf
@@ -33,7 +33,7 @@ resource "aws_nat_gateway" "nat" {
 
   allocation_id = aws_eip.nat[0].id
 
-  subnet_id = aws_subnet.public[var.availability_zone].id
+  subnet_id = aws_subnet.public[var.nat_availability_zone].id
 
   tags = {
     Name = "NAT-GW${count.index}-${var.vpc_name}"


### PR DESCRIPTION
This PR would allow creating EKS clusters on regions other than us-east-2 with terraform without flaws related to hardcoded NAT gateway availability zone.