### PR TITLE
Bump headless version to 131

### DIFF
--- a/9c-main/multiplanetary/network/general.yaml
+++ b/9c-main/multiplanetary/network/general.yaml
@@ -2,7 +2,7 @@ global:
   image:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
-    tag: "v200170"
+    tag: "131"
 
 seed:
   image:


### PR DESCRIPTION
In v200170(=130), `NineChronicles.Headless` bumps OpenTelemetry-related dependencies and it makes Prometheus not able to scrape their metrics. So it releases a hotfix release, 131, disables .NET runtime instruments metrics. It recovers Prometheus' scrapping logics.

~~It is building the Docker image now... https://github.com/planetarium/NineChronicles.Headless/tree/131~~ Done! https://hub.docker.com/layers/planetariumhq/ninechronicles-headless/131/images/sha256-e2fdeb597a61e4c69abdce8fd4ec635d16be7d2bc32a9bb90388f43cc68927ea?context=explore