### PR TITLE
update peripheral services to use ondemand instance during qa period

### DIFF
--- a/9c-internal/multiplanetary/network/9c-network.yaml
+++ b/9c-internal/multiplanetary/network/9c-network.yaml
@@ -59,7 +59,7 @@ seed:
   - "tcp-seed-1.9c-network.svc.cluster.local"
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
 
 validator:
   count: 4
@@ -142,7 +142,7 @@ dataProvider:
     password: ''
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
 
   resources:
     requests:
@@ -165,7 +165,7 @@ explorer:
       memory: 4Gi
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
 
   extraArgs:
   - --tx-quota-per-signer=1
@@ -179,7 +179,7 @@ marketService:
     size: 1Gi
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
 
   env:
   - name: DOTNET_gcServer
@@ -193,7 +193,7 @@ patrolRewardService:
   enabled: true
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
 
   db:
     local: true
@@ -231,7 +231,7 @@ rudolfCurrencyNotifier:
     serverName: "9c-internal"
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
 
 volumeRotator:
   enabled: true
@@ -257,7 +257,7 @@ worldBoss:
     slackSigningSecret: ""
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
 
 acc:
   enabled: false
@@ -278,7 +278,7 @@ stateMigrationService:
   enabled: false
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
 
 jwtHeadless:
   enabled: false

--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -47,7 +47,7 @@ bridgeService:
     size: "50Gi"
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
 
   account:
     type: "kms"
@@ -106,7 +106,7 @@ marketService:
     size: 1Gi
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
 
   env:
   - name: DOTNET_gcServer
@@ -120,7 +120,7 @@ patrolRewardService:
   enabled: true
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
 
   db:
     local: true
@@ -183,7 +183,7 @@ seed:
   - "tcp-seed-1.heimdall.svc.cluster.local"
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
 
 snapshot:
   partition:
@@ -246,7 +246,7 @@ worldBoss:
     slackSigningSecret: ""
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
 
 testHeadless1:
   enabled: false
@@ -298,4 +298,4 @@ stateMigrationService:
   enabled: false
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5d_xl_2c
+    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand

--- a/terraform/environments/internal/main.tf
+++ b/terraform/environments/internal/main.tf
@@ -73,6 +73,15 @@ node_groups = {
       max_size          = 16
     }
 
+    "9c-internal-m5_xl_2c_ondemand" = {
+      instance_types    = ["m5.xlarge"]
+      availability_zone = "us-east-2c"
+      capacity_type     = "ON_DEMAND"
+      desired_size      = 2
+      min_size          = 0
+      max_size          = 10
+    }
+
     "9c-internal-m7g_2xl_2c" = {
       instance_types    = ["m7g.2xlarge"]
       availability_zone = "us-east-2c"


### PR DESCRIPTION
`9c-internal-m5d_xl_2c` spot instances keep restarting 🥲 