### PR TITLE
add `--planet` argument to preloading script

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -247,6 +247,8 @@ dataProvider:
     value: "1"
   - name: PLUGIN_PATH
     value: "/data"
+  - name: NC_Planet
+    value: Odin
 
 explorer:
   enabled: false

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -284,6 +284,14 @@ dataProvider:
       cpu: '3'
       memory: 26Gi
 
+  env:
+  - name: DOTNET_gcServer
+    value: "1"
+  - name: PLUGIN_PATH
+    value: "/data"
+  - name: NC_Planet
+    value: Heimdall
+
 explorer:
   enabled: false
 

--- a/charts/all-in-one/scripts/snapshots/full/preload_headless.sh
+++ b/charts/all-in-one/scripts/snapshots/full/preload_headless.sh
@@ -56,6 +56,9 @@ function run_headless() {
       --app-protocol-version="$APP_PROTOCOL_VERSION" \
       --trusted-app-protocol-version-signer="$TRUSTED_APP_PROTOCOL_VERSION_SIGNER" \
       --ice-server="$ICE_SERVER" \
+      {{- if $.Values.global.planet }}
+      --planet={{ $.Values.global.planet }} \
+      {{- end }}
       {{- if $.Values.global.headlessAppsettingsPath }}
       --config={{ $.Values.global.headlessAppsettingsPath }} \
       {{- end }}

--- a/charts/all-in-one/scripts/snapshots/partition-reset/preload_headless.sh
+++ b/charts/all-in-one/scripts/snapshots/partition-reset/preload_headless.sh
@@ -54,6 +54,12 @@ function run_headless() {
       --app-protocol-version="$APP_PROTOCOL_VERSION" \
       --trusted-app-protocol-version-signer="$TRUSTED_APP_PROTOCOL_VERSION_SIGNER" \
       --ice-server="$ICE_SERVER" \
+      {{- if $.Values.global.planet }}
+      --planet={{ $.Values.global.planet }} \
+      {{- end }}
+      {{- if $.Values.global.headlessAppsettingsPath }}
+      --config={{ $.Values.global.headlessAppsettingsPath }} \
+      {{- end }}
       {{- range $i, $s := $.Values.global.peerStrings }}
       --peer "$SEED{{ add $i 1 }}" \
       {{- end }}

--- a/charts/all-in-one/scripts/snapshots/partition/preload_headless.sh
+++ b/charts/all-in-one/scripts/snapshots/partition/preload_headless.sh
@@ -57,6 +57,9 @@ function run_headless() {
       --app-protocol-version="$APP_PROTOCOL_VERSION" \
       --trusted-app-protocol-version-signer="$TRUSTED_APP_PROTOCOL_VERSION_SIGNER" \
       --ice-server="$ICE_SERVER" \
+      {{- if $.Values.global.planet }}
+      --planet={{ $.Values.global.planet }} \
+      {{- end }}
       {{- if $.Values.global.headlessAppsettingsPath }}
       --config={{ $.Values.global.headlessAppsettingsPath }} \
       {{- end }}


### PR DESCRIPTION
Currently `Heimdall` and `Odin`'s block policies are different so we need to add the `--planet` argument to the snapshot preload script as well.