### PR TITLE
mothership: update chart & cluster settings

### DIFF
--- a/charts/mothership/templates/blockscout.yaml
+++ b/charts/mothership/templates/blockscout.yaml
@@ -61,9 +61,9 @@ spec:
             - name: EMISSION_FORMAT
               value: DEFAULT
             - name: ETHEREUM_JSONRPC_HTTP_URL
-              value: http://node-1:{{ .Values.node.opGeth.port.rpc }}/
+              value: {{ .Values.blockscout.gethRpc }}/
             - name: ETHEREUM_JSONRPC_TRACE_URL
-              value: http://node-1:{{ .Values.node.opGeth.port.rpc }}/
+              value: {{ .Values.blockscout.gethRpc }}/
             - name: ETHEREUM_JSONRPC_VARIANT
               value: geth
             - name: EXTERNAL_APPS
@@ -147,13 +147,13 @@ metadata:
     {{- if .Values.blockscout.loadBalancerExternal }}
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: external
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-2:319679068466:certificate/0027ddf6-3baa-4d9e-85fb-df1fdf710a60
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ .Values.awsLoadBalancerSslCert }}
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
     {{- end }}
 spec:
   selector:
     name: blockscout
-  {{- if $.Values.blockscout.loadBalancerExternal }}
+  {{- if .Values.blockscout.loadBalancerExternal }}
   type: LoadBalancer
   {{- end }}
   ports:

--- a/charts/mothership/templates/node.yaml
+++ b/charts/mothership/templates/node.yaml
@@ -1,5 +1,6 @@
 {{ range $idx := until (int $.Values.node.count) }}
 {{ $index := add $idx 1 }}
+{{ $isSequencer := and $.Values.sequencer.enabled (eq ($index | toString) $.Values.sequencer.nodeIndex) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -111,7 +112,9 @@ spec:
             - --authrpc.jwtsecret=/node/jwt.txt
             - --port={{ $.Values.node.opGeth.port.p2p }}
             - --discovery.port={{ $.Values.node.opGeth.port.p2p }}
-            - --rollup.sequencerhttp=http://node-1:{{ $.Values.node.opGeth.port.rpc }}
+            {{- if not $isSequencer }}
+            - --rollup.sequencerhttp={{ $.Values.sequencer.gethRpc }}
+            {{- end }}
             - --rollup.disabletxpoolgossip=true
             - --syncmode=full
             - --gcmode=archive
@@ -155,7 +158,7 @@ spec:
                 --l2=http://localhost:{{ $.Values.node.opGeth.port.authrpc }} \
                 --l2.jwt-secret=/node/jwt.txt \
                 --rollup.config=/node/rollup.json \
-                --sequencer.enabled={{ and $.Values.node.sequencerEnabled (eq $index 1) }} \
+                --sequencer.enabled={{ $isSequencer }} \
                 --p2p.sequencer.key=$(SEQUENCER_KEY) \
                 --p2p.priv.path=/node/jwt.txt \
                 --p2p.peerstore.path=/node/opnode_peerstore_db \
@@ -240,7 +243,7 @@ metadata:
     {{- if $.Values.node.loadBalancerExternal }}
     service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     service.beta.kubernetes.io/aws-load-balancer-type: external
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-2:319679068466:certificate/0027ddf6-3baa-4d9e-85fb-df1fdf710a60
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ $.Values.awsLoadBalancerSslCert }}
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
     {{- end }}
 spec:

--- a/charts/mothership/templates/op-batcher.yaml
+++ b/charts/mothership/templates/op-batcher.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.sequencer.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -7,7 +8,7 @@ spec:
   selector:
     matchLabels:
       name: op-batcher
-  replicas: {{ .Values.opBatcher.replicas }}
+  replicas: 1
   template:
     metadata:
       labels:
@@ -24,8 +25,8 @@ spec:
               op-batcher \
                 --private-key=$(BATCHER_KEY) \
                 --l1-eth-rpc=$(L1_RPC) \
-                --l2-eth-rpc=http://node-1:{{ .Values.node.opGeth.port.rpc }} \
-                --rollup-rpc=http://node-1:{{ .Values.node.opNode.port.rpc }} \
+                --l2-eth-rpc={{ .Values.sequencer.gethRpc }} \
+                --rollup-rpc={{ .Values.sequencer.nodeRpc }} \
                 --rpc.port={{ .Values.opBatcher.port.rpc }} \
                 --rpc.addr=0.0.0.0 \
                 --rpc.enable-admin \
@@ -46,3 +47,4 @@ spec:
           ports:
             - containerPort: {{ .Values.opBatcher.port.rpc }}
               protocol: TCP
+{{- end }}

--- a/charts/mothership/templates/op-proposer.yaml
+++ b/charts/mothership/templates/op-proposer.yaml
@@ -1,10 +1,11 @@
+{{- if .Values.sequencer.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: op-proposer
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: {{ .Values.opProposer.replicas }}
+  replicas: 1
   selector:
     matchLabels:
       name: op-proposer
@@ -40,7 +41,7 @@ spec:
               op-proposer \
                 --private-key=$(PROPOSER_KEY) \
                 --l1-eth-rpc=$(L1_RPC) \
-                --rollup-rpc=http://node-1:{{ .Values.node.opNode.port.rpc }} \
+                --rollup-rpc={{ .Values.sequencer.nodeRpc }} \
                 --rpc.port={{ .Values.opProposer.port.rpc }} \
                 --l2oo-address=$(cat /genesis/L2OutputOracleProxyAddress) \
                 --poll-interval=12s
@@ -76,3 +77,4 @@ spec:
       storageClassName: {{ .Values.storageClassName }}
       {{- end }}
       volumeMode: Filesystem
+{{- end }}

--- a/charts/mothership/values.yaml
+++ b/charts/mothership/values.yaml
@@ -7,12 +7,17 @@ genesis:
   volume:
     storage: 100Mi
 
+sequencer:
+  enabled: false
+  nodeIndex: ""
+  gethRpc: ""
+  nodeRpc: ""
+
 node:
   count: 1
-  sequencerEnabled: true
   loadBalancerExternal: false
   opGeth:
-    image: &op-geth-image us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101308.2
+    image: &op-geth-image us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101311.0
     port: &op-geth-port
       rpc: 8545
       wsrpc: 8546
@@ -21,7 +26,7 @@ node:
     volume: &op-geth-volume
       storage: 100Gi
   opNode:
-    image: &op-node-image us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.7.2
+    image: &op-node-image us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.7.3
     port: &op-node-port
       rpc: 8547
       p2p: 9003
@@ -30,19 +35,18 @@ node:
       storage: 100Mi
 
 opBatcher:
-  replicas: 1
-  image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.7.2
+  image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.7.3
   port:
     rpc: 8548
 
 opProposer:
-  replicas: 1
-  image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer:v1.7.2
+  image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer:v1.7.3
   port:
     rpc: 8560
 
 blockscout:
   port: 5000
   loadBalancerExternal: false
+  gethRpc: http://node-1:8545
   db:
     storage: 10Gi

--- a/mothership/holesky-devnet/values.yaml
+++ b/mothership/holesky-devnet/values.yaml
@@ -7,6 +7,7 @@ env:
   L1_BEACON_RPC: https://ethereum-holesky-beacon-api.publicnode.com
 
 storageClassName: gp3-extensible
+awsLoadBalancerSslCert: arn:aws:acm:us-east-2:319679068466:certificate/dbb84b9a-cb2b-407c-924a-70b3ca29e880
 
 genesis:
   source: https://mothership-devnet-holesky-genesis.s3.us-east-2.amazonaws.com
@@ -18,17 +19,16 @@ blockscout:
   db:
     storage: 100Gi
 
+sequencer:
+  enabled: true
+  nodeIndex: "1"
+  gethRpc: http://node-1:8545
+  nodeRpc: http://node-1:8547
+
 node:
   count: 2
-  sequencerEnabled: false
   loadBalancerExternal: true
   opGeth:
     resources:
       requests:
         memory: 4Gi
-
-opProposer:
-  replicas: 0
-
-opBatcher:
-  replicas: 0

--- a/srdg/holesky-devnet/values.yaml
+++ b/srdg/holesky-devnet/values.yaml
@@ -7,6 +7,7 @@ env:
   L1_BEACON_RPC: https://ethereum-holesky-beacon-api.publicnode.com
 
 storageClassName: gp3-extensible
+awsLoadBalancerSslCert: arn:aws:acm:ap-northeast-2:319679068466:certificate/3a295c76-66ac-433d-8448-758c83d374d3
 
 genesis:
   source: https://mothership-devnet-holesky-genesis.s3.us-east-2.amazonaws.com
@@ -18,15 +19,14 @@ blockscout:
   db:
     storage: 100Gi
 
+sequencer:
+  enabled: false
+  gethRpc: https://node-1.us-east-2.holesky.tests.mothership-pla.net
+
 node:
   count: 1
-  sequencerEnabled: true
   loadBalancerExternal: true
-  nodeSelector:
-    node.kubernetes.io/instance-type: m7g.xlarge
-
-opProposer:
-  replicas: 1
-
-opBatcher:
-  replicas: 1
+  opGeth:
+    resources:
+      requests:
+        memory: 4Gi


### PR DESCRIPTION
bumped op-node, op-batcher, op-proposer, op-geth images

changes:
- configurable sequencer geth/node rpc, blockscout geth rpc
- create op-batcher, op-proposer only if sequencer is enabled in the cluster
