### PR TITLE
rollback multiplanetary template

### DIFF
--- a/charts/multiplanetary/templates/network.yaml
+++ b/charts/multiplanetary/templates/network.yaml
@@ -12,8 +12,7 @@ spec:
     path: charts/all-in-one
     helm:
       valueFiles:
-        {{- $path := (ternary "9c-main/multiplanetary" .Values.path (eq .Values.clusterName "9c-main-apse1")) }}
-        - "../../{{ $path }}/network/general.yaml"
+        - "../../{{ $.Values.path }}/network/general.yaml"
         - "../../{{ $.Values.path }}/network/{{ . }}.yaml"
 
   destination:


### PR DESCRIPTION
```
rpc error: code = Unknown desc = Manifest generation error (cached): `helm template . --name-template multiplanetary --namespace multiplanetary --kube-version 1.29 --values .9c-main-apse1/multiplanetary/values.yaml --api-versions admissionregistration.k8s.io/v1 --api-versions admissionregistration.k8s.io/v1/MutatingWebhookConfiguration --api-versions admissionregistration.k8s.io/v1/ValidatingWebhookConfiguration --api-versions apiextensions.k8s.io/v1 --api-versions apiextensions.k8s.io/v1/CustomResourceDefinition --api-versions apiregistration.k8s.io/v1 --api-versions apiregistration.k8s.io/v1/APIService --api-versions apps/v1 --api-versions apps/v1/ControllerRevision --api-versions apps/v1/DaemonSet --api-versions apps/v1/Deployment --api-versions apps/v1/ReplicaSet --api-versions apps/v1/StatefulSet --api-versions argoproj.io/v1alpha1 --api-versions argoproj.io/v1alpha1/AppProject --api-versions argoproj.io/v1alpha1/Application --api-versions argoproj.io/v1alpha1/ApplicationSet --api-versions autoscaling/v1 --api-versions autoscaling/v1/HorizontalPodAutoscaler --api-versions autoscaling/v2 --api-versions autoscaling/v2/HorizontalPodAutoscaler --api-versions batch/v1 --api-versions batch/v1/CronJob --api-versions batch/v1/Job --api-versions certificates.k8s.io/v1 --api-versions certificates.k8s.io/v1/CertificateSigningRequest --api-versions coordination.k8s.io/v1 --api-versions coordination.k8s.io/v1/Lease --api-versions crd.k8s.amazonaws.com/v1alpha1 --api-versions crd.k8s.amazonaws.com/v1alpha1/ENIConfig --api-versions discovery.k8s.io/v1 --api-versions discovery.k8s.io/v1/EndpointSlice --api-versions elbv2.k8s.aws/v1alpha1 --api-versions elbv2.k8s.aws/v1alpha1/TargetGroupBinding --api-versions elbv2.k8s.aws/v1beta1 --api-versions elbv2.k8s.aws/v1beta1/IngressClassParams --api-versions elbv2.k8s.aws/v1beta1/TargetGroupBinding --api-versions events.k8s.io/v1 --api-versions events.k8s.io/v1/Event --api-versions external-secrets.io/v1alpha1 --api-versions external-secrets.io/v1alpha1/ClusterSecretStore --api-versions external-secrets.io/v1alpha1/ExternalSecret --api-versions external-secrets.io/v1alpha1/PushSecret --api-versions external-secrets.io/v1alpha1/SecretStore --api-versions external-secrets.io/v1beta1 --api-versions external-secrets.io/v1beta1/ClusterExternalSecret --api-versions external-secrets.io/v1beta1/ClusterSecretStore --api-versions external-secrets.io/v1beta1/ExternalSecret --api-versions external-secrets.io/v1beta1/SecretStore --api-versions flowcontrol.apiserver.k8s.io/v1 --api-versions flowcontrol.apiserver.k8s.io/v1/FlowSchema --api-versions flowcontrol.apiserver.k8s.io/v1/PriorityLevelConfiguration --api-versions flowcontrol.apiserver.k8s.io/v1beta3 --api-versions flowcontrol.apiserver.k8s.io/v1beta3/FlowSchema --api-versions flowcontrol.apiserver.k8s.io/v1beta3/PriorityLevelConfiguration --api-versions generators.external-secrets.io/v1alpha1 --api-versions generators.external-secrets.io/v1alpha1/ACRAccessToken --api-versions generators.external-secrets.io/v1alpha1/ECRAuthorizationToken --api-versions generators.external-secrets.io/v1alpha1/Fake --api-versions generators.external-secrets.io/v1alpha1/GCRAccessToken --api-versions generators.external-secrets.io/v1alpha1/Password --api-versions networking.k8s.aws/v1alpha1 --api-versions networking.k8s.aws/v1alpha1/PolicyEndpoint --api-versions networking.k8s.io/v1 --api-versions networking.k8s.io/v1/Ingress --api-versions networking.k8s.io/v1/IngressClass --api-versions networking.k8s.io/v1/NetworkPolicy --api-versions node.k8s.io/v1 --api-versions node.k8s.io/v1/RuntimeClass --api-versions policy/v1 --api-versions policy/v1/PodDisruptionBudget --api-versions rbac.authorization.k8s.io/v1 --api-versions rbac.authorization.k8s.io/v1/ClusterRole --api-versions rbac.authorization.k8s.io/v1/ClusterRoleBinding --api-versions rbac.authorization.k8s.io/v1/Role --api-versions rbac.authorization.k8s.io/v1/RoleBinding --api-versions scheduling.k8s.io/v1 --api-versions scheduling.k8s.io/v1/PriorityClass --api-versions storage.k8s.io/v1 --api-versions storage.k8s.io/v1/CSIDriver --api-versions storage.k8s.io/v1/CSINode --api-versions storage.k8s.io/v1/CSIStorageCapacity --api-versions storage.k8s.io/v1/StorageClass --api-versions storage.k8s.io/v1/VolumeAttachment --api-versions v1 --api-versions v1/ConfigMap --api-versions v1/Endpoints --api-versions v1/Event --api-versions v1/LimitRange --api-versions v1/Namespace --api-versions v1/Node --api-versions v1/PersistentVolume --api-versions v1/PersistentVolumeClaim --api-versions v1/Pod --api-versions v1/PodTemplate --api-versions v1/ReplicationController --api-versions v1/ResourceQuota --api-versions v1/Secret --api-versions v1/Service --api-versions v1/ServiceAccount --api-versions vpcresources.k8s.aws/v1alpha1 --api-versions vpcresources.k8s.aws/v1alpha1/CNINode --api-versions vpcresources.k8s.aws/v1beta1 --api-versions vpcresources.k8s.aws/v1beta1/SecurityGroupPolicy --include-crds` failed exit status 1: Error: template: multiplanetary/templates/network.yaml:15:62: executing "multiplanetary/templates/network.yaml" at <.Values.path>: can't evaluate field Values in type interface {} Use --debug flag to render out invalid YAML
```