### PR TITLE
mothership/holesky-testnet: bump op-stack & use amd64 node for batcher/proposer

### DIFF
--- a/charts/mothership/templates/op-batcher.yaml
+++ b/charts/mothership/templates/op-batcher.yaml
@@ -47,4 +47,8 @@ spec:
           ports:
             - containerPort: {{ .Values.opBatcher.port.rpc }}
               protocol: TCP
+      {{- with $.Values.opBatcher.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/mothership/templates/op-proposer.yaml
+++ b/charts/mothership/templates/op-proposer.yaml
@@ -64,6 +64,10 @@ spec:
         - name: genesis-volume
           persistentVolumeClaim:
             claimName: genesis-volume
+      {{- with $.Values.opProposer.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: genesis-volume

--- a/mothership/holesky-testnet/values.yaml
+++ b/mothership/holesky-testnet/values.yaml
@@ -34,6 +34,8 @@ node:
   hosts:
     - node-1.testnet.holesky.tests.mothership-pla.net
     - node-2.testnet.holesky.tests.mothership-pla.net
+  opNode:
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.7.7-rc.1
   opGeth:
     image: ghcr.io/planetarium/op-geth:latest
     resources:
@@ -41,6 +43,16 @@ node:
         memory: 4Gi
     extraArgs:
       - "--override.fjord=1717113600"
+  nodeSelector:
+    eks.amazonaws.com/nodegroup: mothership-r7a_l_2c
+
+opBatcher:
+  image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.7.6
+  nodeSelector:
+    eks.amazonaws.com/nodegroup: mothership-r7a_l_2c
+
+opProposer:
+  image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-proposer:v1.7.6
   nodeSelector:
     eks.amazonaws.com/nodegroup: mothership-r7a_l_2c
 


### PR DESCRIPTION
following #1756 