### PR TITLE
update 9c-main-apse1 to use global headless in 9c-main

### DIFF
--- a/9c-main-apse1/multiplanetary/network/general.yaml
+++ b/9c-main-apse1/multiplanetary/network/general.yaml
@@ -1,5 +1,0 @@
-global:
-  image:
-    repository: planetariumhq/ninechronicles-headless
-    pullPolicy: Always
-    tag: "git-0bd630057a9f211a0241f6de8d8876294c5c365c"

--- a/charts/multiplanetary/templates/network.yaml
+++ b/charts/multiplanetary/templates/network.yaml
@@ -12,11 +12,8 @@ spec:
     path: charts/all-in-one
     helm:
       valueFiles:
-        {{- if eq .Values.clusterName "9c-main-apse1" }}
-        - "../../9c-main/multiplanetary/network/general.yaml"
-        {{- else }}
-        - "../../{{ $.Values.path }}/network/general.yaml"
-        {{- end }}
+        {{- $path := (ternary "9c-main/multiplanetary" .Values.path (eq .Values.clusterName "9c-main-apse1")) }}
+        - "../../{{ $path }}/network/general.yaml"
         - "../../{{ $.Values.path }}/network/{{ . }}.yaml"
 
   destination:

--- a/charts/multiplanetary/templates/network.yaml
+++ b/charts/multiplanetary/templates/network.yaml
@@ -12,7 +12,11 @@ spec:
     path: charts/all-in-one
     helm:
       valueFiles:
+        {{- if eq .Values.clusterName "9c-main-apse1" }}
+        - "../../9c-main/multiplanetary/network/general.yaml"
+        {{- else }}
         - "../../{{ $.Values.path }}/network/general.yaml"
+        {{- end }}
         - "../../{{ $.Values.path }}/network/{{ . }}.yaml"
 
   destination:


### PR DESCRIPTION
Todo) Figure out a way to access heimdall's apv(https://github.com/planetarium/9c-infra/blob/main/9c-main/multiplanetary/network/heimdall.yaml#L8) from 9c-main-apse1.