### PR TITLE
reduce rpc and testheadless nodes

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -149,7 +149,7 @@ validator:
       memory: 25Gi
 
 remoteHeadless:
-  count: 3
+  count: 2
   replicas: 1
 
   useTurnServer: false
@@ -157,14 +157,6 @@ remoteHeadless:
   hosts:
   - "9c-main-rpc-1.nine-chronicles.com"
   - "9c-main-rpc-2.nine-chronicles.com"
-  - "9c-main-rpc-3.nine-chronicles.com"
-  - "9c-main-rpc-4.nine-chronicles.com"
-  - "9c-main-rpc-5.nine-chronicles.com"
-  - "9c-main-rpc-6.nine-chronicles.com"
-  - "9c-main-rpc-7.nine-chronicles.com"
-  - "9c-main-rpc-8.nine-chronicles.com"
-  - "9c-main-rpc-9.nine-chronicles.com"
-  - "9c-main-rpc-10.nine-chronicles.com"
 
   env:
   - name: IpRateLimiting__EnableEndpointRateLimiting
@@ -420,7 +412,7 @@ testHeadless1:
     eks.amazonaws.com/nodegroup: 9c-main-2c_spot
 
 testHeadless2:
-  enabled: true
+  enabled: false
 
   loggingEnabled: true
 

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -192,7 +192,7 @@ validator:
     eks.amazonaws.com/nodegroup: heimdall-r7g_xl_2c_validator
 
 remoteHeadless:
-  count: 3
+  count: 2
   replicas: 1
 
   useTurnServer: false
@@ -200,7 +200,6 @@ remoteHeadless:
   hosts:
   - "heimdall-rpc-1.nine-chronicles.com"
   - "heimdall-rpc-2.nine-chronicles.com"
-  - "heimdall-rpc-3.nine-chronicles.com"
 
   env:
   - name: IpRateLimiting__EnableEndpointRateLimiting
@@ -428,7 +427,7 @@ testHeadless1:
     value: remote-headless-test
 
 testHeadless2:
-  enabled: true
+  enabled: false
   replicas: 1
 
   host: "heimdall-test-2.nine-chronicles.com"


### PR DESCRIPTION
reduce remoteHeadless nodes to 2 and disable testHeadless2 node in odin and heimdall networks.