### PR TITLE
add `1` to the end value to account for the unbroadcasted block in validator

### DIFF
--- a/scripts/app/update_paev.py
+++ b/scripts/app/update_paev.py
@@ -27,6 +27,9 @@ class PluggableActionEvaluatorUpdater:
             response = requests.get(url)
             data = response.json()
 
+            # add 1 to end_value
+            end_value = end_value + 1
+
             # Define new values for appending and updating
             start_value = 0
             new_start_value = end_value + 1


### PR DESCRIPTION
When releasing a new update, the validator doesn't broadcast its final block to other nodes (for example, the validator's tip is 3 while other node's tip is 2 upon update).

This unsuccessful broadcast of the validator's tip when restarting the network seems to be happening every update and so the person in charge of game update is very likely to mis-record the previous version's final block.

Therefore, this PR adds 1 to the input end value so that the PAEV will be correctly updated.