### PR TITLE
Mothership: add proxyd to testnet

### DIFF
--- a/charts/mothership/templates/proxyd.yaml
+++ b/charts/mothership/templates/proxyd.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.proxyd.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: proxyd
+  namespace: {{ .Release.Namespace }}
+spec: 
+  selector:
+    matchLabels:
+      name: proxyd
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: proxyd
+    spec:
+      initContainers:
+        - name: fetch-config
+          image: curlimages/curl
+          command: ["sh", "-c"]
+          args:
+            - |
+              curl -LO $GENESIS_SOURCE/proxyd.toml ;
+          workingDir: /etc/proxyd
+          env:
+            - name: GENESIS_SOURCE
+              value: "{{ $.Values.genesis.source }}"
+          volumeMounts:
+            - mountPath: /etc/proxyd/
+              name: proxyd-volume
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+        - name: wait-for-op-geth
+          image: curlimages/curl
+          command: ['sh', '-c']
+          args:
+            - |
+              until curl -sf {{ .Values.proxyd.gethRpc }};
+                do echo waiting for op-geth;
+                sleep 5;
+              done
+      containers:
+        - name: proxyd
+          image: {{ .Values.proxyd.image }}
+          ports:
+            - name: proxyd-rpc
+              containerPort: 8080
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxyd
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- if .Values.proxyd.loadBalancerExternal }}
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+    service.beta.kubernetes.io/aws-load-balancer-type: external
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ .Values.awsLoadBalancerSslCert }}
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+    {{- end }}
+spec:
+  selector:
+    name: proxyd
+  {{- if .Values.proxyd.loadBalancerExternal }}
+  type: LoadBalancer
+  {{- end }}
+  ports:
+    - name: proxyd-rpc-port
+      targetPort: proxyd-rpc
+      port: {{ .Values.proxyd.port }}
+    - name: proxyd-rpc-http
+      targetPort: proxyd-rpc
+      port: 80
+    - name: proxyd-rpc-https
+      targetPort: proxyd-rpc
+      port: 443
+
+---
+
+{{- end }}

--- a/charts/mothership/templates/proxyd.yaml
+++ b/charts/mothership/templates/proxyd.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.proxyd.enabled }}
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: proxyd
   namespace: {{ .Release.Namespace }}
@@ -14,6 +14,9 @@ spec:
       labels:
         name: proxyd
     spec:
+      volumes:
+        - name: proxyd-volume
+          emptyDir: {}
       initContainers:
         - name: fetch-config
           image: curlimages/curl
@@ -26,7 +29,7 @@ spec:
             - name: GENESIS_SOURCE
               value: "{{ $.Values.genesis.source }}"
           volumeMounts:
-            - mountPath: /etc/proxyd/
+            - mountPath: /etc/proxyd
               name: proxyd-volume
           securityContext:
             runAsUser: 0
@@ -46,7 +49,9 @@ spec:
           ports:
             - name: proxyd-rpc
               containerPort: 8080
-
+          volumeMounts:
+            - name: proxyd-volume
+              mountPath: /etc/proxyd
 ---
 
 apiVersion: v1

--- a/charts/mothership/values.yaml
+++ b/charts/mothership/values.yaml
@@ -67,3 +67,10 @@ bundler:
   loadBalancerExternal: false
   gethRpc: http://node-1:8545
   port: 4337
+
+proxyd: 
+  enabled: false
+  image: us-docker.pkg.dev/oplabs-tools-artifacts/images/proxyd:v4.6.0
+  loadBalancerExternal: false
+  gethRpc: http://node-1:8545
+  port: 8080

--- a/mothership/holesky-testnet/values.yaml
+++ b/mothership/holesky-testnet/values.yaml
@@ -52,3 +52,7 @@ opProposer:
 bundler:
   enabled: true
   loadBalancerExternal: true
+
+proxyd:
+  enabled: true
+  loadBalancerExternal: true


### PR DESCRIPTION
the proxyd has been added to distinguish endpoints for specific RPC calls (especially eth_getTransactionReceipt) and to enable load balancing.