### PR TITLE
[9c-internal] revert nodegroups in peripheral services

### DIFF
--- a/9c-internal/multiplanetary/network/9c-network.yaml
+++ b/9c-internal/multiplanetary/network/9c-network.yaml
@@ -59,7 +59,7 @@ seed:
   - "tcp-seed-1.9c-network.svc.cluster.local"
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_l_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
 
 validator:
   count: 4
@@ -142,7 +142,7 @@ dataProvider:
     password: ''
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_l_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
 
   resources:
     requests:
@@ -165,7 +165,7 @@ explorer:
       memory: 4Gi
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_l_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
 
   extraArgs:
   - --tx-quota-per-signer=1
@@ -179,7 +179,7 @@ marketService:
     size: 1Gi
 
   nodeSelector:
-    node.kubernetes.io/instance-type: m5d.large
+    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
 
   env:
   - name: DOTNET_gcServer
@@ -193,7 +193,7 @@ patrolRewardService:
   enabled: true
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_l_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
 
   db:
     local: true
@@ -231,7 +231,7 @@ rudolfCurrencyNotifier:
     serverName: "9c-internal"
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_l_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
 
 volumeRotator:
   enabled: true
@@ -257,7 +257,7 @@ worldBoss:
     slackSigningSecret: ""
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_l_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
 
 acc:
   enabled: false
@@ -278,7 +278,7 @@ stateMigrationService:
   enabled: false
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_l_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
 
 jwtHeadless:
   enabled: false

--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -47,7 +47,7 @@ bridgeService:
     size: "50Gi"
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_l_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
 
   account:
     type: "kms"
@@ -106,7 +106,7 @@ marketService:
     size: 1Gi
 
   nodeSelector:
-    node.kubernetes.io/instance-type: m5d.large
+    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
 
   env:
   - name: DOTNET_gcServer
@@ -120,7 +120,7 @@ patrolRewardService:
   enabled: true
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_l_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
 
   db:
     local: true
@@ -183,7 +183,7 @@ seed:
   - "tcp-seed-1.heimdall.svc.cluster.local"
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_l_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
 
 snapshot:
   partition:
@@ -246,7 +246,7 @@ worldBoss:
     slackSigningSecret: ""
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_l_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
 
 testHeadless1:
   enabled: false
@@ -298,4 +298,4 @@ stateMigrationService:
   enabled: false
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_l_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c


### PR DESCRIPTION
m5d.l spot instances not available 😅 