### PR TITLE
enable pyroscope in test-headless-1

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -24,6 +24,9 @@ global:
   - "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us4.planetarium.dev:3478"
   - "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us5.planetarium.dev:3478"
 
+  pyroscope:
+    enabled: true
+
   networkType: Main
   planet: Odin
   consensusType: pbft
@@ -405,6 +408,8 @@ testHeadless1:
 
   host: "9c-main-test-1.nine-chronicles.com"
 
+  headlessAppsettingsPath: "https://9c-cluster-config.s3.us-east-2.amazonaws.com/9c-main/odin/appsettings-nodeinfra.json"
+
   env:
   - name: IpRateLimiting__EnableEndpointRateLimiting
     value: "true"
@@ -445,7 +450,7 @@ testHeadless1:
     value: remote-headless-test
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-main-2c_spot
+    eks.amazonaws.com/nodegroup: 9c-main-2c_spot_amd
 
 testHeadless2:
   enabled: false

--- a/charts/all-in-one/templates/test-headless-1.yaml
+++ b/charts/all-in-one/templates/test-headless-1.yaml
@@ -71,7 +71,7 @@ spec:
           - >
             apk --no-cache add curl tar
 
-            curl -s -L https://github.com/grafana/pyroscope-dotnet/releases/download/v0.8.14-pyroscope/pyroscope.0.8.14-glibc-aarch64.tar.gz  | tar xvz -C /data
+            curl -s -L https://github.com/grafana/pyroscope-dotnet/releases/download/v0.8.14-pyroscope/pyroscope.0.8.14-glibc-x86_64.tar.gz | tar xvz -C /data
         image: alpine
         imagePullPolicy: Always
         name: setup-pyroscope
@@ -139,8 +139,10 @@ spec:
         - --chain-tip-stale-behavior-type=reboot
         - --tx-life-time=10
         - --planet={{ $.Values.global.planet }}
-        {{- if $.Values.global.headlessAppsettingsPath }}
-        - --config={{ $.Values.global.headlessAppsettingsPath }}
+        {{- if .Values.testHeadless1.headlessAppsettingsPath }}
+        - --config={{ .Values.testHeadless1.headlessAppsettingsPath }}
+        {{- else if .Values.global.headlessAppsettingsPath }}
+        - --config={{ .Values.global.headlessAppsettingsPath }}
         {{- end }}
         {{- with $.Values.testHeadless1.extraArgs }}
           {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
* `9c-main-2c_spot_amd` uses `r5a.xlarge`.