### PR TITLE
mothership: add blockscout.{enabled, db.enabled, databaseUrl} values

### DIFF
--- a/charts/mothership/templates/blockscout.yaml
+++ b/charts/mothership/templates/blockscout.yaml
@@ -1,3 +1,6 @@
+{{- if .Values.blockscout.enabled }}
+---
+
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -41,7 +44,7 @@ spec:
             - name: CHECKSUM_FUNCTION
               value: eth
             - name: DATABASE_URL
-              value: postgresql://postgres:@blockscout-postgres:5432/blockscout?ssl=false
+              value: {{ .Values.blockscout.databaseUrl }}
             - name: DECODE_NOT_A_CONTRACT_CALLS
               value: "true"
             - name: DISABLE_EXCHANGE_RATES
@@ -168,6 +171,8 @@ spec:
       port: 443
 
 ---
+{{- if .Values.blockscout.db.enabled }}
+---
 
 apiVersion: apps/v1
 kind: StatefulSet
@@ -231,3 +236,7 @@ spec:
     - protocol: TCP
       port: 5432
       targetPort: 5432
+
+---
+{{- end }}
+{{- end }}

--- a/charts/mothership/values.yaml
+++ b/charts/mothership/values.yaml
@@ -54,11 +54,14 @@ opProposer:
     rpc: 8560
 
 blockscout:
+  enabled: false
   image: blockscout/blockscout:6.7.1
   port: 5000
   loadBalancerExternal: false
   gethRpc: http://node-1:8545
+  databaseUrl: postgresql://postgres:@blockscout-postgres:5432/blockscout?ssl=false
   db:
+    enabled: false
     storage: 10Gi
 
 bundler:

--- a/mothership/holesky-devnet/values.yaml
+++ b/mothership/holesky-devnet/values.yaml
@@ -15,8 +15,10 @@ genesis:
   s3SnapshotPath: mothership-devnet-holesky-genesis/snapshot
 
 blockscout:
+  enabled: true
   loadBalancerExternal: true
   db:
+    enabled: true
     storage: 100Gi
 
 sequencer:

--- a/mothership/holesky-testnet/values.yaml
+++ b/mothership/holesky-testnet/values.yaml
@@ -15,8 +15,10 @@ genesis:
   s3SnapshotPath: "mothership-devnet-holesky-genesis/testnet/snapshot"
 
 blockscout:
+  enabled: true
   loadBalancerExternal: true
   db:
+    enabled: true
     storage: 100Gi
 
 sequencer:


### PR DESCRIPTION
preparing to migrate blockscout-postgres to external db providers