### PR TITLE
Add `+search` argument for dig command

### DIFF
--- a/charts/mothership/templates/node.yaml
+++ b/charts/mothership/templates/node.yaml
@@ -110,7 +110,7 @@ spec:
                 fi
               done
               
-              sequencerIP=$(dig +short {{ $.Values.sequencer.host }} | tail -n1)
+              sequencerIP=$(dig +search +short {{ $.Values.sequencer.host }} | tail -n1)
               peerString=$(echo "/ip4/$sequencerIP/tcp/{{ $.Values.node.opNode.port.p2p.tcp }}/p2p/$peerID")
               echo $peerString > /node/staticPeer
           volumeMounts:


### PR DESCRIPTION
`dig +short` cannot resolve service name dns like `node-1`
```
/ # dig +short node-1
/ # dig +search +short node-1
172.20.xx.xxx
```