### PR TITLE
update dp-migrator to use tainted node

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -219,7 +219,7 @@ dataProviderDataMigrator:
   enabled: true
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-main-r7g_2xl_2c
+    eks.amazonaws.com/nodegroup: 9c-main-r7g_2xl_2c_test
 
   resources:
     requests:
@@ -227,6 +227,12 @@ dataProviderDataMigrator:
       memory: 56Gi
 
   storage: 1500Gi
+
+  tolerations:
+  - effect: NoSchedule
+    key: dedicated
+    operator: Equal
+    value: remote-headless-test
 
 dataProvider:
   enabled: true


### PR DESCRIPTION
grafana keeps attaching to an open 9c-main-r7g_2xl_2c node and causes eviction in dp-migrator jobs 😢 