### PR TITLE
Bump 9c-rudolf

### DIFF
--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -47,7 +47,7 @@ patrolRewardService:
 
 rudolfService:
   image:
-    tag: "git-df13a4c8f7db88ff96bab9038eed0ba7bb35a3d5"
+    tag: "git-278252e48d7d13306dcb1820bd9524ee6a27203c"
 
 acc:
   image:

--- a/9c-main/multiplanetary/network/general.yaml
+++ b/9c-main/multiplanetary/network/general.yaml
@@ -43,7 +43,7 @@ remoteActionEvaluatorHeadless:
 
 rudolfService:
   image:
-    tag: "git-1f93812f5c1a5626298eb97a59e97dececa052ab"
+    tag: "git-278252e48d7d13306dcb1820bd9524ee6a27203c"
 
 bridgeService:
   image:


### PR DESCRIPTION
You can see the mainnet changes here: https://github.com/planetarium/9c-rudolf/compare/1f93812f5c1a5626298eb97a59e97dececa052ab..278252e48d7d13306dcb1820bd9524ee6a27203c.

- Remove whitelistTicker validation.
- Increase request body size limit to 1 MB.