### PR TITLE
remove unecessary env values

### DIFF
--- a/9c-dev/9c-odin-libplanet4-test-20240104/values.yaml
+++ b/9c-dev/9c-odin-libplanet4-test-20240104/values.yaml
@@ -188,10 +188,6 @@ marketService:
   env:
   - name: DOTNET_gcServer
     value: "1"
-  - name: RpcConfig__Host
-    value: k8s-9codinli-remotehe-55686c889c-fbbfdb2f7f6d58ec.elb.us-east-2.amazonaws.com
-  - name: RpcConfig__Port
-    value: "31238"
   - name: WorkerConfig__SyncShop
     value: "true"
   - name: WorkerConfig__SyncProduct


### PR DESCRIPTION
These env values are no longer needed since https://github.com/planetarium/9c-infra/commit/ae5f9b875a7ba8a5b42cdcf9a646b8109fa591c3