### PR TITLE
move argocd-dex-server patch from common to mothership

### DIFF
--- a/common/argocd/kustomization.yaml
+++ b/common/argocd/kustomization.yaml
@@ -15,17 +15,3 @@ patchesJson6902:
       - op: add
         path: /spec/template/spec/containers/0/command/-
         value: --insecure
-  - target:
-      group: apps
-      version: v1
-      kind: Deployment
-      name: argocd-dex-server
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: ARGO_WORKFLOWS_SSO_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: argo-workflows-sso
-              key: client-secret

--- a/mothership/argocd/kustomization.yaml
+++ b/mothership/argocd/kustomization.yaml
@@ -29,3 +29,18 @@ patchesJson6902:
             name: mothership-external-secrets
             annotations:
               eks.amazonaws.com/role-arn: arn:aws:iam::319679068466:role/eks-mothership-external-secrets
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: argocd-dex-server
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: ARGO_WORKFLOWS_SSO_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: argo-workflows-sso
+              key: client-secret
+


### PR DESCRIPTION
Only use `ARGO_WORKFLOWS_SSO_CLIENT_SECRET` in mothership cluster.