### PR TITLE
Support 'all' option when resetting internal snapshot

### DIFF
--- a/.github/workflows/snapshot-reset.yaml
+++ b/.github/workflows/snapshot-reset.yaml
@@ -10,12 +10,14 @@ on:
         options:
         - odin
         - heimdall
+        - all
 
 concurrency:
   group: release
 
 jobs:
-  release:
+  release-odin:
+    if: ${{ github.event.inputs.chain }} == 'odin' || ${{ github.event.inputs.chain }} == 'all'
     runs-on: ubuntu-latest
     environment:
       name: internal
@@ -23,7 +25,23 @@ jobs:
       - uses: actions/checkout@v3
       - name: reset internal snapshot
         run: |
-          echo "y" | bash .github/scripts/reset-snapshot.sh "${{ github.event.inputs.chain }}"
+          echo "y" | bash .github/scripts/reset-snapshot.sh odin
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+  
+  release-heimdall:
+    if: ${{ github.event.inputs.chain }} == 'heimdall' || ${{ github.event.inputs.chain }} == 'all'
+    runs-on: ubuntu-latest
+    environment:
+      name: internal
+    steps:
+      - uses: actions/checkout@v3
+      - name: reset internal snapshot
+        run: |
+          echo "y" | bash .github/scripts/reset-snapshot.sh heimdall
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -32,7 +50,7 @@ jobs:
 
   reset-bridge-service:
     runs-on: ubuntu-latest
-    needs: release
+    needs: [release-odin, release-heimdall]
 
     steps:
     - name: Checkout Repository


### PR DESCRIPTION
It amends `snapshot-reset` GitHub Actions workflow. It make the workflow provide a new option, `all`. If an user passes `all` option, it will reset internal snapshot in odin and heimdall both. And it'll reset bridge service and it will not reset bridge service when other options are passed. (odin and heimdall).