### PR TITLE
Mothership: Enable proxyd to devnet(include srdg), change op-geth registry

### DIFF
--- a/charts/mothership/templates/proxyd.yaml
+++ b/charts/mothership/templates/proxyd.yaml
@@ -52,6 +52,11 @@ spec:
           volumeMounts:
             - name: proxyd-volume
               mountPath: /etc/proxyd
+      {{- with $.Values.proxyd.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
 ---
 
 apiVersion: v1

--- a/charts/mothership/values.yaml
+++ b/charts/mothership/values.yaml
@@ -21,7 +21,7 @@ node:
   count: 1
   loadBalancerExternal: false
   opGeth:
-    image: &op-geth-image stackupwallet/op-geth:v1.101315.2
+    image: &op-geth-image ghcr.io/planetarium/op-geth:latest
     port: &op-geth-port
       rpc: 8545
       wsrpc: 8546
@@ -65,7 +65,7 @@ bundler:
   enabled: false
   image: stackupwallet/stackup-bundler:v0.6.47
   loadBalancerExternal: false
-  gethRpc: http://node-1:8545
+  gethRpc: http://proxy:8080
   port: 4337
 
 proxyd: 

--- a/charts/mothership/values.yaml
+++ b/charts/mothership/values.yaml
@@ -21,7 +21,7 @@ node:
   count: 1
   loadBalancerExternal: false
   opGeth:
-    image: &op-geth-image ghcr.io/planetarium/op-geth:latest
+    image: &op-geth-image ghcr.io/planetarium/op-geth:v1.101315.2
     port: &op-geth-port
       rpc: 8545
       wsrpc: 8546

--- a/charts/mothership/values.yaml
+++ b/charts/mothership/values.yaml
@@ -65,7 +65,7 @@ bundler:
   enabled: false
   image: stackupwallet/stackup-bundler:v0.6.47
   loadBalancerExternal: false
-  gethRpc: http://proxy:8080
+  gethRpc: http://proxyd:8080
   port: 4337
 
 proxyd: 

--- a/mothership/holesky-devnet/values.yaml
+++ b/mothership/holesky-devnet/values.yaml
@@ -52,3 +52,9 @@ opProposer:
 bundler:
   enabled: true
   loadBalancerExternal: true
+
+proxyd:
+  enabled: true
+  loadBalancerExternal: true
+  nodeSelector:
+    eks.amazonaws.com/nodegroup: mothership-r7a_l_2c

--- a/mothership/holesky-testnet/values.yaml
+++ b/mothership/holesky-testnet/values.yaml
@@ -56,3 +56,5 @@ bundler:
 proxyd:
   enabled: true
   loadBalancerExternal: true
+  nodeSelector:
+    eks.amazonaws.com/nodegroup: mothership-r7a_l_2c

--- a/srdg/holesky-devnet/values.yaml
+++ b/srdg/holesky-devnet/values.yaml
@@ -55,3 +55,13 @@ opBatcher:
 opProposer:
   nodeSelector:
     eks.amazonaws.com/nodegroup: srdg-m5_l_2c
+
+bundler:
+  enabled: true
+  loadBalancerExternal: true
+
+proxyd:
+  enabled: true
+  loadBalancerExternal: true
+  nodeSelector:
+    eks.amazonaws.com/nodegroup: srdg-m5_l_2c


### PR DESCRIPTION
- Add proxyd to the Mothership devnet.
- The Bundler now calls RPCs through the proxy.
- Change the registry to use a customized version of op-geth for interacting with the bundler related to EIP-7212.
- Proxyd only supports the x86_64 architecture.