### PR TITLE
update `9c-main-apse1` headless tag when updating `9c-main` headless tag

### DIFF
--- a/.github/scripts/update-values.sh
+++ b/.github/scripts/update-values.sh
@@ -56,3 +56,9 @@ echo $sources
 
 cd scripts
 python cli.py update-values $file_path $sources
+
+if [ "$DIR" = "9c-main" ] && [ "$FILE_NAME" = "general" ] && [ -n "$HEADLESS" ]; then
+    file_path="9c-main-apse1/multiplanetary/network/$FILE_NAME.yaml"
+    sources="global|planetariumhq/ninechronicles-headless:$HEADLESS"
+    python cli.py update-values $file_path "$sources"
+fi


### PR DESCRIPTION
Only for headless tag updates.