### PR TITLE
Enable remove-key-value-service for internal headless

### DIFF
--- a/9c-internal/multiplanetary/network/9c-network.yaml
+++ b/9c-internal/multiplanetary/network/9c-network.yaml
@@ -93,7 +93,6 @@ validator:
   - --tx-quota-per-signer=1
   - --arena-participants-sync=false
   - --tx-life-time=2000000000
-  - --remote-key-value-service
 
 remoteHeadless:
   image:
@@ -123,6 +122,7 @@ remoteHeadless:
 
   extraArgs:
   - --tx-quota-per-signer=1
+  - --remote-key-value-service
 
 dataProvider:
   enabled: true

--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -155,6 +155,7 @@ remoteHeadless:
 
   extraArgs:
   - --planet=HeimdallInternal
+  - --remote-key-value-service
 
 rudolfService:
   enabled: true
@@ -228,7 +229,6 @@ validator:
   extraArgs:
   - --tx-life-time=2000000000
   - --planet=HeimdallInternal
-  - --remote-key-value-service
 
 worldBoss:
   enabled: true


### PR DESCRIPTION
SSIA