### PR TITLE
disable rudolf-currency-notifier cronjob

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -588,7 +588,7 @@ rudolfService:
     - "sg-033602a010bce902e"
 
 rudolfCurrencyNotifier:
-  enabled: true
+  enabled: false
 
   config:
     schedule: "0 0 * * *"

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -614,7 +614,7 @@ rudolfService:
     - "sg-033602a010bce902e"
 
 rudolfCurrencyNotifier:
-  enabled: true
+  enabled: false
 
   config:
     schedule: "0 0 * * *"


### PR DESCRIPTION
It seems that the rudolf-currency-notifier cronjob hasn't been used for some time now. This PR disables the cronjob.

@moreal Could you confirm that this job is no longer used and can be disabled? 🙏 