### PR TITLE
Recover reset-bridge-service workflow temporarily

### DIFF
--- a/.github/workflows/reset-bridge-service.yaml
+++ b/.github/workflows/reset-bridge-service.yaml
@@ -1,0 +1,57 @@
+name: Reset bridge service
+
+on:
+  workflow_dispatch:
+
+jobs:
+  reset-bridge-service:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Set up kubectl
+      uses: azure/setup-kubectl@v1
+      with:
+        version: 'v1.29.0'
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y jq
+
+    - uses: actions-hub/kubectl@master
+      env:
+        KUBE_CONFIG: ${{ secrets.KUBECONFIG }}
+      with:
+        args: scale --replicas=0 statefulset/bridge-service -n heimdall
+
+    - uses: actions-hub/kubectl@master
+      env:
+        KUBE_CONFIG: ${{ secrets.KUBECONFIG }}
+      with:
+        args: scale --replicas=0 statefulset/bridge-service-db -n heimdall
+
+    - uses: actions-hub/kubectl@master
+      env:
+        KUBE_CONFIG: ${{ secrets.KUBECONFIG }}
+      with:
+        args: delete pvc/bridge-service-db-data-bridge-service-db-0 --namespace=heimdall
+
+    - uses: actions/setup-python@v2.2.2
+      with:
+        python-version: 3.10.13
+
+    - run: |
+        python -m pip install -r requirements.txt
+        flit install
+      name: install dependencies
+      working-directory: ./scripts
+
+    - name: Update 'bridgeService.rdb.defaultStartBlockIndex'
+      run: |
+        python cli.py update-bridge-service 9c-internal heimdall
+      working-directory: ./scripts
+      env:
+        GITHUB_TOKEN: ${{ secrets.P_GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request recovers `reset-bridge-service` workflow which removed in #1786, temporarily. It is because I cannot support a bug occurred from those changes. At the Friday, I'll remove this workflow again.