### PR TITLE
update full state nodegroup

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -349,10 +349,10 @@ fullState:
   resources:
     requests:
       cpu: 3
-      memory: 50Gi
+      memory: 25Gi
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-main-r7g_2xl_2c_test
+    eks.amazonaws.com/nodegroup: 9c-main-c7g_4xl_2c_test
 
 worldBoss:
   enabled: true


### PR DESCRIPTION
increasing memory didn't really help.

test c7g.4xl before m7g.4xl because it's cheaper.