### PR TITLE
update odin validator instance type to m7g.xl

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -146,7 +146,7 @@ validator:
     value: validator-test
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-main-r7g_xl_2c_validator
+    eks.amazonaws.com/nodegroup: 9c-main-m7g_xl_2c_validator
 
   resources:
     requests:


### PR DESCRIPTION
Validator-7 seems to operate fine with m7g.xl.
![image](https://github.com/planetarium/9c-infra/assets/42176649/43aa12b8-6fa3-4ecd-8d35-e6ec39d196fb)
