### PR TITLE
upgrade odin jwt to m7g.4xl

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -510,7 +510,7 @@ jwtHeadless:
     value: remote-headless-test
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-main-c7g_4xl_2c_test
+    eks.amazonaws.com/nodegroup: 9c-main-m7g_4xl_2c_test
 
 remoteActionEvaluatorHeadless:
   enabled: false


### PR DESCRIPTION
jwt tip is unable to catch up with c7g.4xl (combination of high cpu & memory usage).