### PR TITLE
Add gateway api controller

### DIFF
--- a/9c-dev/argocd/bootstrap.yaml
+++ b/9c-dev/argocd/bootstrap.yaml
@@ -91,6 +91,8 @@ spec:
           nodeGroup: general-r7g_xl_2c
         pyroscope:
           enabled: true
+        gatewayApi:
+          enabled: true
 
   destination:
     server: https://kubernetes.default.svc

--- a/common/bootstrap/templates/aws-gateway-api-controller.yaml
+++ b/common/bootstrap/templates/aws-gateway-api-controller.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gatewayApi.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -16,3 +17,4 @@ spec:
     automated:
       prune: false
       selfHeal: false
+{{- end }}

--- a/common/bootstrap/templates/aws-gateway-api-controller.yaml
+++ b/common/bootstrap/templates/aws-gateway-api-controller.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: aws-gateway-api-controller
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/planetarium/9c-infra
+    targetRevision: main
+    path: common/tools/gateway-api-controller
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: aws-application-networking-system
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: false

--- a/common/bootstrap/values.yaml
+++ b/common/bootstrap/values.yaml
@@ -55,3 +55,6 @@ pyroscope:
   enabled: false
   replicaCount: 2
   nodeGroup: ""
+
+gatewayApi:
+  enabled: false

--- a/common/tools/gateway-api-controller/controller.yaml
+++ b/common/tools/gateway-api-controller/controller.yaml
@@ -1,0 +1,8882 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: gateway-api-controller
+  name: aws-application-networking-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: accesslogpolicies.application-networking.k8s.aws
+spec:
+  group: application-networking.k8s.aws
+  names:
+    categories:
+    - gateway-api
+    kind: AccessLogPolicy
+    listKind: AccessLogPolicyList
+    plural: accesslogpolicies
+    shortNames:
+    - alp
+    singular: accesslogpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AccessLogPolicySpec defines the desired state of AccessLogPolicy.
+            properties:
+              destinationArn:
+                description: "The Amazon Resource Name (ARN) of the destination that
+                  will store access logs. Supported values are S3 Bucket, CloudWatch
+                  Log Group, and Firehose Delivery Stream ARNs. \n Changes to this
+                  value results in replacement of the VPC Lattice Access Log Subscription."
+                pattern: ^arn(:[a-z0-9]+([.-][a-z0-9]+)*){2}(:([a-z0-9]+([.-][a-z0-9]+)*)?){2}:([^/].*)?
+                type: string
+              targetRef:
+                description: "TargetRef points to the Kubernetes Gateway, HTTPRoute,
+                  or GRPCRoute resource that will have this policy attached. \n This
+                  field is following the guidelines of Kubernetes Gateway API policy
+                  attachment."
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the referent. When
+                      unspecified, the local namespace is inferred. Even when policy
+                      targets a resource in a different namespace, it MUST only apply
+                      to traffic originating from the same namespace as the policy.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - destinationArn
+            - targetRef
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: NotReconciled
+                status: Unknown
+                type: Accepted
+            description: Status defines the current state of AccessLogPolicy.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the AccessLogPolicy.
+                  \n Implementations should prefer to express Policy conditions using
+                  the `PolicyConditionType` and `PolicyConditionReason` constants
+                  so that operators and tools can converge on a common vocabulary
+                  to describe AccessLogPolicy state. \n Known condition types are:
+                  \n * \"Accepted\" * \"Ready\""
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/external-dns/pull/2007
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: dnsendpoints.externaldns.k8s.io
+spec:
+  group: externaldns.k8s.io
+  names:
+    kind: DNSEndpoint
+    listKind: DNSEndpointList
+    plural: dnsendpoints
+    singular: dnsendpoint
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DNSEndpointSpec defines the desired state of DNSEndpoint
+            properties:
+              endpoints:
+                items:
+                  description: Endpoint is a high-level way of a connection between
+                    a service and an IP
+                  properties:
+                    dnsName:
+                      description: The hostname of the DNS record
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels stores labels defined for the Endpoint
+                      type: object
+                    providerSpecific:
+                      description: ProviderSpecific stores provider specific config
+                      items:
+                        description: ProviderSpecificProperty holds the name and value
+                          of a configuration which is specific to individual DNS providers
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    recordTTL:
+                      description: TTL for the record
+                      format: int64
+                      type: integer
+                    recordType:
+                      description: RecordType type of record, e.g. CNAME, A, SRV,
+                        TXT etc
+                      type: string
+                    setIdentifier:
+                      description: Identifier to distinguish multiple records with
+                        the same name and type (e.g. Route53 records with routing
+                        policies other than 'simple')
+                      type: string
+                    targets:
+                      description: The targets the DNS record points to
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            description: DNSEndpointStatus defines the observed state of DNSEndpoint
+            properties:
+              observedGeneration:
+                description: The generation observed by the external-dns controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
+    gateway.networking.k8s.io/bundle-version: v0.6.1
+    gateway.networking.k8s.io/channel: standard
+  creationTimestamp: null
+  name: gatewayclasses.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: GatewayClass
+    listKind: GatewayClassList
+    plural: gatewayclasses
+    shortNames:
+    - gc
+    singular: gatewayclass
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.controllerName
+      name: Controller
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.description
+      name: Description
+      priority: 1
+      type: string
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of GatewayClass has been deprecated and
+      will be removed in a future release of the API. Please upgrade to v1beta1.
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: "GatewayClass describes a class of Gateways available to the
+          user for creating Gateway resources. \n It is recommended that this resource
+          be used as a template for Gateways. This means that a Gateway is based on
+          the state of the GatewayClass at the time it was created and changes to
+          the GatewayClass or associated parameters are not propagated down to existing
+          Gateways. This recommendation is intended to limit the blast radius of changes
+          to GatewayClass or associated parameters. If implementations choose to propagate
+          GatewayClass changes to existing Gateways, that MUST be clearly documented
+          by the implementation. \n Whenever one or more Gateways are using a GatewayClass,
+          implementations MUST add the `gateway-exists-finalizer.gateway.networking.k8s.io`
+          finalizer on the associated GatewayClass. This ensures that a GatewayClass
+          associated with a Gateway is not deleted while in use. \n GatewayClass is
+          a Cluster level resource."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GatewayClass.
+            properties:
+              controllerName:
+                description: "ControllerName is the name of the controller that is
+                  managing Gateways of this class. The value of this field MUST be
+                  a domain prefixed path. \n Example: \"example.net/gateway-controller\".
+                  \n This field is not mutable and cannot be empty. \n Support: Core"
+                maxLength: 253
+                minLength: 1
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                type: string
+              description:
+                description: Description helps describe a GatewayClass with more details.
+                maxLength: 64
+                type: string
+              parametersRef:
+                description: "ParametersRef is a reference to a resource that contains
+                  the configuration parameters corresponding to the GatewayClass.
+                  This is optional if the controller does not require any additional
+                  configuration. \n ParametersRef can reference a standard Kubernetes
+                  resource, i.e. ConfigMap, or an implementation-specific custom resource.
+                  The resource can be cluster-scoped or namespace-scoped. \n If the
+                  referent cannot be found, the GatewayClass's \"InvalidParameters\"
+                  status condition will be true. \n Support: Implementation-specific"
+                properties:
+                  group:
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the referent.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the referent. This
+                      field is required when referring to a Namespace-scoped resource
+                      and MUST be unset when referring to a Cluster-scoped resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - controllerName
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Waiting
+                status: Unknown
+                type: Accepted
+            description: Status defines the current state of GatewayClass.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                description: "Conditions is the current status from the controller
+                  for this GatewayClass. \n Controllers should prefer to publish conditions
+                  using values of GatewayClassConditionType for the type of each Condition."
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.controllerName
+      name: Controller
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.description
+      name: Description
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: "GatewayClass describes a class of Gateways available to the
+          user for creating Gateway resources. \n It is recommended that this resource
+          be used as a template for Gateways. This means that a Gateway is based on
+          the state of the GatewayClass at the time it was created and changes to
+          the GatewayClass or associated parameters are not propagated down to existing
+          Gateways. This recommendation is intended to limit the blast radius of changes
+          to GatewayClass or associated parameters. If implementations choose to propagate
+          GatewayClass changes to existing Gateways, that MUST be clearly documented
+          by the implementation. \n Whenever one or more Gateways are using a GatewayClass,
+          implementations MUST add the `gateway-exists-finalizer.gateway.networking.k8s.io`
+          finalizer on the associated GatewayClass. This ensures that a GatewayClass
+          associated with a Gateway is not deleted while in use. \n GatewayClass is
+          a Cluster level resource."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GatewayClass.
+            properties:
+              controllerName:
+                description: "ControllerName is the name of the controller that is
+                  managing Gateways of this class. The value of this field MUST be
+                  a domain prefixed path. \n Example: \"example.net/gateway-controller\".
+                  \n This field is not mutable and cannot be empty. \n Support: Core"
+                maxLength: 253
+                minLength: 1
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                type: string
+              description:
+                description: Description helps describe a GatewayClass with more details.
+                maxLength: 64
+                type: string
+              parametersRef:
+                description: "ParametersRef is a reference to a resource that contains
+                  the configuration parameters corresponding to the GatewayClass.
+                  This is optional if the controller does not require any additional
+                  configuration. \n ParametersRef can reference a standard Kubernetes
+                  resource, i.e. ConfigMap, or an implementation-specific custom resource.
+                  The resource can be cluster-scoped or namespace-scoped. \n If the
+                  referent cannot be found, the GatewayClass's \"InvalidParameters\"
+                  status condition will be true. \n Support: Implementation-specific"
+                properties:
+                  group:
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the referent.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the referent. This
+                      field is required when referring to a Namespace-scoped resource
+                      and MUST be unset when referring to a Cluster-scoped resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - controllerName
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Waiting
+                status: Unknown
+                type: Accepted
+            description: Status defines the current state of GatewayClass.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                description: "Conditions is the current status from the controller
+                  for this GatewayClass. \n Controllers should prefer to publish conditions
+                  using values of GatewayClassConditionType for the type of each Condition."
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
+    gateway.networking.k8s.io/bundle-version: v0.6.1
+    gateway.networking.k8s.io/channel: standard
+  creationTimestamp: null
+  name: gateways.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: Gateway
+    listKind: GatewayList
+    plural: gateways
+    shortNames:
+    - gtw
+    singular: gateway
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.gatewayClassName
+      name: Class
+      type: string
+    - jsonPath: .status.addresses[*].value
+      name: Address
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of Gateway has been deprecated and will
+      be removed in a future release of the API. Please upgrade to v1beta1.
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: Gateway represents an instance of a service-traffic handling
+          infrastructure by binding Listeners to a set of IP addresses.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of Gateway.
+            properties:
+              addresses:
+                description: "Addresses requested for this Gateway. This is optional
+                  and behavior can depend on the implementation. If a value is set
+                  in the spec and the requested address is invalid or unavailable,
+                  the implementation MUST indicate this in the associated entry in
+                  GatewayStatus.Addresses. \n The Addresses field represents a request
+                  for the address(es) on the \"outside of the Gateway\", that traffic
+                  bound for this Gateway will use. This could be the IP address or
+                  hostname of an external load balancer or other networking infrastructure,
+                  or some other address that traffic will be sent to. \n The .listener.hostname
+                  field is used to route traffic that has already arrived at the Gateway
+                  to the correct in-cluster destination. \n If no Addresses are specified,
+                  the implementation MAY schedule the Gateway in an implementation-specific
+                  manner, assigning an appropriate set of Addresses. \n The implementation
+                  MUST bind all Listeners to every GatewayAddress that it assigns
+                  to the Gateway and add a corresponding entry in GatewayStatus.Addresses.
+                  \n Support: Extended"
+                items:
+                  description: GatewayAddress describes an address that can be bound
+                    to a Gateway.
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    value:
+                      description: "Value of the address. The validity of the values
+                        will depend on the type and support by the controller. \n
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`."
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - value
+                  type: object
+                maxItems: 16
+                type: array
+              gatewayClassName:
+                description: GatewayClassName used for this Gateway. This is the name
+                  of a GatewayClass resource.
+                maxLength: 253
+                minLength: 1
+                type: string
+              listeners:
+                description: "Listeners associated with this Gateway. Listeners define
+                  logical endpoints that are bound on this Gateway's addresses. At
+                  least one Listener MUST be specified. \n Each listener in a Gateway
+                  must have a unique combination of Hostname, Port, and Protocol.
+                  \n An implementation MAY group Listeners by Port and then collapse
+                  each group of Listeners into a single Listener if the implementation
+                  determines that the Listeners in the group are \"compatible\". An
+                  implementation MAY also group together and collapse compatible Listeners
+                  belonging to different Gateways. \n For example, an implementation
+                  might consider Listeners to be compatible with each other if all
+                  of the following conditions are met: \n 1. Either each Listener
+                  within the group specifies the \"HTTP\"    Protocol or each Listener
+                  within the group specifies either    the \"HTTPS\" or \"TLS\" Protocol.
+                  \n 2. Each Listener within the group specifies a Hostname that is
+                  unique    within the group. \n 3. As a special case, one Listener
+                  within a group may omit Hostname,    in which case this Listener
+                  matches when no other Listener    matches. \n If the implementation
+                  does collapse compatible Listeners, the hostname provided in the
+                  incoming client request MUST be matched to a Listener to find the
+                  correct set of Routes. The incoming hostname MUST be matched using
+                  the Hostname field for each Listener in order of most to least specific.
+                  That is, exact matches must be processed before wildcard matches.
+                  \n If this field specifies multiple Listeners that have the same
+                  Port value but are not compatible, the implementation must raise
+                  a \"Conflicted\" condition in the Listener status. \n Support: Core"
+                items:
+                  description: Listener embodies the concept of a logical endpoint
+                    where a Gateway accepts network connections.
+                  properties:
+                    allowedRoutes:
+                      default:
+                        namespaces:
+                          from: Same
+                      description: "AllowedRoutes defines the types of routes that
+                        MAY be attached to a Listener and the trusted namespaces where
+                        those Route resources MAY be present. \n Although a client
+                        request may match multiple route rules, only one rule may
+                        ultimately receive the request. Matching precedence MUST be
+                        determined in order of the following criteria: \n * The most
+                        specific match as defined by the Route type. * The oldest
+                        Route based on creation timestamp. For example, a Route with
+                        \  a creation timestamp of \"2020-09-08 01:02:03\" is given
+                        precedence over   a Route with a creation timestamp of \"2020-09-08
+                        01:02:04\". * If everything else is equivalent, the Route
+                        appearing first in   alphabetical order (namespace/name) should
+                        be given precedence. For   example, foo/bar is given precedence
+                        over foo/baz. \n All valid rules within a Route attached to
+                        this Listener should be implemented. Invalid Route rules can
+                        be ignored (sometimes that will mean the full Route). If a
+                        Route rule transitions from valid to invalid, support for
+                        that Route rule should be dropped to ensure consistency. For
+                        example, even if a filter specified by a Route rule is invalid,
+                        the rest of the rules within that Route should still be supported.
+                        \n Support: Core"
+                      properties:
+                        kinds:
+                          description: "Kinds specifies the groups and kinds of Routes
+                            that are allowed to bind to this Gateway Listener. When
+                            unspecified or empty, the kinds of Routes selected are
+                            determined using the Listener protocol. \n A RouteGroupKind
+                            MUST correspond to kinds of Routes that are compatible
+                            with the application protocol specified in the Listener's
+                            Protocol field. If an implementation does not support
+                            or recognize this resource type, it MUST set the \"ResolvedRefs\"
+                            condition to False for this Listener with the \"InvalidRouteKinds\"
+                            reason. \n Support: Core"
+                          items:
+                            description: RouteGroupKind indicates the group and kind
+                              of a Route resource.
+                            properties:
+                              group:
+                                default: gateway.networking.k8s.io
+                                description: Group is the group of the Route.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is the kind of the Route.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                            required:
+                            - kind
+                            type: object
+                          maxItems: 8
+                          type: array
+                        namespaces:
+                          default:
+                            from: Same
+                          description: "Namespaces indicates namespaces from which
+                            Routes may be attached to this Listener. This is restricted
+                            to the namespace of this Gateway by default. \n Support:
+                            Core"
+                          properties:
+                            from:
+                              default: Same
+                              description: "From indicates where Routes will be selected
+                                for this Gateway. Possible values are: * All: Routes
+                                in all namespaces may be used by this Gateway. * Selector:
+                                Routes in namespaces selected by the selector may
+                                be used by   this Gateway. * Same: Only Routes in
+                                the same namespace may be used by this Gateway. \n
+                                Support: Core"
+                              enum:
+                              - All
+                              - Selector
+                              - Same
+                              type: string
+                            selector:
+                              description: "Selector must be specified when From is
+                                set to \"Selector\". In that case, only Routes in
+                                Namespaces matching this Selector will be selected
+                                by this Gateway. This field is ignored for other values
+                                of \"From\". \n Support: Core"
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    hostname:
+                      description: "Hostname specifies the virtual hostname to match
+                        for protocol types that define this concept. When unspecified,
+                        all hostnames are matched. This field is ignored for protocols
+                        that don't require hostname based matching. \n Implementations
+                        MUST apply Hostname matching appropriately for each of the
+                        following protocols: \n * TLS: The Listener Hostname MUST
+                        match the SNI. * HTTP: The Listener Hostname MUST match the
+                        Host header of the request. * HTTPS: The Listener Hostname
+                        SHOULD match at both the TLS and HTTP   protocol layers as
+                        described above. If an implementation does not   ensure that
+                        both the SNI and Host header match the Listener hostname,
+                        \  it MUST clearly document that. \n For HTTPRoute and TLSRoute
+                        resources, there is an interaction with the `spec.hostnames`
+                        array. When both listener and route specify hostnames, there
+                        MUST be an intersection between the values for a Route to
+                        be accepted. For more information, refer to the Route specific
+                        Hostnames documentation. \n Hostnames that are prefixed with
+                        a wildcard label (`*.`) are interpreted as a suffix match.
+                        That means that a match for `*.example.com` would match both
+                        `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+                        \n Support: Core"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    name:
+                      description: "Name is the name of the Listener. This name MUST
+                        be unique within a Gateway. \n Support: Core"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    port:
+                      description: "Port is the network port. Multiple listeners may
+                        use the same port, subject to the Listener compatibility rules.
+                        \n Support: Core"
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    protocol:
+                      description: "Protocol specifies the network protocol this listener
+                        expects to receive. \n Support: Core"
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[a-zA-Z0-9]([-a-zSA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                      type: string
+                    tls:
+                      description: "TLS is the TLS configuration for the Listener.
+                        This field is required if the Protocol field is \"HTTPS\"
+                        or \"TLS\". It is invalid to set this field if the Protocol
+                        field is \"HTTP\", \"TCP\", or \"UDP\". \n The association
+                        of SNIs to Certificate defined in GatewayTLSConfig is defined
+                        based on the Hostname field for this listener. \n The GatewayClass
+                        MUST use the longest matching SNI out of all available certificates
+                        for any TLS handshake. \n Support: Core"
+                      properties:
+                        certificateRefs:
+                          description: "CertificateRefs contains a series of references
+                            to Kubernetes objects that contains TLS certificates and
+                            private keys. These certificates are used to establish
+                            a TLS handshake for requests that match the hostname of
+                            the associated listener. \n A single CertificateRef to
+                            a Kubernetes Secret has \"Core\" support. Implementations
+                            MAY choose to support attaching multiple certificates
+                            to a Listener, but this behavior is implementation-specific.
+                            \n References to a resource in different namespace are
+                            invalid UNLESS there is a ReferenceGrant in the target
+                            namespace that allows the certificate to be attached.
+                            If a ReferenceGrant does not allow this reference, the
+                            \"ResolvedRefs\" condition MUST be set to False for this
+                            listener with the \"RefNotPermitted\" reason. \n This
+                            field is required to have at least one element when the
+                            mode is set to \"Terminate\" (default) and is optional
+                            otherwise. \n CertificateRefs can reference to standard
+                            Kubernetes resources, i.e. Secret, or implementation-specific
+                            custom resources. \n Support: Core - A single reference
+                            to a Kubernetes Secret of type kubernetes.io/tls \n Support:
+                            Implementation-specific (More than one reference or other
+                            resource types)"
+                          items:
+                            description: "SecretObjectReference identifies an API
+                              object including its namespace, defaulting to Secret.
+                              \n The API object must be valid in the cluster; the
+                              Group and Kind must be registered in the cluster for
+                              this reference to be valid. \n References to objects
+                              with invalid Group and Kind are not valid, and must
+                              be rejected by the implementation, with appropriate
+                              Conditions set on the containing object."
+                            properties:
+                              group:
+                                default: ""
+                                description: Group is the group of the referent. For
+                                  example, "gateway.networking.k8s.io". When unspecified
+                                  or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Secret
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: "Namespace is the namespace of the backend.
+                                  When unspecified, the local namespace is inferred.
+                                  \n Note that when a namespace is specified, a ReferenceGrant
+                                  object is required in the referent namespace to
+                                  allow that namespace's owner to accept the reference.
+                                  See the ReferenceGrant documentation for details.
+                                  \n Support: Core"
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          maxItems: 64
+                          type: array
+                        mode:
+                          default: Terminate
+                          description: "Mode defines the TLS behavior for the TLS
+                            session initiated by the client. There are two possible
+                            modes: \n - Terminate: The TLS session between the downstream
+                            client   and the Gateway is terminated at the Gateway.
+                            This mode requires   certificateRefs to be set and contain
+                            at least one element. - Passthrough: The TLS session is
+                            NOT terminated by the Gateway. This   implies that the
+                            Gateway can't decipher the TLS stream except for   the
+                            ClientHello message of the TLS protocol.   CertificateRefs
+                            field is ignored in this mode. \n Support: Core"
+                          enum:
+                          - Terminate
+                          - Passthrough
+                          type: string
+                        options:
+                          additionalProperties:
+                            description: AnnotationValue is the value of an annotation
+                              in Gateway API. This is used for validation of maps
+                              such as TLS options. This roughly matches Kubernetes
+                              annotation validation, although the length validation
+                              in that case is based on the entire size of the annotations
+                              struct.
+                            maxLength: 4096
+                            minLength: 0
+                            type: string
+                          description: "Options are a list of key/value pairs to enable
+                            extended TLS configuration for each implementation. For
+                            example, configuring the minimum TLS version or supported
+                            cipher suites. \n A set of common keys MAY be defined
+                            by the API in the future. To avoid any ambiguity, implementation-specific
+                            definitions MUST use domain-prefixed names, such as `example.com/my-custom-option`.
+                            Un-prefixed names are reserved for key names defined by
+                            Gateway API. \n Support: Implementation-specific"
+                          maxProperties: 16
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                maxItems: 64
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            required:
+            - gatewayClassName
+            - listeners
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: NotReconciled
+                status: Unknown
+                type: Accepted
+            description: Status defines the current state of Gateway.
+            properties:
+              addresses:
+                description: Addresses lists the IP addresses that have actually been
+                  bound to the Gateway. These addresses may differ from the addresses
+                  in the Spec, e.g. if the Gateway automatically assigns an address
+                  from a reserved pool.
+                items:
+                  description: GatewayAddress describes an address that can be bound
+                    to a Gateway.
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    value:
+                      description: "Value of the address. The validity of the values
+                        will depend on the type and support by the controller. \n
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`."
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - value
+                  type: object
+                maxItems: 16
+                type: array
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the Gateway.
+                  \n Implementations should prefer to express Gateway conditions using
+                  the `GatewayConditionType` and `GatewayConditionReason` constants
+                  so that operators and tools can converge on a common vocabulary
+                  to describe Gateway state. \n Known condition types are: \n * \"Accepted\"
+                  * \"Ready\""
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              listeners:
+                description: Listeners provide status for each unique listener port
+                  defined in the Spec.
+                items:
+                  description: ListenerStatus is the status associated with a Listener.
+                  properties:
+                    attachedRoutes:
+                      description: AttachedRoutes represents the total number of Routes
+                        that have been successfully attached to this Listener.
+                      format: int32
+                      type: integer
+                    conditions:
+                      description: Conditions describe the current condition of this
+                        listener.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n \ttype FooStatus struct{
+                          \t    // Represents the observations of a foo's current
+                          state. \t    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type
+                          \t    // +patchStrategy=merge \t    // +listType=map \t
+                          \   // +listMapKey=type \t    Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other
+                          fields \t}"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    name:
+                      description: Name is the name of the Listener that this status
+                        corresponds to.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    supportedKinds:
+                      description: "SupportedKinds is the list indicating the Kinds
+                        supported by this listener. This MUST represent the kinds
+                        an implementation supports for that Listener configuration.
+                        \n If kinds are specified in Spec that are not supported,
+                        they MUST NOT appear in this list and an implementation MUST
+                        set the \"ResolvedRefs\" condition to \"False\" with the \"InvalidRouteKinds\"
+                        reason. If both valid and invalid Route kinds are specified,
+                        the implementation MUST reference the valid Route kinds that
+                        have been specified."
+                      items:
+                        description: RouteGroupKind indicates the group and kind of
+                          a Route resource.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: Group is the group of the Route.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            description: Kind is the kind of the Route.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                        required:
+                        - kind
+                        type: object
+                      maxItems: 8
+                      type: array
+                  required:
+                  - attachedRoutes
+                  - conditions
+                  - name
+                  - supportedKinds
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.gatewayClassName
+      name: Class
+      type: string
+    - jsonPath: .status.addresses[*].value
+      name: Address
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Gateway represents an instance of a service-traffic handling
+          infrastructure by binding Listeners to a set of IP addresses.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of Gateway.
+            properties:
+              addresses:
+                description: "Addresses requested for this Gateway. This is optional
+                  and behavior can depend on the implementation. If a value is set
+                  in the spec and the requested address is invalid or unavailable,
+                  the implementation MUST indicate this in the associated entry in
+                  GatewayStatus.Addresses. \n The Addresses field represents a request
+                  for the address(es) on the \"outside of the Gateway\", that traffic
+                  bound for this Gateway will use. This could be the IP address or
+                  hostname of an external load balancer or other networking infrastructure,
+                  or some other address that traffic will be sent to. \n The .listener.hostname
+                  field is used to route traffic that has already arrived at the Gateway
+                  to the correct in-cluster destination. \n If no Addresses are specified,
+                  the implementation MAY schedule the Gateway in an implementation-specific
+                  manner, assigning an appropriate set of Addresses. \n The implementation
+                  MUST bind all Listeners to every GatewayAddress that it assigns
+                  to the Gateway and add a corresponding entry in GatewayStatus.Addresses.
+                  \n Support: Extended"
+                items:
+                  description: GatewayAddress describes an address that can be bound
+                    to a Gateway.
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    value:
+                      description: "Value of the address. The validity of the values
+                        will depend on the type and support by the controller. \n
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`."
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - value
+                  type: object
+                maxItems: 16
+                type: array
+              gatewayClassName:
+                description: GatewayClassName used for this Gateway. This is the name
+                  of a GatewayClass resource.
+                maxLength: 253
+                minLength: 1
+                type: string
+              listeners:
+                description: "Listeners associated with this Gateway. Listeners define
+                  logical endpoints that are bound on this Gateway's addresses. At
+                  least one Listener MUST be specified. \n Each listener in a Gateway
+                  must have a unique combination of Hostname, Port, and Protocol.
+                  \n An implementation MAY group Listeners by Port and then collapse
+                  each group of Listeners into a single Listener if the implementation
+                  determines that the Listeners in the group are \"compatible\". An
+                  implementation MAY also group together and collapse compatible Listeners
+                  belonging to different Gateways. \n For example, an implementation
+                  might consider Listeners to be compatible with each other if all
+                  of the following conditions are met: \n 1. Either each Listener
+                  within the group specifies the \"HTTP\"    Protocol or each Listener
+                  within the group specifies either    the \"HTTPS\" or \"TLS\" Protocol.
+                  \n 2. Each Listener within the group specifies a Hostname that is
+                  unique    within the group. \n 3. As a special case, one Listener
+                  within a group may omit Hostname,    in which case this Listener
+                  matches when no other Listener    matches. \n If the implementation
+                  does collapse compatible Listeners, the hostname provided in the
+                  incoming client request MUST be matched to a Listener to find the
+                  correct set of Routes. The incoming hostname MUST be matched using
+                  the Hostname field for each Listener in order of most to least specific.
+                  That is, exact matches must be processed before wildcard matches.
+                  \n If this field specifies multiple Listeners that have the same
+                  Port value but are not compatible, the implementation must raise
+                  a \"Conflicted\" condition in the Listener status. \n Support: Core"
+                items:
+                  description: Listener embodies the concept of a logical endpoint
+                    where a Gateway accepts network connections.
+                  properties:
+                    allowedRoutes:
+                      default:
+                        namespaces:
+                          from: Same
+                      description: "AllowedRoutes defines the types of routes that
+                        MAY be attached to a Listener and the trusted namespaces where
+                        those Route resources MAY be present. \n Although a client
+                        request may match multiple route rules, only one rule may
+                        ultimately receive the request. Matching precedence MUST be
+                        determined in order of the following criteria: \n * The most
+                        specific match as defined by the Route type. * The oldest
+                        Route based on creation timestamp. For example, a Route with
+                        \  a creation timestamp of \"2020-09-08 01:02:03\" is given
+                        precedence over   a Route with a creation timestamp of \"2020-09-08
+                        01:02:04\". * If everything else is equivalent, the Route
+                        appearing first in   alphabetical order (namespace/name) should
+                        be given precedence. For   example, foo/bar is given precedence
+                        over foo/baz. \n All valid rules within a Route attached to
+                        this Listener should be implemented. Invalid Route rules can
+                        be ignored (sometimes that will mean the full Route). If a
+                        Route rule transitions from valid to invalid, support for
+                        that Route rule should be dropped to ensure consistency. For
+                        example, even if a filter specified by a Route rule is invalid,
+                        the rest of the rules within that Route should still be supported.
+                        \n Support: Core"
+                      properties:
+                        kinds:
+                          description: "Kinds specifies the groups and kinds of Routes
+                            that are allowed to bind to this Gateway Listener. When
+                            unspecified or empty, the kinds of Routes selected are
+                            determined using the Listener protocol. \n A RouteGroupKind
+                            MUST correspond to kinds of Routes that are compatible
+                            with the application protocol specified in the Listener's
+                            Protocol field. If an implementation does not support
+                            or recognize this resource type, it MUST set the \"ResolvedRefs\"
+                            condition to False for this Listener with the \"InvalidRouteKinds\"
+                            reason. \n Support: Core"
+                          items:
+                            description: RouteGroupKind indicates the group and kind
+                              of a Route resource.
+                            properties:
+                              group:
+                                default: gateway.networking.k8s.io
+                                description: Group is the group of the Route.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is the kind of the Route.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                            required:
+                            - kind
+                            type: object
+                          maxItems: 8
+                          type: array
+                        namespaces:
+                          default:
+                            from: Same
+                          description: "Namespaces indicates namespaces from which
+                            Routes may be attached to this Listener. This is restricted
+                            to the namespace of this Gateway by default. \n Support:
+                            Core"
+                          properties:
+                            from:
+                              default: Same
+                              description: "From indicates where Routes will be selected
+                                for this Gateway. Possible values are: * All: Routes
+                                in all namespaces may be used by this Gateway. * Selector:
+                                Routes in namespaces selected by the selector may
+                                be used by   this Gateway. * Same: Only Routes in
+                                the same namespace may be used by this Gateway. \n
+                                Support: Core"
+                              enum:
+                              - All
+                              - Selector
+                              - Same
+                              type: string
+                            selector:
+                              description: "Selector must be specified when From is
+                                set to \"Selector\". In that case, only Routes in
+                                Namespaces matching this Selector will be selected
+                                by this Gateway. This field is ignored for other values
+                                of \"From\". \n Support: Core"
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    hostname:
+                      description: "Hostname specifies the virtual hostname to match
+                        for protocol types that define this concept. When unspecified,
+                        all hostnames are matched. This field is ignored for protocols
+                        that don't require hostname based matching. \n Implementations
+                        MUST apply Hostname matching appropriately for each of the
+                        following protocols: \n * TLS: The Listener Hostname MUST
+                        match the SNI. * HTTP: The Listener Hostname MUST match the
+                        Host header of the request. * HTTPS: The Listener Hostname
+                        SHOULD match at both the TLS and HTTP   protocol layers as
+                        described above. If an implementation does not   ensure that
+                        both the SNI and Host header match the Listener hostname,
+                        \  it MUST clearly document that. \n For HTTPRoute and TLSRoute
+                        resources, there is an interaction with the `spec.hostnames`
+                        array. When both listener and route specify hostnames, there
+                        MUST be an intersection between the values for a Route to
+                        be accepted. For more information, refer to the Route specific
+                        Hostnames documentation. \n Hostnames that are prefixed with
+                        a wildcard label (`*.`) are interpreted as a suffix match.
+                        That means that a match for `*.example.com` would match both
+                        `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+                        \n Support: Core"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    name:
+                      description: "Name is the name of the Listener. This name MUST
+                        be unique within a Gateway. \n Support: Core"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    port:
+                      description: "Port is the network port. Multiple listeners may
+                        use the same port, subject to the Listener compatibility rules.
+                        \n Support: Core"
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    protocol:
+                      description: "Protocol specifies the network protocol this listener
+                        expects to receive. \n Support: Core"
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[a-zA-Z0-9]([-a-zSA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                      type: string
+                    tls:
+                      description: "TLS is the TLS configuration for the Listener.
+                        This field is required if the Protocol field is \"HTTPS\"
+                        or \"TLS\". It is invalid to set this field if the Protocol
+                        field is \"HTTP\", \"TCP\", or \"UDP\". \n The association
+                        of SNIs to Certificate defined in GatewayTLSConfig is defined
+                        based on the Hostname field for this listener. \n The GatewayClass
+                        MUST use the longest matching SNI out of all available certificates
+                        for any TLS handshake. \n Support: Core"
+                      properties:
+                        certificateRefs:
+                          description: "CertificateRefs contains a series of references
+                            to Kubernetes objects that contains TLS certificates and
+                            private keys. These certificates are used to establish
+                            a TLS handshake for requests that match the hostname of
+                            the associated listener. \n A single CertificateRef to
+                            a Kubernetes Secret has \"Core\" support. Implementations
+                            MAY choose to support attaching multiple certificates
+                            to a Listener, but this behavior is implementation-specific.
+                            \n References to a resource in different namespace are
+                            invalid UNLESS there is a ReferenceGrant in the target
+                            namespace that allows the certificate to be attached.
+                            If a ReferenceGrant does not allow this reference, the
+                            \"ResolvedRefs\" condition MUST be set to False for this
+                            listener with the \"RefNotPermitted\" reason. \n This
+                            field is required to have at least one element when the
+                            mode is set to \"Terminate\" (default) and is optional
+                            otherwise. \n CertificateRefs can reference to standard
+                            Kubernetes resources, i.e. Secret, or implementation-specific
+                            custom resources. \n Support: Core - A single reference
+                            to a Kubernetes Secret of type kubernetes.io/tls \n Support:
+                            Implementation-specific (More than one reference or other
+                            resource types)"
+                          items:
+                            description: "SecretObjectReference identifies an API
+                              object including its namespace, defaulting to Secret.
+                              \n The API object must be valid in the cluster; the
+                              Group and Kind must be registered in the cluster for
+                              this reference to be valid. \n References to objects
+                              with invalid Group and Kind are not valid, and must
+                              be rejected by the implementation, with appropriate
+                              Conditions set on the containing object."
+                            properties:
+                              group:
+                                default: ""
+                                description: Group is the group of the referent. For
+                                  example, "gateway.networking.k8s.io". When unspecified
+                                  or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                default: Secret
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              namespace:
+                                description: "Namespace is the namespace of the backend.
+                                  When unspecified, the local namespace is inferred.
+                                  \n Note that when a namespace is specified, a ReferenceGrant
+                                  object is required in the referent namespace to
+                                  allow that namespace's owner to accept the reference.
+                                  See the ReferenceGrant documentation for details.
+                                  \n Support: Core"
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          maxItems: 64
+                          type: array
+                        mode:
+                          default: Terminate
+                          description: "Mode defines the TLS behavior for the TLS
+                            session initiated by the client. There are two possible
+                            modes: \n - Terminate: The TLS session between the downstream
+                            client   and the Gateway is terminated at the Gateway.
+                            This mode requires   certificateRefs to be set and contain
+                            at least one element. - Passthrough: The TLS session is
+                            NOT terminated by the Gateway. This   implies that the
+                            Gateway can't decipher the TLS stream except for   the
+                            ClientHello message of the TLS protocol.   CertificateRefs
+                            field is ignored in this mode. \n Support: Core"
+                          enum:
+                          - Terminate
+                          - Passthrough
+                          type: string
+                        options:
+                          additionalProperties:
+                            description: AnnotationValue is the value of an annotation
+                              in Gateway API. This is used for validation of maps
+                              such as TLS options. This roughly matches Kubernetes
+                              annotation validation, although the length validation
+                              in that case is based on the entire size of the annotations
+                              struct.
+                            maxLength: 4096
+                            minLength: 0
+                            type: string
+                          description: "Options are a list of key/value pairs to enable
+                            extended TLS configuration for each implementation. For
+                            example, configuring the minimum TLS version or supported
+                            cipher suites. \n A set of common keys MAY be defined
+                            by the API in the future. To avoid any ambiguity, implementation-specific
+                            definitions MUST use domain-prefixed names, such as `example.com/my-custom-option`.
+                            Un-prefixed names are reserved for key names defined by
+                            Gateway API. \n Support: Implementation-specific"
+                          maxProperties: 16
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - port
+                  - protocol
+                  type: object
+                maxItems: 64
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            required:
+            - gatewayClassName
+            - listeners
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: NotReconciled
+                status: Unknown
+                type: Accepted
+            description: Status defines the current state of Gateway.
+            properties:
+              addresses:
+                description: Addresses lists the IP addresses that have actually been
+                  bound to the Gateway. These addresses may differ from the addresses
+                  in the Spec, e.g. if the Gateway automatically assigns an address
+                  from a reserved pool.
+                items:
+                  description: GatewayAddress describes an address that can be bound
+                    to a Gateway.
+                  properties:
+                    type:
+                      default: IPAddress
+                      description: Type of the address.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^Hostname|IPAddress|NamedAddress|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    value:
+                      description: "Value of the address. The validity of the values
+                        will depend on the type and support by the controller. \n
+                        Examples: `1.2.3.4`, `128::1`, `my-ip-address`."
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - value
+                  type: object
+                maxItems: 16
+                type: array
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the Gateway.
+                  \n Implementations should prefer to express Gateway conditions using
+                  the `GatewayConditionType` and `GatewayConditionReason` constants
+                  so that operators and tools can converge on a common vocabulary
+                  to describe Gateway state. \n Known condition types are: \n * \"Accepted\"
+                  * \"Ready\""
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              listeners:
+                description: Listeners provide status for each unique listener port
+                  defined in the Spec.
+                items:
+                  description: ListenerStatus is the status associated with a Listener.
+                  properties:
+                    attachedRoutes:
+                      description: AttachedRoutes represents the total number of Routes
+                        that have been successfully attached to this Listener.
+                      format: int32
+                      type: integer
+                    conditions:
+                      description: Conditions describe the current condition of this
+                        listener.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n \ttype FooStatus struct{
+                          \t    // Represents the observations of a foo's current
+                          state. \t    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type
+                          \t    // +patchStrategy=merge \t    // +listType=map \t
+                          \   // +listMapKey=type \t    Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other
+                          fields \t}"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    name:
+                      description: Name is the name of the Listener that this status
+                        corresponds to.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    supportedKinds:
+                      description: "SupportedKinds is the list indicating the Kinds
+                        supported by this listener. This MUST represent the kinds
+                        an implementation supports for that Listener configuration.
+                        \n If kinds are specified in Spec that are not supported,
+                        they MUST NOT appear in this list and an implementation MUST
+                        set the \"ResolvedRefs\" condition to \"False\" with the \"InvalidRouteKinds\"
+                        reason. If both valid and invalid Route kinds are specified,
+                        the implementation MUST reference the valid Route kinds that
+                        have been specified."
+                      items:
+                        description: RouteGroupKind indicates the group and kind of
+                          a Route resource.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: Group is the group of the Route.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            description: Kind is the kind of the Route.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                        required:
+                        - kind
+                        type: object
+                      maxItems: 8
+                      type: array
+                  required:
+                  - attachedRoutes
+                  - conditions
+                  - name
+                  - supportedKinds
+                  type: object
+                maxItems: 64
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
+    gateway.networking.k8s.io/bundle-version: v0.6.1
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: grpcroutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: GRPCRoute
+    listKind: GRPCRouteList
+    plural: grpcroutes
+    singular: grpcroute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: "GRPCRoute provides a way to route gRPC requests. This includes
+          the capability to match requests by hostname, gRPC service, gRPC method,
+          or HTTP/2 header. Filters can be used to specify additional processing steps.
+          Backends specify where matching requests will be routed. \n GRPCRoute falls
+          under extended support within the Gateway API. Within the following specification,
+          the word \"MUST\" indicates that an implementation supporting GRPCRoute
+          must conform to the indicated requirement, but an implementation not supporting
+          this route type need not follow the requirement unless explicitly indicated.
+          \n Implementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType`
+          MUST accept HTTP/2 connections without an initial upgrade from HTTP/1.1,
+          i.e. via ALPN. If the implementation does not support this, then it MUST
+          set the \"Accepted\" condition to \"False\" for the affected listener with
+          a reason of \"UnsupportedProtocol\".  Implementations MAY also accept HTTP/2
+          connections with an upgrade from HTTP/1. \n Implementations supporting `GRPCRoute`
+          with the `HTTP` `ProtocolType` MUST support HTTP/2 over cleartext TCP (h2c,
+          https://www.rfc-editor.org/rfc/rfc7540#section-3.1) without an initial upgrade
+          from HTTP/1.1, i.e. with prior knowledge (https://www.rfc-editor.org/rfc/rfc7540#section-3.4).
+          If the implementation does not support this, then it MUST set the \"Accepted\"
+          condition to \"False\" for the affected listener with a reason of \"UnsupportedProtocol\".
+          Implementations MAY also accept HTTP/2 connections with an upgrade from
+          HTTP/1, i.e. without prior knowledge. \n Support: Extended"
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GRPCRoute.
+            properties:
+              hostnames:
+                description: "Hostnames defines a set of hostnames to match against
+                  the GRPC Host header to select a GRPCRoute to process the request.
+                  This matches the RFC 1123 definition of a hostname with 2 notable
+                  exceptions: \n 1. IPs are not allowed. 2. A hostname may be prefixed
+                  with a wildcard label (`*.`). The wildcard    label MUST appear
+                  by itself as the first label. \n If a hostname is specified by both
+                  the Listener and GRPCRoute, there MUST be at least one intersecting
+                  hostname for the GRPCRoute to be attached to the Listener. For example:
+                  \n * A Listener with `test.example.com` as the hostname matches
+                  GRPCRoutes   that have either not specified any hostnames, or have
+                  specified at   least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches GRPCRoutes
+                  \  that have either not specified any hostnames or have specified
+                  at least   one hostname that matches the Listener hostname. For
+                  example,   `test.example.com` and `*.example.com` would both match.
+                  On the other   hand, `example.com` and `test.example.net` would
+                  not match. \n Hostnames that are prefixed with a wildcard label
+                  (`*.`) are interpreted as a suffix match. That means that a match
+                  for `*.example.com` would match both `test.example.com`, and `foo.test.example.com`,
+                  but not `example.com`. \n If both the Listener and GRPCRoute have
+                  specified hostnames, any GRPCRoute hostnames that do not match the
+                  Listener hostname MUST be ignored. For example, if a Listener specified
+                  `*.example.com`, and the GRPCRoute specified `test.example.com`
+                  and `test.example.net`, `test.example.net` MUST NOT be considered
+                  for a match. \n If both the Listener and GRPCRoute have specified
+                  hostnames, and none match with the criteria above, then the GRPCRoute
+                  MUST NOT be accepted by the implementation. The implementation MUST
+                  raise an 'Accepted' Condition with a status of `False` in the corresponding
+                  RouteParentStatus. \n If a Route (A) of type HTTPRoute or GRPCRoute
+                  is attached to a Listener and that listener already has another
+                  Route (B) of the other type attached and the intersection of the
+                  hostnames of A and B is non-empty, then the implementation MUST
+                  accept exactly one of these two routes, determined by the following
+                  criteria, in order: \n * The oldest Route based on creation timestamp.
+                  * The Route appearing first in alphabetical order by   \"{namespace}/{name}\".
+                  \n The rejected Route MUST raise an 'Accepted' condition with a
+                  status of 'False' in the corresponding RouteParentStatus. \n Support:
+                  Core"
+                items:
+                  description: "Hostname is the fully qualified domain name of a network
+                    host. This matches the RFC 1123 definition of a hostname with
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
+                    must appear by itself as the first label. \n Hostname can be \"precise\"
+                    which is a domain name without the terminating dot of a network
+                    host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
+                    name prefixed with a single wildcard label (e.g. `*.example.com`).
+                    \n Note that as per RFC1035 and RFC1123, a *label* must consist
+                    of lower case alphanumeric characters or '-', and must start and
+                    end with an alphanumeric character. No other punctuation is allowed."
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)
+                  that a Route wants to be attached to. Note that the referenced parent
+                  resource needs to allow this for the attachment to be complete.
+                  For Gateways, that means the Gateway needs to allow attachment from
+                  Routes of this kind and namespace. \n The only kind of parent resource
+                  with \"Core\" support is Gateway. This API may be extended in the
+                  future to support additional kinds of parent resources such as one
+                  of the route kinds. \n It is invalid to reference an identical parent
+                  more than once. It is valid to reference multiple distinct sections
+                  within the same parent resource, such as 2 Listeners within a Gateway.
+                  \n It is possible to separately reference multiple distinct objects
+                  that may be collapsed by an implementation. For example, some implementations
+                  may choose to merge compatible Gateway Listeners together. If that
+                  is the case, the list of routes attached to those resources should
+                  also be merged. \n Note that for ParentRefs that cross namespace
+                  boundaries, there are specific rules. Cross-namespace references
+                  are only valid if they are explicitly allowed by something in the
+                  namespace they are referring to. For example, Gateway has the AllowedRoutes
+                  field, and ReferenceGrant provides a generic way to enable any other
+                  kind of cross-namespace reference."
+                items:
+                  description: "ParentReference identifies an API object (usually
+                    a Gateway) that can be considered a parent of this resource (usually
+                    a route). The only kind of parent resource with \"Core\" support
+                    is Gateway. This API may be extended in the future to support
+                    additional kinds of parent resources, such as HTTPRoute. \n The
+                    API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid."
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: "Group is the group of the referent. When unspecified,
+                        \"gateway.networking.k8s.io\" is inferred. To set the core
+                        API group (such as for a \"Service\" kind referent), Group
+                        must be explicitly set to \"\" (empty string). \n Support:
+                        Core"
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: "Kind is kind of the referent. \n Support: Core
+                        (Gateway) \n Support: Implementation-specific (Other Resources)"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: "Name is the name of the referent. \n Support:
+                        Core"
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: "Namespace is the namespace of the referent. When
+                        unspecified, this refers to the local namespace of the Route.
+                        \n Note that there are specific rules for ParentRefs which
+                        cross namespace boundaries. Cross-namespace references are
+                        only valid if they are explicitly allowed by something in
+                        the namespace they are referring to. For example: Gateway
+                        has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+                        \n Support: Core"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: "Port is the network port this Route targets. It
+                        can be interpreted differently based on the type of parent
+                        resource. \n When the parent resource is a Gateway, this targets
+                        all listeners listening on the specified port that also support
+                        this kind of Route(and select this Route). It's not recommended
+                        to set `Port` unless the networking behaviors specified in
+                        a Route must apply to a specific port as opposed to a listener(s)
+                        whose port(s) may be changed. When both Port and SectionName
+                        are specified, the name and port of the selected listener
+                        must match both specified values. \n Implementations MAY choose
+                        to support other parent resources. Implementations supporting
+                        other types of parent resources MUST clearly document how/if
+                        Port is interpreted. \n For the purpose of status, an attachment
+                        is considered successful as long as the parent resource accepts
+                        it partially. For example, Gateway listeners can restrict
+                        which Routes can attach to them by Route kind, namespace,
+                        or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the Route MUST be considered detached from the Gateway.
+                        \n Support: Extended \n <gateway:experimental>"
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: "SectionName is the name of a section within the
+                        target resource. In the following resources, SectionName is
+                        interpreted as the following: \n * Gateway: Listener Name.
+                        When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected listener must match both
+                        specified values. \n Implementations MAY choose to support
+                        attaching Routes to other resources. If that is the case,
+                        they MUST clearly document how SectionName is interpreted.
+                        \n When unspecified (empty string), this will reference the
+                        entire resource. For the purpose of status, an attachment
+                        is considered successful if at least one section in the parent
+                        resource accepts it. For example, Gateway listeners can restrict
+                        which Routes can attach to them by Route kind, namespace,
+                        or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the Route MUST be considered detached from the Gateway.
+                        \n Support: Core"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+              rules:
+                default:
+                - matches:
+                  - method:
+                      type: Exact
+                description: Rules are a list of GRPC matchers, filters and actions.
+                items:
+                  description: GRPCRouteRule defines the semantics for matching an
+                    gRPC request based on conditions (matches), processing it (filters),
+                    and forwarding the request to an API object (backendRefs).
+                  properties:
+                    backendRefs:
+                      description: "BackendRefs defines the backend(s) where matching
+                        requests should be sent. \n Failure behavior here depends
+                        on how many BackendRefs are specified and how many are invalid.
+                        \n If *all* entries in BackendRefs are invalid, and there
+                        are also no filters specified in this route rule, *all* traffic
+                        which matches this rule MUST receive an `UNAVAILABLE` status.
+                        \n See the GRPCBackendRef definition for the rules about what
+                        makes a single GRPCBackendRef invalid. \n When a GRPCBackendRef
+                        is invalid, `UNAVAILABLE` statuses MUST be returned for requests
+                        that would have otherwise been routed to an invalid backend.
+                        If multiple backends are specified, and some are invalid,
+                        the proportion of requests that would otherwise have been
+                        routed to an invalid backend MUST receive an `UNAVAILABLE`
+                        status. \n For example, if two backends are specified with
+                        equal weights, and one is invalid, 50 percent of traffic MUST
+                        receive an `UNAVAILABLE` status. Implementations may choose
+                        how that 50 percent is determined. \n Support: Core for Kubernetes
+                        Service \n Support: Implementation-specific for any other
+                        resource \n Support for weight: Core"
+                      items:
+                        description: GRPCBackendRef defines how a GRPCRoute forwards
+                          a gRPC request.
+                        properties:
+                          filters:
+                            description: "Filters defined at this level MUST be executed
+                              if and only if the request is being forwarded to the
+                              backend defined here. \n Support: Implementation-specific
+                              (For broader support of filters, use the Filters field
+                              in GRPCRouteRule.)"
+                            items:
+                              description: GRPCRouteFilter defines processing steps
+                                that must be completed during the request or response
+                                lifecycle. GRPCRouteFilters are meant as an extension
+                                point to express processing that may be done in Gateway
+                                implementations. Some examples include request or
+                                response modification, implementing authentication
+                                strategies, rate-limiting, and traffic shaping. API
+                                guarantee/conformance is defined based on the type
+                                of the filter.
+                              properties:
+                                extensionRef:
+                                  description: "ExtensionRef is an optional, implementation-specific
+                                    extension to the \"filter\" behavior.  For example,
+                                    resource \"myroutefilter\" in group \"networking.example.net\").
+                                    ExtensionRef MUST NOT be used for core and extended
+                                    filters. \n Support: Implementation-specific"
+                                  properties:
+                                    group:
+                                      description: Group is the group of the referent.
+                                        For example, "gateway.networking.k8s.io".
+                                        When unspecified or empty string, core API
+                                        group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "HTTPRoute" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                requestHeaderModifier:
+                                  description: "RequestHeaderModifier defines a schema
+                                    for a filter that modifies request headers. \n
+                                    Support: Core"
+                                  properties:
+                                    add:
+                                      description: "Add adds the given header(s) (name,
+                                        value) to the request before the action. It
+                                        appends to any existing values associated
+                                        with the header name. \n Input:   GET /foo
+                                        HTTP/1.1   my-header: foo \n Config:   add:
+                                        \  - name: \"my-header\"     value: \"bar,baz\"
+                                        \n Output:   GET /foo HTTP/1.1   my-header:
+                                        foo,bar,baz"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: "Remove the given header(s) from
+                                        the HTTP request before the action. The value
+                                        of Remove is a list of HTTP header names.
+                                        Note that the header names are case-insensitive
+                                        (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                        \n Input:   GET /foo HTTP/1.1   my-header1:
+                                        foo   my-header2: bar   my-header3: baz \n
+                                        Config:   remove: [\"my-header1\", \"my-header3\"]
+                                        \n Output:   GET /foo HTTP/1.1   my-header2:
+                                        bar"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                    set:
+                                      description: "Set overwrites the request with
+                                        the given header (name, value) before the
+                                        action. \n Input:   GET /foo HTTP/1.1   my-header:
+                                        foo \n Config:   set:   - name: \"my-header\"
+                                        \    value: \"bar\" \n Output:   GET /foo
+                                        HTTP/1.1   my-header: bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                requestMirror:
+                                  description: "RequestMirror defines a schema for
+                                    a filter that mirrors requests. Requests are sent
+                                    to the specified destination, but responses from
+                                    that destination are ignored. \n Support: Extended"
+                                  properties:
+                                    backendRef:
+                                      description: "BackendRef references a resource
+                                        where mirrored requests are sent. \n If the
+                                        referent cannot be found, this BackendRef
+                                        is invalid and must be dropped from the Gateway.
+                                        The controller must ensure the \"ResolvedRefs\"
+                                        condition on the Route status is set to `status:
+                                        False` and not configure this backend in the
+                                        underlying implementation. \n If there is
+                                        a cross-namespace reference to an *existing*
+                                        object that is not allowed by a ReferenceGrant,
+                                        the controller must ensure the \"ResolvedRefs\"
+                                        \ condition on the Route is set to `status:
+                                        False`, with the \"RefNotPermitted\" reason
+                                        and not configure this backend in the underlying
+                                        implementation. \n In either error case, the
+                                        Message of the `ResolvedRefs` Condition should
+                                        be used to provide more detail about the problem.
+                                        \n Support: Extended for Kubernetes Service
+                                        \n Support: Implementation-specific for any
+                                        other resource"
+                                      properties:
+                                        group:
+                                          default: ""
+                                          description: Group is the group of the referent.
+                                            For example, "gateway.networking.k8s.io".
+                                            When unspecified or empty string, core
+                                            API group is inferred.
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: Kind is kind of the referent.
+                                            For example "HTTPRoute" or "Service".
+                                            Defaults to "Service" when not specified.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: "Namespace is the namespace
+                                            of the backend. When unspecified, the
+                                            local namespace is inferred. \n Note that
+                                            when a namespace is specified, a ReferenceGrant
+                                            object is required in the referent namespace
+                                            to allow that namespace's owner to accept
+                                            the reference. See the ReferenceGrant
+                                            documentation for details. \n Support:
+                                            Core"
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: Port specifies the destination
+                                            port number to use for this resource.
+                                            Port is required when the referent is
+                                            a Kubernetes Service. In this case, the
+                                            port number is the service port number,
+                                            not the target port. For other resources,
+                                            destination port might be derived from
+                                            the referent resource or this field.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                  required:
+                                  - backendRef
+                                  type: object
+                                responseHeaderModifier:
+                                  description: "ResponseHeaderModifier defines a schema
+                                    for a filter that modifies response headers. \n
+                                    Support: Extended \n <gateway:experimental>"
+                                  properties:
+                                    add:
+                                      description: "Add adds the given header(s) (name,
+                                        value) to the request before the action. It
+                                        appends to any existing values associated
+                                        with the header name. \n Input:   GET /foo
+                                        HTTP/1.1   my-header: foo \n Config:   add:
+                                        \  - name: \"my-header\"     value: \"bar,baz\"
+                                        \n Output:   GET /foo HTTP/1.1   my-header:
+                                        foo,bar,baz"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: "Remove the given header(s) from
+                                        the HTTP request before the action. The value
+                                        of Remove is a list of HTTP header names.
+                                        Note that the header names are case-insensitive
+                                        (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                        \n Input:   GET /foo HTTP/1.1   my-header1:
+                                        foo   my-header2: bar   my-header3: baz \n
+                                        Config:   remove: [\"my-header1\", \"my-header3\"]
+                                        \n Output:   GET /foo HTTP/1.1   my-header2:
+                                        bar"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                    set:
+                                      description: "Set overwrites the request with
+                                        the given header (name, value) before the
+                                        action. \n Input:   GET /foo HTTP/1.1   my-header:
+                                        foo \n Config:   set:   - name: \"my-header\"
+                                        \    value: \"bar\" \n Output:   GET /foo
+                                        HTTP/1.1   my-header: bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                type:
+                                  description: "Type identifies the type of filter
+                                    to apply. As with other API fields, types are
+                                    classified into three conformance levels: \n -
+                                    Core: Filter types and their corresponding configuration
+                                    defined by   \"Support: Core\" in this package,
+                                    e.g. \"RequestHeaderModifier\". All   implementations
+                                    supporting GRPCRoute MUST support core filters.
+                                    \n - Extended: Filter types and their corresponding
+                                    configuration defined by   \"Support: Extended\"
+                                    in this package, e.g. \"RequestMirror\". Implementers
+                                    \  are encouraged to support extended filters.
+                                    \n - Implementation-specific: Filters that are
+                                    defined and supported by specific vendors.   In
+                                    the future, filters showing convergence in behavior
+                                    across multiple   implementations will be considered
+                                    for inclusion in extended or core   conformance
+                                    levels. Filter-specific configuration for such
+                                    filters   is specified using the ExtensionRef
+                                    field. `Type` MUST be set to   \"ExtensionRef\"
+                                    for custom filters. \n Implementers are encouraged
+                                    to define custom implementation types to extend
+                                    the core API with implementation-specific behavior.
+                                    \n If a reference to a custom filter type cannot
+                                    be resolved, the filter MUST NOT be skipped. Instead,
+                                    requests that would have been processed by that
+                                    filter MUST receive a HTTP error response. \n "
+                                  enum:
+                                  - ResponseHeaderModifier
+                                  - RequestHeaderModifier
+                                  - RequestMirror
+                                  - ExtensionRef
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            maxItems: 16
+                            type: array
+                          group:
+                            default: ""
+                            description: Group is the group of the referent. For example,
+                              "gateway.networking.k8s.io". When unspecified or empty
+                              string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: Kind is kind of the referent. For example
+                              "HTTPRoute" or "Service". Defaults to "Service" when
+                              not specified.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: "Namespace is the namespace of the backend.
+                              When unspecified, the local namespace is inferred. \n
+                              Note that when a namespace is specified, a ReferenceGrant
+                              object is required in the referent namespace to allow
+                              that namespace's owner to accept the reference. See
+                              the ReferenceGrant documentation for details. \n Support:
+                              Core"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: Port specifies the destination port number
+                              to use for this resource. Port is required when the
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: "Weight specifies the proportion of requests
+                              forwarded to the referenced backend. This is computed
+                              as weight/(sum of all weights in this BackendRefs list).
+                              For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision
+                              an implementation supports. Weight is not a percentage
+                              and the sum of weights does not need to equal 100. \n
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100% of the traffic is forwarded to
+                              that backend. If weight is set to 0, no traffic should
+                              be forwarded for this entry. If unspecified, weight
+                              defaults to 1. \n Support for this field varies based
+                              on the context where used."
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                      maxItems: 16
+                      type: array
+                    filters:
+                      description: "Filters define the filters that are applied to
+                        requests that match this rule. \n The effects of ordering
+                        of multiple behaviors are currently unspecified. This can
+                        change in the future based on feedback during the alpha stage.
+                        \n Conformance-levels at this level are defined based on the
+                        type of filter: \n - ALL core filters MUST be supported by
+                        all implementations that support   GRPCRoute. - Implementers
+                        are encouraged to support extended filters. - Implementation-specific
+                        custom filters have no API guarantees across   implementations.
+                        \n Specifying a core filter multiple times has unspecified
+                        or implementation-specific conformance. Support: Core"
+                      items:
+                        description: GRPCRouteFilter defines processing steps that
+                          must be completed during the request or response lifecycle.
+                          GRPCRouteFilters are meant as an extension point to express
+                          processing that may be done in Gateway implementations.
+                          Some examples include request or response modification,
+                          implementing authentication strategies, rate-limiting, and
+                          traffic shaping. API guarantee/conformance is defined based
+                          on the type of the filter.
+                        properties:
+                          extensionRef:
+                            description: "ExtensionRef is an optional, implementation-specific
+                              extension to the \"filter\" behavior.  For example,
+                              resource \"myroutefilter\" in group \"networking.example.net\").
+                              ExtensionRef MUST NOT be used for core and extended
+                              filters. \n Support: Implementation-specific"
+                            properties:
+                              group:
+                                description: Group is the group of the referent. For
+                                  example, "gateway.networking.k8s.io". When unspecified
+                                  or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          requestHeaderModifier:
+                            description: "RequestHeaderModifier defines a schema for
+                              a filter that modifies request headers. \n Support:
+                              Core"
+                            properties:
+                              add:
+                                description: "Add adds the given header(s) (name,
+                                  value) to the request before the action. It appends
+                                  to any existing values associated with the header
+                                  name. \n Input:   GET /foo HTTP/1.1   my-header:
+                                  foo \n Config:   add:   - name: \"my-header\"     value:
+                                  \"bar,baz\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo,bar,baz"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: "Remove the given header(s) from the
+                                  HTTP request before the action. The value of Remove
+                                  is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                  \n Input:   GET /foo HTTP/1.1   my-header1: foo
+                                  \  my-header2: bar   my-header3: baz \n Config:
+                                  \  remove: [\"my-header1\", \"my-header3\"] \n Output:
+                                  \  GET /foo HTTP/1.1   my-header2: bar"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                              set:
+                                description: "Set overwrites the request with the
+                                  given header (name, value) before the action. \n
+                                  Input:   GET /foo HTTP/1.1   my-header: foo \n Config:
+                                  \  set:   - name: \"my-header\"     value: \"bar\"
+                                  \n Output:   GET /foo HTTP/1.1   my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          requestMirror:
+                            description: "RequestMirror defines a schema for a filter
+                              that mirrors requests. Requests are sent to the specified
+                              destination, but responses from that destination are
+                              ignored. \n Support: Extended"
+                            properties:
+                              backendRef:
+                                description: "BackendRef references a resource where
+                                  mirrored requests are sent. \n If the referent cannot
+                                  be found, this BackendRef is invalid and must be
+                                  dropped from the Gateway. The controller must ensure
+                                  the \"ResolvedRefs\" condition on the Route status
+                                  is set to `status: False` and not configure this
+                                  backend in the underlying implementation. \n If
+                                  there is a cross-namespace reference to an *existing*
+                                  object that is not allowed by a ReferenceGrant,
+                                  the controller must ensure the \"ResolvedRefs\"
+                                  \ condition on the Route is set to `status: False`,
+                                  with the \"RefNotPermitted\" reason and not configure
+                                  this backend in the underlying implementation. \n
+                                  In either error case, the Message of the `ResolvedRefs`
+                                  Condition should be used to provide more detail
+                                  about the problem. \n Support: Extended for Kubernetes
+                                  Service \n Support: Implementation-specific for
+                                  any other resource"
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: Group is the group of the referent.
+                                      For example, "gateway.networking.k8s.io". When
+                                      unspecified or empty string, core API group
+                                      is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: Kind is kind of the referent. For
+                                      example "HTTPRoute" or "Service". Defaults to
+                                      "Service" when not specified.
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: "Namespace is the namespace of the
+                                      backend. When unspecified, the local namespace
+                                      is inferred. \n Note that when a namespace is
+                                      specified, a ReferenceGrant object is required
+                                      in the referent namespace to allow that namespace's
+                                      owner to accept the reference. See the ReferenceGrant
+                                      documentation for details. \n Support: Core"
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: Port specifies the destination port
+                                      number to use for this resource. Port is required
+                                      when the referent is a Kubernetes Service. In
+                                      this case, the port number is the service port
+                                      number, not the target port. For other resources,
+                                      destination port might be derived from the referent
+                                      resource or this field.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - backendRef
+                            type: object
+                          responseHeaderModifier:
+                            description: "ResponseHeaderModifier defines a schema
+                              for a filter that modifies response headers. \n Support:
+                              Extended \n <gateway:experimental>"
+                            properties:
+                              add:
+                                description: "Add adds the given header(s) (name,
+                                  value) to the request before the action. It appends
+                                  to any existing values associated with the header
+                                  name. \n Input:   GET /foo HTTP/1.1   my-header:
+                                  foo \n Config:   add:   - name: \"my-header\"     value:
+                                  \"bar,baz\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo,bar,baz"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: "Remove the given header(s) from the
+                                  HTTP request before the action. The value of Remove
+                                  is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                  \n Input:   GET /foo HTTP/1.1   my-header1: foo
+                                  \  my-header2: bar   my-header3: baz \n Config:
+                                  \  remove: [\"my-header1\", \"my-header3\"] \n Output:
+                                  \  GET /foo HTTP/1.1   my-header2: bar"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                              set:
+                                description: "Set overwrites the request with the
+                                  given header (name, value) before the action. \n
+                                  Input:   GET /foo HTTP/1.1   my-header: foo \n Config:
+                                  \  set:   - name: \"my-header\"     value: \"bar\"
+                                  \n Output:   GET /foo HTTP/1.1   my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          type:
+                            description: "Type identifies the type of filter to apply.
+                              As with other API fields, types are classified into
+                              three conformance levels: \n - Core: Filter types and
+                              their corresponding configuration defined by   \"Support:
+                              Core\" in this package, e.g. \"RequestHeaderModifier\".
+                              All   implementations supporting GRPCRoute MUST support
+                              core filters. \n - Extended: Filter types and their
+                              corresponding configuration defined by   \"Support:
+                              Extended\" in this package, e.g. \"RequestMirror\".
+                              Implementers   are encouraged to support extended filters.
+                              \n - Implementation-specific: Filters that are defined
+                              and supported by specific vendors.   In the future,
+                              filters showing convergence in behavior across multiple
+                              \  implementations will be considered for inclusion
+                              in extended or core   conformance levels. Filter-specific
+                              configuration for such filters   is specified using
+                              the ExtensionRef field. `Type` MUST be set to   \"ExtensionRef\"
+                              for custom filters. \n Implementers are encouraged to
+                              define custom implementation types to extend the core
+                              API with implementation-specific behavior. \n If a reference
+                              to a custom filter type cannot be resolved, the filter
+                              MUST NOT be skipped. Instead, requests that would have
+                              been processed by that filter MUST receive a HTTP error
+                              response. \n "
+                            enum:
+                            - ResponseHeaderModifier
+                            - RequestHeaderModifier
+                            - RequestMirror
+                            - ExtensionRef
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      maxItems: 16
+                      type: array
+                    matches:
+                      default:
+                      - method:
+                          type: Exact
+                      description: "Matches define conditions used for matching the
+                        rule against incoming gRPC requests. Each match is independent,
+                        i.e. this rule will be matched if **any** one of the matches
+                        is satisfied. \n For example, take the following matches configuration:
+                        \n ``` matches: - method:     service: foo.bar   headers:
+                        \    values:       version: 2 - method:     service: foo.bar.v2
+                        ``` \n For a request to match against this rule, it MUST satisfy
+                        EITHER of the two conditions: \n - service of foo.bar AND
+                        contains the header `version: 2` - service of foo.bar.v2 \n
+                        See the documentation for GRPCRouteMatch on how to specify
+                        multiple match conditions to be ANDed together. \n If no matches
+                        are specified, the implementation MUST match every gRPC request.
+                        \n Proxy or Load Balancer routing configuration generated
+                        from GRPCRoutes MUST prioritize rules based on the following
+                        criteria, continuing on ties. Merging MUST not be done between
+                        GRPCRoutes and HTTPRoutes. Precedence MUST be given to the
+                        rule with the largest number of: \n * Characters in a matching
+                        non-wildcard hostname. * Characters in a matching hostname.
+                        * Characters in a matching service. * Characters in a matching
+                        method. * Header matches. \n If ties still exist across multiple
+                        Routes, matching precedence MUST be determined in order of
+                        the following criteria, continuing on ties: \n * The oldest
+                        Route based on creation timestamp. * The Route appearing first
+                        in alphabetical order by   \"{namespace}/{name}\". \n If ties
+                        still exist within the Route that has been given precedence,
+                        matching precedence MUST be granted to the first matching
+                        rule meeting the above criteria."
+                      items:
+                        description: "GRPCRouteMatch defines the predicate used to
+                          match requests to a given action. Multiple match types are
+                          ANDed together, i.e. the match will evaluate to true only
+                          if all conditions are satisfied. \n For example, the match
+                          below will match a gRPC request only if its service is `foo`
+                          AND it contains the `version: v1` header: \n ``` matches:
+                          \  - method:     type: Exact     service: \"foo\"     headers:
+                          \  - name: \"version\"     value \"v1\" \n ```"
+                        properties:
+                          headers:
+                            description: Headers specifies gRPC request header matchers.
+                              Multiple match values are ANDed together, meaning, a
+                              request MUST match all the specified headers to select
+                              the route.
+                            items:
+                              description: GRPCHeaderMatch describes how to select
+                                a gRPC route by matching gRPC request headers.
+                              properties:
+                                name:
+                                  description: "Name is the name of the gRPC Header
+                                    to be matched. \n If multiple entries specify
+                                    equivalent header names, only the first entry
+                                    with an equivalent name MUST be considered for
+                                    a match. Subsequent entries with an equivalent
+                                    header name MUST be ignored. Due to the case-insensitivity
+                                    of header names, \"foo\" and \"Foo\" are considered
+                                    equivalent."
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: Type specifies how to match against
+                                    the value of the header.
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of the gRPC Header
+                                    to be matched.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          method:
+                            default:
+                              type: Exact
+                            description: Method specifies a gRPC request service/method
+                              matcher. If this field is not specified, all services
+                              and methods will match.
+                            properties:
+                              method:
+                                description: "Value of the method to match against.
+                                  If left empty or omitted, will match all services.
+                                  \n At least one of Service and Method MUST be a
+                                  non-empty string. \n A GRPC Method must be a valid
+                                  Protobuf Method (https://protobuf.com/docs/language-spec#methods)."
+                                maxLength: 1024
+                                pattern: ^[A-Za-z_][A-Za-z_0-9]*$
+                                type: string
+                              service:
+                                description: "Value of the service to match against.
+                                  If left empty or omitted, will match any service.
+                                  \n At least one of Service and Method MUST be a
+                                  non-empty string. \n A GRPC Service must be a valid
+                                  Protobuf Type Name (https://protobuf.com/docs/language-spec#type-references)."
+                                maxLength: 1024
+                                pattern: ^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$
+                                type: string
+                              type:
+                                default: Exact
+                                description: "Type specifies how to match against
+                                  the service and/or method. Support: Core (Exact
+                                  with service and method specified) \n Support: Implementation-specific
+                                  (Exact with method specified but no service specified)
+                                  \n Support: Implementation-specific (RegularExpression)"
+                                enum:
+                                - Exact
+                                - RegularExpression
+                                type: string
+                            type: object
+                        type: object
+                      maxItems: 8
+                      type: array
+                  type: object
+                maxItems: 16
+                type: array
+            type: object
+          status:
+            description: Status defines the current state of GRPCRoute.
+            properties:
+              parents:
+                description: "Parents is a list of parent resources (usually Gateways)
+                  that are associated with the route, and the status of the route
+                  with respect to each parent. When this route attaches to a parent,
+                  the controller that manages the parent must add an entry to this
+                  list when the controller first sees the route and should update
+                  the entry as appropriate when the route or gateway is modified.
+                  \n Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this
+                  API can only populate Route status for the Gateways/parent resources
+                  they are responsible for. \n A maximum of 32 Gateways will be represented
+                  in this list. An empty list means the route has not been attached
+                  to any Gateway."
+                items:
+                  description: RouteParentStatus describes the status of a route with
+                    respect to an associated Parent.
+                  properties:
+                    conditions:
+                      description: "Conditions describes the status of the route with
+                        respect to the Gateway. Note that the route's availability
+                        is also subject to the Gateway's own status conditions and
+                        listener status. \n If the Route's ParentRef specifies an
+                        existing Gateway that supports Routes of this kind AND that
+                        Gateway's controller has sufficient access, then that Gateway's
+                        controller MUST set the \"Accepted\" condition on the Route,
+                        to indicate whether the route has been accepted or rejected
+                        by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
+                        if at least one of the Route's rules is implemented by the
+                        Gateway. \n There are a number of cases where the \"Accepted\"
+                        condition may not be set due to lack of controller visibility,
+                        that includes when: \n * The Route refers to a non-existent
+                        parent. * The Route is of a type that the controller does
+                        not support. * The Route is in a namespace the controller
+                        does not have access to."
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n \ttype FooStatus struct{
+                          \t    // Represents the observations of a foo's current
+                          state. \t    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type
+                          \t    // +patchStrategy=merge \t    // +listType=map \t
+                          \   // +listMapKey=type \t    Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other
+                          fields \t}"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: "ControllerName is a domain/path string that indicates
+                        the name of the controller that wrote this status. This corresponds
+                        with the controllerName field on GatewayClass. \n Example:
+                        \"example.net/gateway-controller\". \n The format of this
+                        field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid
+                        Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                        \n Controllers MUST populate this field when writing status.
+                        Controllers should ensure that entries to status populated
+                        with their ControllerName are cleaned up when they are no
+                        longer necessary."
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: ParentRef corresponds with a ParentRef in the spec
+                        that this RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: "Group is the group of the referent. When unspecified,
+                            \"gateway.networking.k8s.io\" is inferred. To set the
+                            core API group (such as for a \"Service\" kind referent),
+                            Group must be explicitly set to \"\" (empty string). \n
+                            Support: Core"
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: "Kind is kind of the referent. \n Support:
+                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Resources)"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: "Name is the name of the referent. \n Support:
+                            Core"
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: "Namespace is the namespace of the referent.
+                            When unspecified, this refers to the local namespace of
+                            the Route. \n Note that there are specific rules for ParentRefs
+                            which cross namespace boundaries. Cross-namespace references
+                            are only valid if they are explicitly allowed by something
+                            in the namespace they are referring to. For example: Gateway
+                            has the AllowedRoutes field, and ReferenceGrant provides
+                            a generic way to enable any other kind of cross-namespace
+                            reference. \n Support: Core"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: "Port is the network port this Route targets.
+                            It can be interpreted differently based on the type of
+                            parent resource. \n When the parent resource is a Gateway,
+                            this targets all listeners listening on the specified
+                            port that also support this kind of Route(and select this
+                            Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to
+                            a specific port as opposed to a listener(s) whose port(s)
+                            may be changed. When both Port and SectionName are specified,
+                            the name and port of the selected listener must match
+                            both specified values. \n Implementations MAY choose to
+                            support other parent resources. Implementations supporting
+                            other types of parent resources MUST clearly document
+                            how/if Port is interpreted. \n For the purpose of status,
+                            an attachment is considered successful as long as the
+                            parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them
+                            by Route kind, namespace, or hostname. If 1 of 2 Gateway
+                            listeners accept attachment from the referencing Route,
+                            the Route MUST be considered successfully attached. If
+                            no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Extended \n <gateway:experimental>"
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: "SectionName is the name of a section within
+                            the target resource. In the following resources, SectionName
+                            is interpreted as the following: \n * Gateway: Listener
+                            Name. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected listener
+                            must match both specified values. \n Implementations MAY
+                            choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
+                            is interpreted. \n When unspecified (empty string), this
+                            will reference the entire resource. For the purpose of
+                            status, an attachment is considered successful if at least
+                            one section in the parent resource accepts it. For example,
+                            Gateway listeners can restrict which Routes can attach
+                            to them by Route kind, namespace, or hostname. If 1 of
+                            2 Gateway listeners accept attachment from the referencing
+                            Route, the Route MUST be considered successfully attached.
+                            If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Core"
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
+    gateway.networking.k8s.io/bundle-version: v0.6.1
+    gateway.networking.k8s.io/channel: standard
+  creationTimestamp: null
+  name: httproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: HTTPRoute
+    listKind: HTTPRouteList
+    plural: httproutes
+    singular: httproute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of HTTPRoute has been deprecated and
+      will be removed in a future release of the API. Please upgrade to v1beta1.
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: HTTPRoute provides a way to route HTTP requests. This includes
+          the capability to match requests by hostname, path, header, or query param.
+          Filters can be used to specify additional processing steps. Backends specify
+          where matching requests should be routed.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of HTTPRoute.
+            properties:
+              hostnames:
+                description: "Hostnames defines a set of hostname that should match
+                  against the HTTP Host header to select a HTTPRoute to process the
+                  request. This matches the RFC 1123 definition of a hostname with
+                  2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname may
+                  be prefixed with a wildcard label (`*.`). The wildcard    label
+                  must appear by itself as the first label. \n If a hostname is specified
+                  by both the Listener and HTTPRoute, there must be at least one intersecting
+                  hostname for the HTTPRoute to be attached to the Listener. For example:
+                  \n * A Listener with `test.example.com` as the hostname matches
+                  HTTPRoutes   that have either not specified any hostnames, or have
+                  specified at   least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches HTTPRoutes
+                  \  that have either not specified any hostnames or have specified
+                  at least   one hostname that matches the Listener hostname. For
+                  example,   `*.example.com`, `test.example.com`, and `foo.test.example.com`
+                  would   all match. On the other hand, `example.com` and `test.example.net`
+                  would   not match. \n Hostnames that are prefixed with a wildcard
+                  label (`*.`) are interpreted as a suffix match. That means that
+                  a match for `*.example.com` would match both `test.example.com`,
+                  and `foo.test.example.com`, but not `example.com`. \n If both the
+                  Listener and HTTPRoute have specified hostnames, any HTTPRoute hostnames
+                  that do not match the Listener hostname MUST be ignored. For example,
+                  if a Listener specified `*.example.com`, and the HTTPRoute specified
+                  `test.example.com` and `test.example.net`, `test.example.net` must
+                  not be considered for a match. \n If both the Listener and HTTPRoute
+                  have specified hostnames, and none match with the criteria above,
+                  then the HTTPRoute is not accepted. The implementation must raise
+                  an 'Accepted' Condition with a status of `False` in the corresponding
+                  RouteParentStatus. \n In the event that multiple HTTPRoutes specify
+                  intersecting hostnames (e.g. overlapping wildcard matching and exact
+                  matching hostnames), precedence must be given to rules from the
+                  HTTPRoute with the largest number of: \n * Characters in a matching
+                  non-wildcard hostname. * Characters in a matching hostname. \n If
+                  ties exist across multiple Routes, the matching precedence rules
+                  for HTTPRouteMatches takes over. \n Support: Core"
+                items:
+                  description: "Hostname is the fully qualified domain name of a network
+                    host. This matches the RFC 1123 definition of a hostname with
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
+                    must appear by itself as the first label. \n Hostname can be \"precise\"
+                    which is a domain name without the terminating dot of a network
+                    host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
+                    name prefixed with a single wildcard label (e.g. `*.example.com`).
+                    \n Note that as per RFC1035 and RFC1123, a *label* must consist
+                    of lower case alphanumeric characters or '-', and must start and
+                    end with an alphanumeric character. No other punctuation is allowed."
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)
+                  that a Route wants to be attached to. Note that the referenced parent
+                  resource needs to allow this for the attachment to be complete.
+                  For Gateways, that means the Gateway needs to allow attachment from
+                  Routes of this kind and namespace. \n The only kind of parent resource
+                  with \"Core\" support is Gateway. This API may be extended in the
+                  future to support additional kinds of parent resources such as one
+                  of the route kinds. \n It is invalid to reference an identical parent
+                  more than once. It is valid to reference multiple distinct sections
+                  within the same parent resource, such as 2 Listeners within a Gateway.
+                  \n It is possible to separately reference multiple distinct objects
+                  that may be collapsed by an implementation. For example, some implementations
+                  may choose to merge compatible Gateway Listeners together. If that
+                  is the case, the list of routes attached to those resources should
+                  also be merged. \n Note that for ParentRefs that cross namespace
+                  boundaries, there are specific rules. Cross-namespace references
+                  are only valid if they are explicitly allowed by something in the
+                  namespace they are referring to. For example, Gateway has the AllowedRoutes
+                  field, and ReferenceGrant provides a generic way to enable any other
+                  kind of cross-namespace reference."
+                items:
+                  description: "ParentReference identifies an API object (usually
+                    a Gateway) that can be considered a parent of this resource (usually
+                    a route). The only kind of parent resource with \"Core\" support
+                    is Gateway. This API may be extended in the future to support
+                    additional kinds of parent resources, such as HTTPRoute. \n The
+                    API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid."
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: "Group is the group of the referent. When unspecified,
+                        \"gateway.networking.k8s.io\" is inferred. To set the core
+                        API group (such as for a \"Service\" kind referent), Group
+                        must be explicitly set to \"\" (empty string). \n Support:
+                        Core"
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: "Kind is kind of the referent. \n Support: Core
+                        (Gateway) \n Support: Implementation-specific (Other Resources)"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: "Name is the name of the referent. \n Support:
+                        Core"
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: "Namespace is the namespace of the referent. When
+                        unspecified, this refers to the local namespace of the Route.
+                        \n Note that there are specific rules for ParentRefs which
+                        cross namespace boundaries. Cross-namespace references are
+                        only valid if they are explicitly allowed by something in
+                        the namespace they are referring to. For example: Gateway
+                        has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+                        \n Support: Core"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    sectionName:
+                      description: "SectionName is the name of a section within the
+                        target resource. In the following resources, SectionName is
+                        interpreted as the following: \n * Gateway: Listener Name.
+                        When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected listener must match both
+                        specified values. \n Implementations MAY choose to support
+                        attaching Routes to other resources. If that is the case,
+                        they MUST clearly document how SectionName is interpreted.
+                        \n When unspecified (empty string), this will reference the
+                        entire resource. For the purpose of status, an attachment
+                        is considered successful if at least one section in the parent
+                        resource accepts it. For example, Gateway listeners can restrict
+                        which Routes can attach to them by Route kind, namespace,
+                        or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the Route MUST be considered detached from the Gateway.
+                        \n Support: Core"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+              rules:
+                default:
+                - matches:
+                  - path:
+                      type: PathPrefix
+                      value: /
+                description: Rules are a list of HTTP matchers, filters and actions.
+                items:
+                  description: HTTPRouteRule defines semantics for matching an HTTP
+                    request based on conditions (matches), processing it (filters),
+                    and forwarding the request to an API object (backendRefs).
+                  properties:
+                    backendRefs:
+                      description: "BackendRefs defines the backend(s) where matching
+                        requests should be sent. \n Failure behavior here depends
+                        on how many BackendRefs are specified and how many are invalid.
+                        \n If *all* entries in BackendRefs are invalid, and there
+                        are also no filters specified in this route rule, *all* traffic
+                        which matches this rule MUST receive a 500 status code. \n
+                        See the HTTPBackendRef definition for the rules about what
+                        makes a single HTTPBackendRef invalid. \n When a HTTPBackendRef
+                        is invalid, 500 status codes MUST be returned for requests
+                        that would have otherwise been routed to an invalid backend.
+                        If multiple backends are specified, and some are invalid,
+                        the proportion of requests that would otherwise have been
+                        routed to an invalid backend MUST receive a 500 status code.
+                        \n For example, if two backends are specified with equal weights,
+                        and one is invalid, 50 percent of traffic must receive a 500.
+                        Implementations may choose how that 50 percent is determined.
+                        \n Support: Core for Kubernetes Service \n Support: Implementation-specific
+                        for any other resource \n Support for weight: Core"
+                      items:
+                        description: HTTPBackendRef defines how a HTTPRoute should
+                          forward an HTTP request.
+                        properties:
+                          filters:
+                            description: "Filters defined at this level should be
+                              executed if and only if the request is being forwarded
+                              to the backend defined here. \n Support: Implementation-specific
+                              (For broader support of filters, use the Filters field
+                              in HTTPRouteRule.)"
+                            items:
+                              description: HTTPRouteFilter defines processing steps
+                                that must be completed during the request or response
+                                lifecycle. HTTPRouteFilters are meant as an extension
+                                point to express processing that may be done in Gateway
+                                implementations. Some examples include request or
+                                response modification, implementing authentication
+                                strategies, rate-limiting, and traffic shaping. API
+                                guarantee/conformance is defined based on the type
+                                of the filter.
+                              properties:
+                                extensionRef:
+                                  description: "ExtensionRef is an optional, implementation-specific
+                                    extension to the \"filter\" behavior.  For example,
+                                    resource \"myroutefilter\" in group \"networking.example.net\").
+                                    ExtensionRef MUST NOT be used for core and extended
+                                    filters. \n Support: Implementation-specific"
+                                  properties:
+                                    group:
+                                      description: Group is the group of the referent.
+                                        For example, "gateway.networking.k8s.io".
+                                        When unspecified or empty string, core API
+                                        group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "HTTPRoute" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                requestHeaderModifier:
+                                  description: "RequestHeaderModifier defines a schema
+                                    for a filter that modifies request headers. \n
+                                    Support: Core"
+                                  properties:
+                                    add:
+                                      description: "Add adds the given header(s) (name,
+                                        value) to the request before the action. It
+                                        appends to any existing values associated
+                                        with the header name. \n Input:   GET /foo
+                                        HTTP/1.1   my-header: foo \n Config:   add:
+                                        \  - name: \"my-header\"     value: \"bar,baz\"
+                                        \n Output:   GET /foo HTTP/1.1   my-header:
+                                        foo,bar,baz"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: "Remove the given header(s) from
+                                        the HTTP request before the action. The value
+                                        of Remove is a list of HTTP header names.
+                                        Note that the header names are case-insensitive
+                                        (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                        \n Input:   GET /foo HTTP/1.1   my-header1:
+                                        foo   my-header2: bar   my-header3: baz \n
+                                        Config:   remove: [\"my-header1\", \"my-header3\"]
+                                        \n Output:   GET /foo HTTP/1.1   my-header2:
+                                        bar"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                    set:
+                                      description: "Set overwrites the request with
+                                        the given header (name, value) before the
+                                        action. \n Input:   GET /foo HTTP/1.1   my-header:
+                                        foo \n Config:   set:   - name: \"my-header\"
+                                        \    value: \"bar\" \n Output:   GET /foo
+                                        HTTP/1.1   my-header: bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                requestMirror:
+                                  description: "RequestMirror defines a schema for
+                                    a filter that mirrors requests. Requests are sent
+                                    to the specified destination, but responses from
+                                    that destination are ignored. \n Support: Extended"
+                                  properties:
+                                    backendRef:
+                                      description: "BackendRef references a resource
+                                        where mirrored requests are sent. \n If the
+                                        referent cannot be found, this BackendRef
+                                        is invalid and must be dropped from the Gateway.
+                                        The controller must ensure the \"ResolvedRefs\"
+                                        condition on the Route status is set to `status:
+                                        False` and not configure this backend in the
+                                        underlying implementation. \n If there is
+                                        a cross-namespace reference to an *existing*
+                                        object that is not allowed by a ReferenceGrant,
+                                        the controller must ensure the \"ResolvedRefs\"
+                                        \ condition on the Route is set to `status:
+                                        False`, with the \"RefNotPermitted\" reason
+                                        and not configure this backend in the underlying
+                                        implementation. \n In either error case, the
+                                        Message of the `ResolvedRefs` Condition should
+                                        be used to provide more detail about the problem.
+                                        \n Support: Extended for Kubernetes Service
+                                        \n Support: Implementation-specific for any
+                                        other resource"
+                                      properties:
+                                        group:
+                                          default: ""
+                                          description: Group is the group of the referent.
+                                            For example, "gateway.networking.k8s.io".
+                                            When unspecified or empty string, core
+                                            API group is inferred.
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: Kind is kind of the referent.
+                                            For example "HTTPRoute" or "Service".
+                                            Defaults to "Service" when not specified.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: "Namespace is the namespace
+                                            of the backend. When unspecified, the
+                                            local namespace is inferred. \n Note that
+                                            when a namespace is specified, a ReferenceGrant
+                                            object is required in the referent namespace
+                                            to allow that namespace's owner to accept
+                                            the reference. See the ReferenceGrant
+                                            documentation for details. \n Support:
+                                            Core"
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: Port specifies the destination
+                                            port number to use for this resource.
+                                            Port is required when the referent is
+                                            a Kubernetes Service. In this case, the
+                                            port number is the service port number,
+                                            not the target port. For other resources,
+                                            destination port might be derived from
+                                            the referent resource or this field.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                  required:
+                                  - backendRef
+                                  type: object
+                                requestRedirect:
+                                  description: "RequestRedirect defines a schema for
+                                    a filter that responds to the request with an
+                                    HTTP redirection. \n Support: Core"
+                                  properties:
+                                    hostname:
+                                      description: "Hostname is the hostname to be
+                                        used in the value of the `Location` header
+                                        in the response. When empty, the hostname
+                                        of the request is used. \n Support: Core"
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    port:
+                                      description: "Port is the port to be used in
+                                        the value of the `Location` header in the
+                                        response. When empty, port (if specified)
+                                        of the request is used. \n Support: Extended"
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    scheme:
+                                      description: "Scheme is the scheme to be used
+                                        in the value of the `Location` header in the
+                                        response. When empty, the scheme of the request
+                                        is used. \n Note that values may be added
+                                        to this enum, implementations must ensure
+                                        that unknown values will not cause a crash.
+                                        \n Unknown values here must result in the
+                                        implementation setting the Accepted Condition
+                                        for the Route to `status: False`, with a Reason
+                                        of `UnsupportedValue`. \n Support: Extended"
+                                      enum:
+                                      - http
+                                      - https
+                                      type: string
+                                    statusCode:
+                                      default: 302
+                                      description: "StatusCode is the HTTP status
+                                        code to be used in response. \n Note that
+                                        values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause
+                                        a crash. \n Unknown values here must result
+                                        in the implementation setting the Accepted
+                                        Condition for the Route to `status: False`,
+                                        with a Reason of `UnsupportedValue`. \n Support:
+                                        Core"
+                                      enum:
+                                      - 301
+                                      - 302
+                                      type: integer
+                                  type: object
+                                type:
+                                  description: "Type identifies the type of filter
+                                    to apply. As with other API fields, types are
+                                    classified into three conformance levels: \n -
+                                    Core: Filter types and their corresponding configuration
+                                    defined by   \"Support: Core\" in this package,
+                                    e.g. \"RequestHeaderModifier\". All   implementations
+                                    must support core filters. \n - Extended: Filter
+                                    types and their corresponding configuration defined
+                                    by   \"Support: Extended\" in this package, e.g.
+                                    \"RequestMirror\". Implementers   are encouraged
+                                    to support extended filters. \n - Implementation-specific:
+                                    Filters that are defined and supported by   specific
+                                    vendors.   In the future, filters showing convergence
+                                    in behavior across multiple   implementations
+                                    will be considered for inclusion in extended or
+                                    core   conformance levels. Filter-specific configuration
+                                    for such filters   is specified using the ExtensionRef
+                                    field. `Type` should be set to   \"ExtensionRef\"
+                                    for custom filters. \n Implementers are encouraged
+                                    to define custom implementation types to extend
+                                    the core API with implementation-specific behavior.
+                                    \n If a reference to a custom filter type cannot
+                                    be resolved, the filter MUST NOT be skipped. Instead,
+                                    requests that would have been processed by that
+                                    filter MUST receive a HTTP error response. \n
+                                    Note that values may be added to this enum, implementations
+                                    must ensure that unknown values will not cause
+                                    a crash. \n Unknown values here must result in
+                                    the implementation setting the Accepted Condition
+                                    for the Route to `status: False`, with a Reason
+                                    of `UnsupportedValue`. \n "
+                                  enum:
+                                  - RequestHeaderModifier
+                                  - RequestMirror
+                                  - RequestRedirect
+                                  - ExtensionRef
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            maxItems: 16
+                            type: array
+                          group:
+                            default: ""
+                            description: Group is the group of the referent. For example,
+                              "gateway.networking.k8s.io". When unspecified or empty
+                              string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: Kind is kind of the referent. For example
+                              "HTTPRoute" or "Service". Defaults to "Service" when
+                              not specified.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: "Namespace is the namespace of the backend.
+                              When unspecified, the local namespace is inferred. \n
+                              Note that when a namespace is specified, a ReferenceGrant
+                              object is required in the referent namespace to allow
+                              that namespace's owner to accept the reference. See
+                              the ReferenceGrant documentation for details. \n Support:
+                              Core"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: Port specifies the destination port number
+                              to use for this resource. Port is required when the
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: "Weight specifies the proportion of requests
+                              forwarded to the referenced backend. This is computed
+                              as weight/(sum of all weights in this BackendRefs list).
+                              For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision
+                              an implementation supports. Weight is not a percentage
+                              and the sum of weights does not need to equal 100. \n
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100% of the traffic is forwarded to
+                              that backend. If weight is set to 0, no traffic should
+                              be forwarded for this entry. If unspecified, weight
+                              defaults to 1. \n Support for this field varies based
+                              on the context where used."
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                      maxItems: 16
+                      type: array
+                    filters:
+                      description: "Filters define the filters that are applied to
+                        requests that match this rule. \n The effects of ordering
+                        of multiple behaviors are currently unspecified. This can
+                        change in the future based on feedback during the alpha stage.
+                        \n Conformance-levels at this level are defined based on the
+                        type of filter: \n - ALL core filters MUST be supported by
+                        all implementations. - Implementers are encouraged to support
+                        extended filters. - Implementation-specific custom filters
+                        have no API guarantees across   implementations. \n Specifying
+                        a core filter multiple times has unspecified or implementation-specific
+                        conformance. \n All filters are expected to be compatible
+                        with each other except for the URLRewrite and RequestRedirect
+                        filters, which may not be combined. If an implementation can
+                        not support other combinations of filters, they must clearly
+                        document that limitation. In all cases where incompatible
+                        or unsupported filters are specified, implementations MUST
+                        add a warning condition to status. \n Support: Core"
+                      items:
+                        description: HTTPRouteFilter defines processing steps that
+                          must be completed during the request or response lifecycle.
+                          HTTPRouteFilters are meant as an extension point to express
+                          processing that may be done in Gateway implementations.
+                          Some examples include request or response modification,
+                          implementing authentication strategies, rate-limiting, and
+                          traffic shaping. API guarantee/conformance is defined based
+                          on the type of the filter.
+                        properties:
+                          extensionRef:
+                            description: "ExtensionRef is an optional, implementation-specific
+                              extension to the \"filter\" behavior.  For example,
+                              resource \"myroutefilter\" in group \"networking.example.net\").
+                              ExtensionRef MUST NOT be used for core and extended
+                              filters. \n Support: Implementation-specific"
+                            properties:
+                              group:
+                                description: Group is the group of the referent. For
+                                  example, "gateway.networking.k8s.io". When unspecified
+                                  or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          requestHeaderModifier:
+                            description: "RequestHeaderModifier defines a schema for
+                              a filter that modifies request headers. \n Support:
+                              Core"
+                            properties:
+                              add:
+                                description: "Add adds the given header(s) (name,
+                                  value) to the request before the action. It appends
+                                  to any existing values associated with the header
+                                  name. \n Input:   GET /foo HTTP/1.1   my-header:
+                                  foo \n Config:   add:   - name: \"my-header\"     value:
+                                  \"bar,baz\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo,bar,baz"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: "Remove the given header(s) from the
+                                  HTTP request before the action. The value of Remove
+                                  is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                  \n Input:   GET /foo HTTP/1.1   my-header1: foo
+                                  \  my-header2: bar   my-header3: baz \n Config:
+                                  \  remove: [\"my-header1\", \"my-header3\"] \n Output:
+                                  \  GET /foo HTTP/1.1   my-header2: bar"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                              set:
+                                description: "Set overwrites the request with the
+                                  given header (name, value) before the action. \n
+                                  Input:   GET /foo HTTP/1.1   my-header: foo \n Config:
+                                  \  set:   - name: \"my-header\"     value: \"bar\"
+                                  \n Output:   GET /foo HTTP/1.1   my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          requestMirror:
+                            description: "RequestMirror defines a schema for a filter
+                              that mirrors requests. Requests are sent to the specified
+                              destination, but responses from that destination are
+                              ignored. \n Support: Extended"
+                            properties:
+                              backendRef:
+                                description: "BackendRef references a resource where
+                                  mirrored requests are sent. \n If the referent cannot
+                                  be found, this BackendRef is invalid and must be
+                                  dropped from the Gateway. The controller must ensure
+                                  the \"ResolvedRefs\" condition on the Route status
+                                  is set to `status: False` and not configure this
+                                  backend in the underlying implementation. \n If
+                                  there is a cross-namespace reference to an *existing*
+                                  object that is not allowed by a ReferenceGrant,
+                                  the controller must ensure the \"ResolvedRefs\"
+                                  \ condition on the Route is set to `status: False`,
+                                  with the \"RefNotPermitted\" reason and not configure
+                                  this backend in the underlying implementation. \n
+                                  In either error case, the Message of the `ResolvedRefs`
+                                  Condition should be used to provide more detail
+                                  about the problem. \n Support: Extended for Kubernetes
+                                  Service \n Support: Implementation-specific for
+                                  any other resource"
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: Group is the group of the referent.
+                                      For example, "gateway.networking.k8s.io". When
+                                      unspecified or empty string, core API group
+                                      is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: Kind is kind of the referent. For
+                                      example "HTTPRoute" or "Service". Defaults to
+                                      "Service" when not specified.
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: "Namespace is the namespace of the
+                                      backend. When unspecified, the local namespace
+                                      is inferred. \n Note that when a namespace is
+                                      specified, a ReferenceGrant object is required
+                                      in the referent namespace to allow that namespace's
+                                      owner to accept the reference. See the ReferenceGrant
+                                      documentation for details. \n Support: Core"
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: Port specifies the destination port
+                                      number to use for this resource. Port is required
+                                      when the referent is a Kubernetes Service. In
+                                      this case, the port number is the service port
+                                      number, not the target port. For other resources,
+                                      destination port might be derived from the referent
+                                      resource or this field.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - backendRef
+                            type: object
+                          requestRedirect:
+                            description: "RequestRedirect defines a schema for a filter
+                              that responds to the request with an HTTP redirection.
+                              \n Support: Core"
+                            properties:
+                              hostname:
+                                description: "Hostname is the hostname to be used
+                                  in the value of the `Location` header in the response.
+                                  When empty, the hostname of the request is used.
+                                  \n Support: Core"
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              port:
+                                description: "Port is the port to be used in the value
+                                  of the `Location` header in the response. When empty,
+                                  port (if specified) of the request is used. \n Support:
+                                  Extended"
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              scheme:
+                                description: "Scheme is the scheme to be used in the
+                                  value of the `Location` header in the response.
+                                  When empty, the scheme of the request is used. \n
+                                  Note that values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a
+                                  crash. \n Unknown values here must result in the
+                                  implementation setting the Accepted Condition for
+                                  the Route to `status: False`, with a Reason of `UnsupportedValue`.
+                                  \n Support: Extended"
+                                enum:
+                                - http
+                                - https
+                                type: string
+                              statusCode:
+                                default: 302
+                                description: "StatusCode is the HTTP status code to
+                                  be used in response. \n Note that values may be
+                                  added to this enum, implementations must ensure
+                                  that unknown values will not cause a crash. \n Unknown
+                                  values here must result in the implementation setting
+                                  the Accepted Condition for the Route to `status:
+                                  False`, with a Reason of `UnsupportedValue`. \n
+                                  Support: Core"
+                                enum:
+                                - 301
+                                - 302
+                                type: integer
+                            type: object
+                          type:
+                            description: "Type identifies the type of filter to apply.
+                              As with other API fields, types are classified into
+                              three conformance levels: \n - Core: Filter types and
+                              their corresponding configuration defined by   \"Support:
+                              Core\" in this package, e.g. \"RequestHeaderModifier\".
+                              All   implementations must support core filters. \n
+                              - Extended: Filter types and their corresponding configuration
+                              defined by   \"Support: Extended\" in this package,
+                              e.g. \"RequestMirror\". Implementers   are encouraged
+                              to support extended filters. \n - Implementation-specific:
+                              Filters that are defined and supported by   specific
+                              vendors.   In the future, filters showing convergence
+                              in behavior across multiple   implementations will be
+                              considered for inclusion in extended or core   conformance
+                              levels. Filter-specific configuration for such filters
+                              \  is specified using the ExtensionRef field. `Type`
+                              should be set to   \"ExtensionRef\" for custom filters.
+                              \n Implementers are encouraged to define custom implementation
+                              types to extend the core API with implementation-specific
+                              behavior. \n If a reference to a custom filter type
+                              cannot be resolved, the filter MUST NOT be skipped.
+                              Instead, requests that would have been processed by
+                              that filter MUST receive a HTTP error response. \n Note
+                              that values may be added to this enum, implementations
+                              must ensure that unknown values will not cause a crash.
+                              \n Unknown values here must result in the implementation
+                              setting the Accepted Condition for the Route to `status:
+                              False`, with a Reason of `UnsupportedValue`. \n "
+                            enum:
+                            - RequestHeaderModifier
+                            - RequestMirror
+                            - RequestRedirect
+                            - ExtensionRef
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      maxItems: 16
+                      type: array
+                    matches:
+                      default:
+                      - path:
+                          type: PathPrefix
+                          value: /
+                      description: "Matches define conditions used for matching the
+                        rule against incoming HTTP requests. Each match is independent,
+                        i.e. this rule will be matched if **any** one of the matches
+                        is satisfied. \n For example, take the following matches configuration:
+                        \n ``` matches: - path:     value: \"/foo\"   headers:   -
+                        name: \"version\"     value: \"v2\" - path:     value: \"/v2/foo\"
+                        ``` \n For a request to match against this rule, a request
+                        must satisfy EITHER of the two conditions: \n - path prefixed
+                        with `/foo` AND contains the header `version: v2` - path prefix
+                        of `/v2/foo` \n See the documentation for HTTPRouteMatch on
+                        how to specify multiple match conditions that should be ANDed
+                        together. \n If no matches are specified, the default is a
+                        prefix path match on \"/\", which has the effect of matching
+                        every HTTP request. \n Proxy or Load Balancer routing configuration
+                        generated from HTTPRoutes MUST prioritize matches based on
+                        the following criteria, continuing on ties. Across all rules
+                        specified on applicable Routes, precedence must be given to
+                        the match with the largest number of: \n * Characters in a
+                        matching path. * Header matches. * Query param matches. \n
+                        If ties still exist across multiple Routes, matching precedence
+                        MUST be determined in order of the following criteria, continuing
+                        on ties: \n * The oldest Route based on creation timestamp.
+                        * The Route appearing first in alphabetical order by   \"{namespace}/{name}\".
+                        \n If ties still exist within an HTTPRoute, matching precedence
+                        MUST be granted to the FIRST matching rule (in list order)
+                        with a match meeting the above criteria. \n When no rules
+                        matching a request have been successfully attached to the
+                        parent a request is coming from, a HTTP 404 status code MUST
+                        be returned."
+                      items:
+                        description: "HTTPRouteMatch defines the predicate used to
+                          match requests to a given action. Multiple match types are
+                          ANDed together, i.e. the match will evaluate to true only
+                          if all conditions are satisfied. \n For example, the match
+                          below will match a HTTP request only if its path starts
+                          with `/foo` AND it contains the `version: v1` header: \n
+                          ``` match: \n \tpath: \t  value: \"/foo\" \theaders: \t-
+                          name: \"version\" \t  value \"v1\" \n ```"
+                        properties:
+                          headers:
+                            description: Headers specifies HTTP request header matchers.
+                              Multiple match values are ANDed together, meaning, a
+                              request must match all the specified headers to select
+                              the route.
+                            items:
+                              description: HTTPHeaderMatch describes how to select
+                                a HTTP route by matching HTTP request headers.
+                              properties:
+                                name:
+                                  description: "Name is the name of the HTTP Header
+                                    to be matched. Name matching MUST be case insensitive.
+                                    (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                    \n If multiple entries specify equivalent header
+                                    names, only the first entry with an equivalent
+                                    name MUST be considered for a match. Subsequent
+                                    entries with an equivalent header name MUST be
+                                    ignored. Due to the case-insensitivity of header
+                                    names, \"foo\" and \"Foo\" are considered equivalent.
+                                    \n When a header is repeated in an HTTP request,
+                                    it is implementation-specific behavior as to how
+                                    this is represented. Generally, proxies should
+                                    follow the guidance from the RFC: https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2
+                                    regarding processing a repeated header, with special
+                                    handling for \"Set-Cookie\"."
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: "Type specifies how to match against
+                                    the value of the header. \n Support: Core (Exact)
+                                    \n Support: Implementation-specific (RegularExpression)
+                                    \n Since RegularExpression HeaderMatchType has
+                                    implementation-specific conformance, implementations
+                                    can support POSIX, PCRE or any other dialects
+                                    of regular expressions. Please read the implementation's
+                                    documentation to determine the supported dialect."
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP Header to
+                                    be matched.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          method:
+                            description: "Method specifies HTTP method matcher. When
+                              specified, this route will be matched only if the request
+                              has the specified method. \n Support: Extended"
+                            enum:
+                            - GET
+                            - HEAD
+                            - POST
+                            - PUT
+                            - DELETE
+                            - CONNECT
+                            - OPTIONS
+                            - TRACE
+                            - PATCH
+                            type: string
+                          path:
+                            default:
+                              type: PathPrefix
+                              value: /
+                            description: Path specifies a HTTP request path matcher.
+                              If this field is not specified, a default prefix match
+                              on the "/" path is provided.
+                            properties:
+                              type:
+                                default: PathPrefix
+                                description: "Type specifies how to match against
+                                  the path Value. \n Support: Core (Exact, PathPrefix)
+                                  \n Support: Implementation-specific (RegularExpression)"
+                                enum:
+                                - Exact
+                                - PathPrefix
+                                - RegularExpression
+                                type: string
+                              value:
+                                default: /
+                                description: Value of the HTTP path to match against.
+                                maxLength: 1024
+                                type: string
+                            type: object
+                          queryParams:
+                            description: "QueryParams specifies HTTP query parameter
+                              matchers. Multiple match values are ANDed together,
+                              meaning, a request must match all the specified query
+                              parameters to select the route. \n Support: Extended"
+                            items:
+                              description: HTTPQueryParamMatch describes how to select
+                                a HTTP route by matching HTTP query parameters.
+                              properties:
+                                name:
+                                  description: "Name is the name of the HTTP query
+                                    param to be matched. This must be an exact string
+                                    match. (See https://tools.ietf.org/html/rfc7230#section-2.7.3).
+                                    \n If multiple entries specify equivalent query
+                                    param names, only the first entry with an equivalent
+                                    name MUST be considered for a match. Subsequent
+                                    entries with an equivalent query param name MUST
+                                    be ignored. \n If a query param is repeated in
+                                    an HTTP request, the behavior is purposely left
+                                    undefined, since different data planes have different
+                                    capabilities. However, it is *recommended* that
+                                    implementations should match against the first
+                                    value of the param if the data plane supports
+                                    it, as this behavior is expected in other load
+                                    balancing contexts outside of the Gateway API.
+                                    \n Users SHOULD NOT route traffic based on repeated
+                                    query params to guard themselves against potential
+                                    differences in the implementations."
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: "Type specifies how to match against
+                                    the value of the query parameter. \n Support:
+                                    Extended (Exact) \n Support: Implementation-specific
+                                    (RegularExpression) \n Since RegularExpression
+                                    QueryParamMatchType has Implementation-specific
+                                    conformance, implementations can support POSIX,
+                                    PCRE or any other dialects of regular expressions.
+                                    Please read the implementation's documentation
+                                    to determine the supported dialect."
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP query param
+                                    to be matched.
+                                  maxLength: 1024
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        type: object
+                      maxItems: 8
+                      type: array
+                  type: object
+                maxItems: 16
+                type: array
+            type: object
+          status:
+            description: Status defines the current state of HTTPRoute.
+            properties:
+              parents:
+                description: "Parents is a list of parent resources (usually Gateways)
+                  that are associated with the route, and the status of the route
+                  with respect to each parent. When this route attaches to a parent,
+                  the controller that manages the parent must add an entry to this
+                  list when the controller first sees the route and should update
+                  the entry as appropriate when the route or gateway is modified.
+                  \n Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this
+                  API can only populate Route status for the Gateways/parent resources
+                  they are responsible for. \n A maximum of 32 Gateways will be represented
+                  in this list. An empty list means the route has not been attached
+                  to any Gateway."
+                items:
+                  description: RouteParentStatus describes the status of a route with
+                    respect to an associated Parent.
+                  properties:
+                    conditions:
+                      description: "Conditions describes the status of the route with
+                        respect to the Gateway. Note that the route's availability
+                        is also subject to the Gateway's own status conditions and
+                        listener status. \n If the Route's ParentRef specifies an
+                        existing Gateway that supports Routes of this kind AND that
+                        Gateway's controller has sufficient access, then that Gateway's
+                        controller MUST set the \"Accepted\" condition on the Route,
+                        to indicate whether the route has been accepted or rejected
+                        by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
+                        if at least one of the Route's rules is implemented by the
+                        Gateway. \n There are a number of cases where the \"Accepted\"
+                        condition may not be set due to lack of controller visibility,
+                        that includes when: \n * The Route refers to a non-existent
+                        parent. * The Route is of a type that the controller does
+                        not support. * The Route is in a namespace the controller
+                        does not have access to."
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n \ttype FooStatus struct{
+                          \t    // Represents the observations of a foo's current
+                          state. \t    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type
+                          \t    // +patchStrategy=merge \t    // +listType=map \t
+                          \   // +listMapKey=type \t    Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other
+                          fields \t}"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: "ControllerName is a domain/path string that indicates
+                        the name of the controller that wrote this status. This corresponds
+                        with the controllerName field on GatewayClass. \n Example:
+                        \"example.net/gateway-controller\". \n The format of this
+                        field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid
+                        Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                        \n Controllers MUST populate this field when writing status.
+                        Controllers should ensure that entries to status populated
+                        with their ControllerName are cleaned up when they are no
+                        longer necessary."
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: ParentRef corresponds with a ParentRef in the spec
+                        that this RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: "Group is the group of the referent. When unspecified,
+                            \"gateway.networking.k8s.io\" is inferred. To set the
+                            core API group (such as for a \"Service\" kind referent),
+                            Group must be explicitly set to \"\" (empty string). \n
+                            Support: Core"
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: "Kind is kind of the referent. \n Support:
+                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Resources)"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: "Name is the name of the referent. \n Support:
+                            Core"
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: "Namespace is the namespace of the referent.
+                            When unspecified, this refers to the local namespace of
+                            the Route. \n Note that there are specific rules for ParentRefs
+                            which cross namespace boundaries. Cross-namespace references
+                            are only valid if they are explicitly allowed by something
+                            in the namespace they are referring to. For example: Gateway
+                            has the AllowedRoutes field, and ReferenceGrant provides
+                            a generic way to enable any other kind of cross-namespace
+                            reference. \n Support: Core"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        sectionName:
+                          description: "SectionName is the name of a section within
+                            the target resource. In the following resources, SectionName
+                            is interpreted as the following: \n * Gateway: Listener
+                            Name. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected listener
+                            must match both specified values. \n Implementations MAY
+                            choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
+                            is interpreted. \n When unspecified (empty string), this
+                            will reference the entire resource. For the purpose of
+                            status, an attachment is considered successful if at least
+                            one section in the parent resource accepts it. For example,
+                            Gateway listeners can restrict which Routes can attach
+                            to them by Route kind, namespace, or hostname. If 1 of
+                            2 Gateway listeners accept attachment from the referencing
+                            Route, the Route MUST be considered successfully attached.
+                            If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Core"
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: HTTPRoute provides a way to route HTTP requests. This includes
+          the capability to match requests by hostname, path, header, or query param.
+          Filters can be used to specify additional processing steps. Backends specify
+          where matching requests should be routed.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of HTTPRoute.
+            properties:
+              hostnames:
+                description: "Hostnames defines a set of hostname that should match
+                  against the HTTP Host header to select a HTTPRoute to process the
+                  request. This matches the RFC 1123 definition of a hostname with
+                  2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname may
+                  be prefixed with a wildcard label (`*.`). The wildcard    label
+                  must appear by itself as the first label. \n If a hostname is specified
+                  by both the Listener and HTTPRoute, there must be at least one intersecting
+                  hostname for the HTTPRoute to be attached to the Listener. For example:
+                  \n * A Listener with `test.example.com` as the hostname matches
+                  HTTPRoutes   that have either not specified any hostnames, or have
+                  specified at   least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches HTTPRoutes
+                  \  that have either not specified any hostnames or have specified
+                  at least   one hostname that matches the Listener hostname. For
+                  example,   `*.example.com`, `test.example.com`, and `foo.test.example.com`
+                  would   all match. On the other hand, `example.com` and `test.example.net`
+                  would   not match. \n Hostnames that are prefixed with a wildcard
+                  label (`*.`) are interpreted as a suffix match. That means that
+                  a match for `*.example.com` would match both `test.example.com`,
+                  and `foo.test.example.com`, but not `example.com`. \n If both the
+                  Listener and HTTPRoute have specified hostnames, any HTTPRoute hostnames
+                  that do not match the Listener hostname MUST be ignored. For example,
+                  if a Listener specified `*.example.com`, and the HTTPRoute specified
+                  `test.example.com` and `test.example.net`, `test.example.net` must
+                  not be considered for a match. \n If both the Listener and HTTPRoute
+                  have specified hostnames, and none match with the criteria above,
+                  then the HTTPRoute is not accepted. The implementation must raise
+                  an 'Accepted' Condition with a status of `False` in the corresponding
+                  RouteParentStatus. \n In the event that multiple HTTPRoutes specify
+                  intersecting hostnames (e.g. overlapping wildcard matching and exact
+                  matching hostnames), precedence must be given to rules from the
+                  HTTPRoute with the largest number of: \n * Characters in a matching
+                  non-wildcard hostname. * Characters in a matching hostname. \n If
+                  ties exist across multiple Routes, the matching precedence rules
+                  for HTTPRouteMatches takes over. \n Support: Core"
+                items:
+                  description: "Hostname is the fully qualified domain name of a network
+                    host. This matches the RFC 1123 definition of a hostname with
+                    2 notable exceptions: \n  1. IPs are not allowed.  2. A hostname
+                    may be prefixed with a wildcard label (`*.`). The wildcard     label
+                    must appear by itself as the first label. \n Hostname can be \"precise\"
+                    which is a domain name without the terminating dot of a network
+                    host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
+                    name prefixed with a single wildcard label (e.g. `*.example.com`).
+                    \n Note that as per RFC1035 and RFC1123, a *label* must consist
+                    of lower case alphanumeric characters or '-', and must start and
+                    end with an alphanumeric character. No other punctuation is allowed."
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)
+                  that a Route wants to be attached to. Note that the referenced parent
+                  resource needs to allow this for the attachment to be complete.
+                  For Gateways, that means the Gateway needs to allow attachment from
+                  Routes of this kind and namespace. \n The only kind of parent resource
+                  with \"Core\" support is Gateway. This API may be extended in the
+                  future to support additional kinds of parent resources such as one
+                  of the route kinds. \n It is invalid to reference an identical parent
+                  more than once. It is valid to reference multiple distinct sections
+                  within the same parent resource, such as 2 Listeners within a Gateway.
+                  \n It is possible to separately reference multiple distinct objects
+                  that may be collapsed by an implementation. For example, some implementations
+                  may choose to merge compatible Gateway Listeners together. If that
+                  is the case, the list of routes attached to those resources should
+                  also be merged. \n Note that for ParentRefs that cross namespace
+                  boundaries, there are specific rules. Cross-namespace references
+                  are only valid if they are explicitly allowed by something in the
+                  namespace they are referring to. For example, Gateway has the AllowedRoutes
+                  field, and ReferenceGrant provides a generic way to enable any other
+                  kind of cross-namespace reference."
+                items:
+                  description: "ParentReference identifies an API object (usually
+                    a Gateway) that can be considered a parent of this resource (usually
+                    a route). The only kind of parent resource with \"Core\" support
+                    is Gateway. This API may be extended in the future to support
+                    additional kinds of parent resources, such as HTTPRoute. \n The
+                    API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid."
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: "Group is the group of the referent. When unspecified,
+                        \"gateway.networking.k8s.io\" is inferred. To set the core
+                        API group (such as for a \"Service\" kind referent), Group
+                        must be explicitly set to \"\" (empty string). \n Support:
+                        Core"
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: "Kind is kind of the referent. \n Support: Core
+                        (Gateway) \n Support: Implementation-specific (Other Resources)"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: "Name is the name of the referent. \n Support:
+                        Core"
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: "Namespace is the namespace of the referent. When
+                        unspecified, this refers to the local namespace of the Route.
+                        \n Note that there are specific rules for ParentRefs which
+                        cross namespace boundaries. Cross-namespace references are
+                        only valid if they are explicitly allowed by something in
+                        the namespace they are referring to. For example: Gateway
+                        has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+                        \n Support: Core"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    sectionName:
+                      description: "SectionName is the name of a section within the
+                        target resource. In the following resources, SectionName is
+                        interpreted as the following: \n * Gateway: Listener Name.
+                        When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected listener must match both
+                        specified values. \n Implementations MAY choose to support
+                        attaching Routes to other resources. If that is the case,
+                        they MUST clearly document how SectionName is interpreted.
+                        \n When unspecified (empty string), this will reference the
+                        entire resource. For the purpose of status, an attachment
+                        is considered successful if at least one section in the parent
+                        resource accepts it. For example, Gateway listeners can restrict
+                        which Routes can attach to them by Route kind, namespace,
+                        or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this
+                        Route, the Route MUST be considered detached from the Gateway.
+                        \n Support: Core"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+              rules:
+                default:
+                - matches:
+                  - path:
+                      type: PathPrefix
+                      value: /
+                description: Rules are a list of HTTP matchers, filters and actions.
+                items:
+                  description: HTTPRouteRule defines semantics for matching an HTTP
+                    request based on conditions (matches), processing it (filters),
+                    and forwarding the request to an API object (backendRefs).
+                  properties:
+                    backendRefs:
+                      description: "BackendRefs defines the backend(s) where matching
+                        requests should be sent. \n Failure behavior here depends
+                        on how many BackendRefs are specified and how many are invalid.
+                        \n If *all* entries in BackendRefs are invalid, and there
+                        are also no filters specified in this route rule, *all* traffic
+                        which matches this rule MUST receive a 500 status code. \n
+                        See the HTTPBackendRef definition for the rules about what
+                        makes a single HTTPBackendRef invalid. \n When a HTTPBackendRef
+                        is invalid, 500 status codes MUST be returned for requests
+                        that would have otherwise been routed to an invalid backend.
+                        If multiple backends are specified, and some are invalid,
+                        the proportion of requests that would otherwise have been
+                        routed to an invalid backend MUST receive a 500 status code.
+                        \n For example, if two backends are specified with equal weights,
+                        and one is invalid, 50 percent of traffic must receive a 500.
+                        Implementations may choose how that 50 percent is determined.
+                        \n Support: Core for Kubernetes Service \n Support: Implementation-specific
+                        for any other resource \n Support for weight: Core"
+                      items:
+                        description: HTTPBackendRef defines how a HTTPRoute should
+                          forward an HTTP request.
+                        properties:
+                          filters:
+                            description: "Filters defined at this level should be
+                              executed if and only if the request is being forwarded
+                              to the backend defined here. \n Support: Implementation-specific
+                              (For broader support of filters, use the Filters field
+                              in HTTPRouteRule.)"
+                            items:
+                              description: HTTPRouteFilter defines processing steps
+                                that must be completed during the request or response
+                                lifecycle. HTTPRouteFilters are meant as an extension
+                                point to express processing that may be done in Gateway
+                                implementations. Some examples include request or
+                                response modification, implementing authentication
+                                strategies, rate-limiting, and traffic shaping. API
+                                guarantee/conformance is defined based on the type
+                                of the filter.
+                              properties:
+                                extensionRef:
+                                  description: "ExtensionRef is an optional, implementation-specific
+                                    extension to the \"filter\" behavior.  For example,
+                                    resource \"myroutefilter\" in group \"networking.example.net\").
+                                    ExtensionRef MUST NOT be used for core and extended
+                                    filters. \n Support: Implementation-specific"
+                                  properties:
+                                    group:
+                                      description: Group is the group of the referent.
+                                        For example, "gateway.networking.k8s.io".
+                                        When unspecified or empty string, core API
+                                        group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "HTTPRoute" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                requestHeaderModifier:
+                                  description: "RequestHeaderModifier defines a schema
+                                    for a filter that modifies request headers. \n
+                                    Support: Core"
+                                  properties:
+                                    add:
+                                      description: "Add adds the given header(s) (name,
+                                        value) to the request before the action. It
+                                        appends to any existing values associated
+                                        with the header name. \n Input:   GET /foo
+                                        HTTP/1.1   my-header: foo \n Config:   add:
+                                        \  - name: \"my-header\"     value: \"bar,baz\"
+                                        \n Output:   GET /foo HTTP/1.1   my-header:
+                                        foo,bar,baz"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: "Remove the given header(s) from
+                                        the HTTP request before the action. The value
+                                        of Remove is a list of HTTP header names.
+                                        Note that the header names are case-insensitive
+                                        (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                        \n Input:   GET /foo HTTP/1.1   my-header1:
+                                        foo   my-header2: bar   my-header3: baz \n
+                                        Config:   remove: [\"my-header1\", \"my-header3\"]
+                                        \n Output:   GET /foo HTTP/1.1   my-header2:
+                                        bar"
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                    set:
+                                      description: "Set overwrites the request with
+                                        the given header (name, value) before the
+                                        action. \n Input:   GET /foo HTTP/1.1   my-header:
+                                        foo \n Config:   set:   - name: \"my-header\"
+                                        \    value: \"bar\" \n Output:   GET /foo
+                                        HTTP/1.1   my-header: bar"
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: "Name is the name of the
+                                              HTTP Header to be matched. Name matching
+                                              MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                              \n If multiple entries specify equivalent
+                                              header names, the first entry with an
+                                              equivalent name MUST be considered for
+                                              a match. Subsequent entries with an
+                                              equivalent header name MUST be ignored.
+                                              Due to the case-insensitivity of header
+                                              names, \"foo\" and \"Foo\" are considered
+                                              equivalent."
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                requestMirror:
+                                  description: "RequestMirror defines a schema for
+                                    a filter that mirrors requests. Requests are sent
+                                    to the specified destination, but responses from
+                                    that destination are ignored. \n Support: Extended"
+                                  properties:
+                                    backendRef:
+                                      description: "BackendRef references a resource
+                                        where mirrored requests are sent. \n If the
+                                        referent cannot be found, this BackendRef
+                                        is invalid and must be dropped from the Gateway.
+                                        The controller must ensure the \"ResolvedRefs\"
+                                        condition on the Route status is set to `status:
+                                        False` and not configure this backend in the
+                                        underlying implementation. \n If there is
+                                        a cross-namespace reference to an *existing*
+                                        object that is not allowed by a ReferenceGrant,
+                                        the controller must ensure the \"ResolvedRefs\"
+                                        \ condition on the Route is set to `status:
+                                        False`, with the \"RefNotPermitted\" reason
+                                        and not configure this backend in the underlying
+                                        implementation. \n In either error case, the
+                                        Message of the `ResolvedRefs` Condition should
+                                        be used to provide more detail about the problem.
+                                        \n Support: Extended for Kubernetes Service
+                                        \n Support: Implementation-specific for any
+                                        other resource"
+                                      properties:
+                                        group:
+                                          default: ""
+                                          description: Group is the group of the referent.
+                                            For example, "gateway.networking.k8s.io".
+                                            When unspecified or empty string, core
+                                            API group is inferred.
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: Kind is kind of the referent.
+                                            For example "HTTPRoute" or "Service".
+                                            Defaults to "Service" when not specified.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: "Namespace is the namespace
+                                            of the backend. When unspecified, the
+                                            local namespace is inferred. \n Note that
+                                            when a namespace is specified, a ReferenceGrant
+                                            object is required in the referent namespace
+                                            to allow that namespace's owner to accept
+                                            the reference. See the ReferenceGrant
+                                            documentation for details. \n Support:
+                                            Core"
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: Port specifies the destination
+                                            port number to use for this resource.
+                                            Port is required when the referent is
+                                            a Kubernetes Service. In this case, the
+                                            port number is the service port number,
+                                            not the target port. For other resources,
+                                            destination port might be derived from
+                                            the referent resource or this field.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                  required:
+                                  - backendRef
+                                  type: object
+                                requestRedirect:
+                                  description: "RequestRedirect defines a schema for
+                                    a filter that responds to the request with an
+                                    HTTP redirection. \n Support: Core"
+                                  properties:
+                                    hostname:
+                                      description: "Hostname is the hostname to be
+                                        used in the value of the `Location` header
+                                        in the response. When empty, the hostname
+                                        of the request is used. \n Support: Core"
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    port:
+                                      description: "Port is the port to be used in
+                                        the value of the `Location` header in the
+                                        response. When empty, port (if specified)
+                                        of the request is used. \n Support: Extended"
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    scheme:
+                                      description: "Scheme is the scheme to be used
+                                        in the value of the `Location` header in the
+                                        response. When empty, the scheme of the request
+                                        is used. \n Note that values may be added
+                                        to this enum, implementations must ensure
+                                        that unknown values will not cause a crash.
+                                        \n Unknown values here must result in the
+                                        implementation setting the Accepted Condition
+                                        for the Route to `status: False`, with a Reason
+                                        of `UnsupportedValue`. \n Support: Extended"
+                                      enum:
+                                      - http
+                                      - https
+                                      type: string
+                                    statusCode:
+                                      default: 302
+                                      description: "StatusCode is the HTTP status
+                                        code to be used in response. \n Note that
+                                        values may be added to this enum, implementations
+                                        must ensure that unknown values will not cause
+                                        a crash. \n Unknown values here must result
+                                        in the implementation setting the Accepted
+                                        Condition for the Route to `status: False`,
+                                        with a Reason of `UnsupportedValue`. \n Support:
+                                        Core"
+                                      enum:
+                                      - 301
+                                      - 302
+                                      type: integer
+                                  type: object
+                                type:
+                                  description: "Type identifies the type of filter
+                                    to apply. As with other API fields, types are
+                                    classified into three conformance levels: \n -
+                                    Core: Filter types and their corresponding configuration
+                                    defined by   \"Support: Core\" in this package,
+                                    e.g. \"RequestHeaderModifier\". All   implementations
+                                    must support core filters. \n - Extended: Filter
+                                    types and their corresponding configuration defined
+                                    by   \"Support: Extended\" in this package, e.g.
+                                    \"RequestMirror\". Implementers   are encouraged
+                                    to support extended filters. \n - Implementation-specific:
+                                    Filters that are defined and supported by   specific
+                                    vendors.   In the future, filters showing convergence
+                                    in behavior across multiple   implementations
+                                    will be considered for inclusion in extended or
+                                    core   conformance levels. Filter-specific configuration
+                                    for such filters   is specified using the ExtensionRef
+                                    field. `Type` should be set to   \"ExtensionRef\"
+                                    for custom filters. \n Implementers are encouraged
+                                    to define custom implementation types to extend
+                                    the core API with implementation-specific behavior.
+                                    \n If a reference to a custom filter type cannot
+                                    be resolved, the filter MUST NOT be skipped. Instead,
+                                    requests that would have been processed by that
+                                    filter MUST receive a HTTP error response. \n
+                                    Note that values may be added to this enum, implementations
+                                    must ensure that unknown values will not cause
+                                    a crash. \n Unknown values here must result in
+                                    the implementation setting the Accepted Condition
+                                    for the Route to `status: False`, with a Reason
+                                    of `UnsupportedValue`. \n "
+                                  enum:
+                                  - RequestHeaderModifier
+                                  - RequestMirror
+                                  - RequestRedirect
+                                  - ExtensionRef
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            maxItems: 16
+                            type: array
+                          group:
+                            default: ""
+                            description: Group is the group of the referent. For example,
+                              "gateway.networking.k8s.io". When unspecified or empty
+                              string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: Kind is kind of the referent. For example
+                              "HTTPRoute" or "Service". Defaults to "Service" when
+                              not specified.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: "Namespace is the namespace of the backend.
+                              When unspecified, the local namespace is inferred. \n
+                              Note that when a namespace is specified, a ReferenceGrant
+                              object is required in the referent namespace to allow
+                              that namespace's owner to accept the reference. See
+                              the ReferenceGrant documentation for details. \n Support:
+                              Core"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: Port specifies the destination port number
+                              to use for this resource. Port is required when the
+                              referent is a Kubernetes Service. In this case, the
+                              port number is the service port number, not the target
+                              port. For other resources, destination port might be
+                              derived from the referent resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: "Weight specifies the proportion of requests
+                              forwarded to the referenced backend. This is computed
+                              as weight/(sum of all weights in this BackendRefs list).
+                              For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision
+                              an implementation supports. Weight is not a percentage
+                              and the sum of weights does not need to equal 100. \n
+                              If only one backend is specified and it has a weight
+                              greater than 0, 100% of the traffic is forwarded to
+                              that backend. If weight is set to 0, no traffic should
+                              be forwarded for this entry. If unspecified, weight
+                              defaults to 1. \n Support for this field varies based
+                              on the context where used."
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                      maxItems: 16
+                      type: array
+                    filters:
+                      description: "Filters define the filters that are applied to
+                        requests that match this rule. \n The effects of ordering
+                        of multiple behaviors are currently unspecified. This can
+                        change in the future based on feedback during the alpha stage.
+                        \n Conformance-levels at this level are defined based on the
+                        type of filter: \n - ALL core filters MUST be supported by
+                        all implementations. - Implementers are encouraged to support
+                        extended filters. - Implementation-specific custom filters
+                        have no API guarantees across   implementations. \n Specifying
+                        a core filter multiple times has unspecified or implementation-specific
+                        conformance. \n All filters are expected to be compatible
+                        with each other except for the URLRewrite and RequestRedirect
+                        filters, which may not be combined. If an implementation can
+                        not support other combinations of filters, they must clearly
+                        document that limitation. In all cases where incompatible
+                        or unsupported filters are specified, implementations MUST
+                        add a warning condition to status. \n Support: Core"
+                      items:
+                        description: HTTPRouteFilter defines processing steps that
+                          must be completed during the request or response lifecycle.
+                          HTTPRouteFilters are meant as an extension point to express
+                          processing that may be done in Gateway implementations.
+                          Some examples include request or response modification,
+                          implementing authentication strategies, rate-limiting, and
+                          traffic shaping. API guarantee/conformance is defined based
+                          on the type of the filter.
+                        properties:
+                          extensionRef:
+                            description: "ExtensionRef is an optional, implementation-specific
+                              extension to the \"filter\" behavior.  For example,
+                              resource \"myroutefilter\" in group \"networking.example.net\").
+                              ExtensionRef MUST NOT be used for core and extended
+                              filters. \n Support: Implementation-specific"
+                            properties:
+                              group:
+                                description: Group is the group of the referent. For
+                                  example, "gateway.networking.k8s.io". When unspecified
+                                  or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          requestHeaderModifier:
+                            description: "RequestHeaderModifier defines a schema for
+                              a filter that modifies request headers. \n Support:
+                              Core"
+                            properties:
+                              add:
+                                description: "Add adds the given header(s) (name,
+                                  value) to the request before the action. It appends
+                                  to any existing values associated with the header
+                                  name. \n Input:   GET /foo HTTP/1.1   my-header:
+                                  foo \n Config:   add:   - name: \"my-header\"     value:
+                                  \"bar,baz\" \n Output:   GET /foo HTTP/1.1   my-header:
+                                  foo,bar,baz"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: "Remove the given header(s) from the
+                                  HTTP request before the action. The value of Remove
+                                  is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+                                  \n Input:   GET /foo HTTP/1.1   my-header1: foo
+                                  \  my-header2: bar   my-header3: baz \n Config:
+                                  \  remove: [\"my-header1\", \"my-header3\"] \n Output:
+                                  \  GET /foo HTTP/1.1   my-header2: bar"
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                              set:
+                                description: "Set overwrites the request with the
+                                  given header (name, value) before the action. \n
+                                  Input:   GET /foo HTTP/1.1   my-header: foo \n Config:
+                                  \  set:   - name: \"my-header\"     value: \"bar\"
+                                  \n Output:   GET /foo HTTP/1.1   my-header: bar"
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: "Name is the name of the HTTP Header
+                                        to be matched. Name matching MUST be case
+                                        insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                        \n If multiple entries specify equivalent
+                                        header names, the first entry with an equivalent
+                                        name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST
+                                        be ignored. Due to the case-insensitivity
+                                        of header names, \"foo\" and \"Foo\" are considered
+                                        equivalent."
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          requestMirror:
+                            description: "RequestMirror defines a schema for a filter
+                              that mirrors requests. Requests are sent to the specified
+                              destination, but responses from that destination are
+                              ignored. \n Support: Extended"
+                            properties:
+                              backendRef:
+                                description: "BackendRef references a resource where
+                                  mirrored requests are sent. \n If the referent cannot
+                                  be found, this BackendRef is invalid and must be
+                                  dropped from the Gateway. The controller must ensure
+                                  the \"ResolvedRefs\" condition on the Route status
+                                  is set to `status: False` and not configure this
+                                  backend in the underlying implementation. \n If
+                                  there is a cross-namespace reference to an *existing*
+                                  object that is not allowed by a ReferenceGrant,
+                                  the controller must ensure the \"ResolvedRefs\"
+                                  \ condition on the Route is set to `status: False`,
+                                  with the \"RefNotPermitted\" reason and not configure
+                                  this backend in the underlying implementation. \n
+                                  In either error case, the Message of the `ResolvedRefs`
+                                  Condition should be used to provide more detail
+                                  about the problem. \n Support: Extended for Kubernetes
+                                  Service \n Support: Implementation-specific for
+                                  any other resource"
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: Group is the group of the referent.
+                                      For example, "gateway.networking.k8s.io". When
+                                      unspecified or empty string, core API group
+                                      is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: Kind is kind of the referent. For
+                                      example "HTTPRoute" or "Service". Defaults to
+                                      "Service" when not specified.
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: "Namespace is the namespace of the
+                                      backend. When unspecified, the local namespace
+                                      is inferred. \n Note that when a namespace is
+                                      specified, a ReferenceGrant object is required
+                                      in the referent namespace to allow that namespace's
+                                      owner to accept the reference. See the ReferenceGrant
+                                      documentation for details. \n Support: Core"
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: Port specifies the destination port
+                                      number to use for this resource. Port is required
+                                      when the referent is a Kubernetes Service. In
+                                      this case, the port number is the service port
+                                      number, not the target port. For other resources,
+                                      destination port might be derived from the referent
+                                      resource or this field.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - backendRef
+                            type: object
+                          requestRedirect:
+                            description: "RequestRedirect defines a schema for a filter
+                              that responds to the request with an HTTP redirection.
+                              \n Support: Core"
+                            properties:
+                              hostname:
+                                description: "Hostname is the hostname to be used
+                                  in the value of the `Location` header in the response.
+                                  When empty, the hostname of the request is used.
+                                  \n Support: Core"
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              port:
+                                description: "Port is the port to be used in the value
+                                  of the `Location` header in the response. When empty,
+                                  port (if specified) of the request is used. \n Support:
+                                  Extended"
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              scheme:
+                                description: "Scheme is the scheme to be used in the
+                                  value of the `Location` header in the response.
+                                  When empty, the scheme of the request is used. \n
+                                  Note that values may be added to this enum, implementations
+                                  must ensure that unknown values will not cause a
+                                  crash. \n Unknown values here must result in the
+                                  implementation setting the Accepted Condition for
+                                  the Route to `status: False`, with a Reason of `UnsupportedValue`.
+                                  \n Support: Extended"
+                                enum:
+                                - http
+                                - https
+                                type: string
+                              statusCode:
+                                default: 302
+                                description: "StatusCode is the HTTP status code to
+                                  be used in response. \n Note that values may be
+                                  added to this enum, implementations must ensure
+                                  that unknown values will not cause a crash. \n Unknown
+                                  values here must result in the implementation setting
+                                  the Accepted Condition for the Route to `status:
+                                  False`, with a Reason of `UnsupportedValue`. \n
+                                  Support: Core"
+                                enum:
+                                - 301
+                                - 302
+                                type: integer
+                            type: object
+                          type:
+                            description: "Type identifies the type of filter to apply.
+                              As with other API fields, types are classified into
+                              three conformance levels: \n - Core: Filter types and
+                              their corresponding configuration defined by   \"Support:
+                              Core\" in this package, e.g. \"RequestHeaderModifier\".
+                              All   implementations must support core filters. \n
+                              - Extended: Filter types and their corresponding configuration
+                              defined by   \"Support: Extended\" in this package,
+                              e.g. \"RequestMirror\". Implementers   are encouraged
+                              to support extended filters. \n - Implementation-specific:
+                              Filters that are defined and supported by   specific
+                              vendors.   In the future, filters showing convergence
+                              in behavior across multiple   implementations will be
+                              considered for inclusion in extended or core   conformance
+                              levels. Filter-specific configuration for such filters
+                              \  is specified using the ExtensionRef field. `Type`
+                              should be set to   \"ExtensionRef\" for custom filters.
+                              \n Implementers are encouraged to define custom implementation
+                              types to extend the core API with implementation-specific
+                              behavior. \n If a reference to a custom filter type
+                              cannot be resolved, the filter MUST NOT be skipped.
+                              Instead, requests that would have been processed by
+                              that filter MUST receive a HTTP error response. \n Note
+                              that values may be added to this enum, implementations
+                              must ensure that unknown values will not cause a crash.
+                              \n Unknown values here must result in the implementation
+                              setting the Accepted Condition for the Route to `status:
+                              False`, with a Reason of `UnsupportedValue`. \n "
+                            enum:
+                            - RequestHeaderModifier
+                            - RequestMirror
+                            - RequestRedirect
+                            - ExtensionRef
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      maxItems: 16
+                      type: array
+                    matches:
+                      default:
+                      - path:
+                          type: PathPrefix
+                          value: /
+                      description: "Matches define conditions used for matching the
+                        rule against incoming HTTP requests. Each match is independent,
+                        i.e. this rule will be matched if **any** one of the matches
+                        is satisfied. \n For example, take the following matches configuration:
+                        \n ``` matches: - path:     value: \"/foo\"   headers:   -
+                        name: \"version\"     value: \"v2\" - path:     value: \"/v2/foo\"
+                        ``` \n For a request to match against this rule, a request
+                        must satisfy EITHER of the two conditions: \n - path prefixed
+                        with `/foo` AND contains the header `version: v2` - path prefix
+                        of `/v2/foo` \n See the documentation for HTTPRouteMatch on
+                        how to specify multiple match conditions that should be ANDed
+                        together. \n If no matches are specified, the default is a
+                        prefix path match on \"/\", which has the effect of matching
+                        every HTTP request. \n Proxy or Load Balancer routing configuration
+                        generated from HTTPRoutes MUST prioritize matches based on
+                        the following criteria, continuing on ties. Across all rules
+                        specified on applicable Routes, precedence must be given to
+                        the match with the largest number of: \n * Characters in a
+                        matching path. * Header matches. * Query param matches. \n
+                        If ties still exist across multiple Routes, matching precedence
+                        MUST be determined in order of the following criteria, continuing
+                        on ties: \n * The oldest Route based on creation timestamp.
+                        * The Route appearing first in alphabetical order by   \"{namespace}/{name}\".
+                        \n If ties still exist within an HTTPRoute, matching precedence
+                        MUST be granted to the FIRST matching rule (in list order)
+                        with a match meeting the above criteria. \n When no rules
+                        matching a request have been successfully attached to the
+                        parent a request is coming from, a HTTP 404 status code MUST
+                        be returned."
+                      items:
+                        description: "HTTPRouteMatch defines the predicate used to
+                          match requests to a given action. Multiple match types are
+                          ANDed together, i.e. the match will evaluate to true only
+                          if all conditions are satisfied. \n For example, the match
+                          below will match a HTTP request only if its path starts
+                          with `/foo` AND it contains the `version: v1` header: \n
+                          ``` match: \n \tpath: \t  value: \"/foo\" \theaders: \t-
+                          name: \"version\" \t  value \"v1\" \n ```"
+                        properties:
+                          headers:
+                            description: Headers specifies HTTP request header matchers.
+                              Multiple match values are ANDed together, meaning, a
+                              request must match all the specified headers to select
+                              the route.
+                            items:
+                              description: HTTPHeaderMatch describes how to select
+                                a HTTP route by matching HTTP request headers.
+                              properties:
+                                name:
+                                  description: "Name is the name of the HTTP Header
+                                    to be matched. Name matching MUST be case insensitive.
+                                    (See https://tools.ietf.org/html/rfc7230#section-3.2).
+                                    \n If multiple entries specify equivalent header
+                                    names, only the first entry with an equivalent
+                                    name MUST be considered for a match. Subsequent
+                                    entries with an equivalent header name MUST be
+                                    ignored. Due to the case-insensitivity of header
+                                    names, \"foo\" and \"Foo\" are considered equivalent.
+                                    \n When a header is repeated in an HTTP request,
+                                    it is implementation-specific behavior as to how
+                                    this is represented. Generally, proxies should
+                                    follow the guidance from the RFC: https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2
+                                    regarding processing a repeated header, with special
+                                    handling for \"Set-Cookie\"."
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: "Type specifies how to match against
+                                    the value of the header. \n Support: Core (Exact)
+                                    \n Support: Implementation-specific (RegularExpression)
+                                    \n Since RegularExpression HeaderMatchType has
+                                    implementation-specific conformance, implementations
+                                    can support POSIX, PCRE or any other dialects
+                                    of regular expressions. Please read the implementation's
+                                    documentation to determine the supported dialect."
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP Header to
+                                    be matched.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          method:
+                            description: "Method specifies HTTP method matcher. When
+                              specified, this route will be matched only if the request
+                              has the specified method. \n Support: Extended"
+                            enum:
+                            - GET
+                            - HEAD
+                            - POST
+                            - PUT
+                            - DELETE
+                            - CONNECT
+                            - OPTIONS
+                            - TRACE
+                            - PATCH
+                            type: string
+                          path:
+                            default:
+                              type: PathPrefix
+                              value: /
+                            description: Path specifies a HTTP request path matcher.
+                              If this field is not specified, a default prefix match
+                              on the "/" path is provided.
+                            properties:
+                              type:
+                                default: PathPrefix
+                                description: "Type specifies how to match against
+                                  the path Value. \n Support: Core (Exact, PathPrefix)
+                                  \n Support: Implementation-specific (RegularExpression)"
+                                enum:
+                                - Exact
+                                - PathPrefix
+                                - RegularExpression
+                                type: string
+                              value:
+                                default: /
+                                description: Value of the HTTP path to match against.
+                                maxLength: 1024
+                                type: string
+                            type: object
+                          queryParams:
+                            description: "QueryParams specifies HTTP query parameter
+                              matchers. Multiple match values are ANDed together,
+                              meaning, a request must match all the specified query
+                              parameters to select the route. \n Support: Extended"
+                            items:
+                              description: HTTPQueryParamMatch describes how to select
+                                a HTTP route by matching HTTP query parameters.
+                              properties:
+                                name:
+                                  description: "Name is the name of the HTTP query
+                                    param to be matched. This must be an exact string
+                                    match. (See https://tools.ietf.org/html/rfc7230#section-2.7.3).
+                                    \n If multiple entries specify equivalent query
+                                    param names, only the first entry with an equivalent
+                                    name MUST be considered for a match. Subsequent
+                                    entries with an equivalent query param name MUST
+                                    be ignored. \n If a query param is repeated in
+                                    an HTTP request, the behavior is purposely left
+                                    undefined, since different data planes have different
+                                    capabilities. However, it is *recommended* that
+                                    implementations should match against the first
+                                    value of the param if the data plane supports
+                                    it, as this behavior is expected in other load
+                                    balancing contexts outside of the Gateway API.
+                                    \n Users SHOULD NOT route traffic based on repeated
+                                    query params to guard themselves against potential
+                                    differences in the implementations."
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: "Type specifies how to match against
+                                    the value of the query parameter. \n Support:
+                                    Extended (Exact) \n Support: Implementation-specific
+                                    (RegularExpression) \n Since RegularExpression
+                                    QueryParamMatchType has Implementation-specific
+                                    conformance, implementations can support POSIX,
+                                    PCRE or any other dialects of regular expressions.
+                                    Please read the implementation's documentation
+                                    to determine the supported dialect."
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of HTTP query param
+                                    to be matched.
+                                  maxLength: 1024
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        type: object
+                      maxItems: 8
+                      type: array
+                  type: object
+                maxItems: 16
+                type: array
+            type: object
+          status:
+            description: Status defines the current state of HTTPRoute.
+            properties:
+              parents:
+                description: "Parents is a list of parent resources (usually Gateways)
+                  that are associated with the route, and the status of the route
+                  with respect to each parent. When this route attaches to a parent,
+                  the controller that manages the parent must add an entry to this
+                  list when the controller first sees the route and should update
+                  the entry as appropriate when the route or gateway is modified.
+                  \n Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this
+                  API can only populate Route status for the Gateways/parent resources
+                  they are responsible for. \n A maximum of 32 Gateways will be represented
+                  in this list. An empty list means the route has not been attached
+                  to any Gateway."
+                items:
+                  description: RouteParentStatus describes the status of a route with
+                    respect to an associated Parent.
+                  properties:
+                    conditions:
+                      description: "Conditions describes the status of the route with
+                        respect to the Gateway. Note that the route's availability
+                        is also subject to the Gateway's own status conditions and
+                        listener status. \n If the Route's ParentRef specifies an
+                        existing Gateway that supports Routes of this kind AND that
+                        Gateway's controller has sufficient access, then that Gateway's
+                        controller MUST set the \"Accepted\" condition on the Route,
+                        to indicate whether the route has been accepted or rejected
+                        by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
+                        if at least one of the Route's rules is implemented by the
+                        Gateway. \n There are a number of cases where the \"Accepted\"
+                        condition may not be set due to lack of controller visibility,
+                        that includes when: \n * The Route refers to a non-existent
+                        parent. * The Route is of a type that the controller does
+                        not support. * The Route is in a namespace the controller
+                        does not have access to."
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n \ttype FooStatus struct{
+                          \t    // Represents the observations of a foo's current
+                          state. \t    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\" \t    // +patchMergeKey=type
+                          \t    // +patchStrategy=merge \t    // +listType=map \t
+                          \   // +listMapKey=type \t    Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other
+                          fields \t}"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: "ControllerName is a domain/path string that indicates
+                        the name of the controller that wrote this status. This corresponds
+                        with the controllerName field on GatewayClass. \n Example:
+                        \"example.net/gateway-controller\". \n The format of this
+                        field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid
+                        Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                        \n Controllers MUST populate this field when writing status.
+                        Controllers should ensure that entries to status populated
+                        with their ControllerName are cleaned up when they are no
+                        longer necessary."
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: ParentRef corresponds with a ParentRef in the spec
+                        that this RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: "Group is the group of the referent. When unspecified,
+                            \"gateway.networking.k8s.io\" is inferred. To set the
+                            core API group (such as for a \"Service\" kind referent),
+                            Group must be explicitly set to \"\" (empty string). \n
+                            Support: Core"
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: "Kind is kind of the referent. \n Support:
+                            Core (Gateway) \n Support: Implementation-specific (Other
+                            Resources)"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: "Name is the name of the referent. \n Support:
+                            Core"
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: "Namespace is the namespace of the referent.
+                            When unspecified, this refers to the local namespace of
+                            the Route. \n Note that there are specific rules for ParentRefs
+                            which cross namespace boundaries. Cross-namespace references
+                            are only valid if they are explicitly allowed by something
+                            in the namespace they are referring to. For example: Gateway
+                            has the AllowedRoutes field, and ReferenceGrant provides
+                            a generic way to enable any other kind of cross-namespace
+                            reference. \n Support: Core"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        sectionName:
+                          description: "SectionName is the name of a section within
+                            the target resource. In the following resources, SectionName
+                            is interpreted as the following: \n * Gateway: Listener
+                            Name. When both Port (experimental) and SectionName are
+                            specified, the name and port of the selected listener
+                            must match both specified values. \n Implementations MAY
+                            choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName
+                            is interpreted. \n When unspecified (empty string), this
+                            will reference the entire resource. For the purpose of
+                            status, an attachment is considered successful if at least
+                            one section in the parent resource accepts it. For example,
+                            Gateway listeners can restrict which Routes can attach
+                            to them by Route kind, namespace, or hostname. If 1 of
+                            2 Gateway listeners accept attachment from the referencing
+                            Route, the Route MUST be considered successfully attached.
+                            If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+                            \n Support: Core"
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: iamauthpolicies.application-networking.k8s.aws
+spec:
+  group: application-networking.k8s.aws
+  names:
+    categories:
+    - gateway-api
+    kind: IAMAuthPolicy
+    listKind: IAMAuthPolicyList
+    plural: iamauthpolicies
+    shortNames:
+    - iap
+    singular: iamauthpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IAMAuthPolicySpec defines the desired state of IAMAuthPolicy.
+              When the controller handles IAMAuthPolicy creation, if the targetRef
+              k8s and VPC Lattice resource exists, the controller will change the
+              auth_type of that VPC Lattice resource to AWS_IAM and attach this policy.
+              When the controller handles IAMAuthPolicy deletion, if the targetRef
+              k8s and VPC Lattice resource exists, the controller will change the
+              auth_type of that VPC Lattice resource to NONE and detach this policy.
+            properties:
+              policy:
+                description: IAM auth policy content. It is a JSON string that uses
+                  the same syntax as AWS IAM policies. Please check the VPC Lattice
+                  documentation to get [the common elements in an auth policy](https://docs.aws.amazon.com/vpc-lattice/latest/ug/auth-policies.html#auth-policies-common-elements)
+                type: string
+              targetRef:
+                description: "TargetRef points to the Kubernetes Gateway, HTTPRoute,
+                  or GRPCRoute resource that will have this policy attached. \n This
+                  field is following the guidelines of Kubernetes Gateway API policy
+                  attachment."
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the referent. When
+                      unspecified, the local namespace is inferred. Even when policy
+                      targets a resource in a different namespace, it MUST only apply
+                      to traffic originating from the same namespace as the policy.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - policy
+            - targetRef
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: NotReconciled
+                status: Unknown
+                type: Accepted
+            description: Status defines the current state of IAMAuthPolicy.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the IAMAuthPolicy.
+                  \n Implementations should prefer to express Policy conditions using
+                  the `PolicyConditionType` and `PolicyConditionReason` constants
+                  so that operators and tools can converge on a common vocabulary
+                  to describe IAMAuthPolicy state. \n Known condition types are: \n
+                  * \"Accepted\" * \"Ready\""
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: serviceexports.application-networking.k8s.aws
+spec:
+  group: application-networking.k8s.aws
+  names:
+    kind: ServiceExport
+    listKind: ServiceExportList
+    plural: serviceexports
+    singular: serviceexport
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ServiceExport declares that the Service with the same name and
+          namespace as this export should be consumable from other clusters.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          status:
+            description: status describes the current state of an exported service.
+              Service configuration comes from the Service that had the same name
+              and namespace as this ServiceExport. Populated by the multi-cluster
+              service implementation's controller.
+            properties:
+              conditions:
+                items:
+                  description: "ServiceExportCondition contains details for the current
+                    condition of this service export. \n Once [KEP-1623](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1623-standardize-conditions)
+                    is implemented, this will be replaced by metav1.Condition."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      description: Status is one of {"True", "False", "Unknown"}
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: ServiceExportConditionType identifies a specific
+                        condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: serviceimports.application-networking.k8s.aws
+spec:
+  group: application-networking.k8s.aws
+  names:
+    kind: ServiceImport
+    listKind: ServiceImportList
+    plural: serviceimports
+    singular: serviceimport
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ServiceImport describes a service imported from clusters in a
+          ClusterSet.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the behavior of a ServiceImport.
+            properties:
+              ips:
+                description: ip will be used as the VIP for this service when type
+                  is ClusterSetIP.
+                items:
+                  type: string
+                maxItems: 1
+                type: array
+              ports:
+                items:
+                  description: ServicePort represents the port on which the service
+                    is exposed
+                  properties:
+                    appProtocol:
+                      description: The application protocol for this port. This field
+                        follows standard Kubernetes label syntax. Un-prefixed names
+                        are reserved for IANA standard service names (as per RFC-6335
+                        and http://www.iana.org/assignments/service-names). Non-standard
+                        protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                        Field can be enabled with ServiceAppProtocol feature gate.
+                      type: string
+                    name:
+                      description: The name of this port within the service. This
+                        must be a DNS_LABEL. All ports within a ServiceSpec must have
+                        unique names. When considering the endpoints for a Service,
+                        this must match the 'name' field in the EndpointPort. Optional
+                        if only one ServicePort is defined on this service.
+                      type: string
+                    port:
+                      description: The port that will be exposed by this service.
+                      format: int32
+                      type: integer
+                    protocol:
+                      default: TCP
+                      description: The IP protocol for this port. Supports "TCP",
+                        "UDP", and "SCTP". Default is TCP.
+                      type: string
+                  required:
+                  - port
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              sessionAffinity:
+                description: 'Supports "ClientIP" and "None". Used to maintain session
+                  affinity. Enable client IP based session affinity. Must be ClientIP
+                  or None. Defaults to None. Ignored when type is Headless More info:
+                  https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                type: string
+              sessionAffinityConfig:
+                description: sessionAffinityConfig contains session affinity configuration.
+                properties:
+                  clientIP:
+                    description: clientIP contains the configurations of Client IP
+                      based session affinity.
+                    properties:
+                      timeoutSeconds:
+                        description: timeoutSeconds specifies the seconds of ClientIP
+                          type session sticky time. The value must be >0 && <=86400(for
+                          1 day) if ServiceAffinity == "ClientIP". Default value is
+                          10800(for 3 hours).
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+              type:
+                description: type defines the type of this service. Must be ClusterSetIP
+                  or Headless.
+                enum:
+                - ClusterSetIP
+                - Headless
+                type: string
+            required:
+            - ports
+            - type
+            type: object
+          status:
+            description: status contains information about the exported services that
+              form the multi-cluster service referenced by this ServiceImport.
+            properties:
+              clusters:
+                description: clusters is the list of exporting clusters from which
+                  this service was derived.
+                items:
+                  description: ClusterStatus contains service configuration mapped
+                    to a specific source cluster
+                  properties:
+                    cluster:
+                      description: cluster is the name of the exporting cluster. Must
+                        be a valid RFC-1123 DNS label.
+                      type: string
+                  required:
+                  - cluster
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - cluster
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: targetgrouppolicies.application-networking.k8s.aws
+spec:
+  group: application-networking.k8s.aws
+  names:
+    categories:
+    - gateway-api
+    kind: TargetGroupPolicy
+    listKind: TargetGroupPolicyList
+    plural: targetgrouppolicies
+    shortNames:
+    - tgp
+    singular: targetgrouppolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TargetGroupPolicySpec defines the desired state of TargetGroupPolicy.
+            properties:
+              healthCheck:
+                description: "The health check configuration. \n Changes to this value
+                  will update VPC Lattice resource in place."
+                properties:
+                  enabled:
+                    description: Indicates whether health checking is enabled.
+                    type: boolean
+                  healthyThresholdCount:
+                    description: The number of consecutive successful health checks
+                      required before considering an unhealthy target healthy.
+                    format: int64
+                    maximum: 10
+                    minimum: 2
+                    type: integer
+                  intervalSeconds:
+                    description: The approximate amount of time, in seconds, between
+                      health checks of an individual target.
+                    format: int64
+                    maximum: 300
+                    minimum: 5
+                    type: integer
+                  path:
+                    description: The destination for health checks on the targets.
+                    type: string
+                  port:
+                    description: The port used when performing health checks on targets.
+                      If not specified, health check defaults to the port that a target
+                      receives traffic on.
+                    format: int64
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  protocol:
+                    description: The protocol used when performing health checks on
+                      targets.
+                    enum:
+                    - HTTP
+                    - HTTPS
+                    type: string
+                  protocolVersion:
+                    description: The protocol version used when performing health
+                      checks on targets.
+                    enum:
+                    - HTTP1
+                    - HTTP2
+                    type: string
+                  statusMatch:
+                    description: A regular expression to match HTTP status codes when
+                      checking for successful response from a target.
+                    type: string
+                  timeoutSeconds:
+                    description: The amount of time, in seconds, to wait before reporting
+                      a target as unhealthy.
+                    format: int64
+                    maximum: 120
+                    minimum: 1
+                    type: integer
+                  unhealthyThresholdCount:
+                    description: The number of consecutive failed health checks required
+                      before considering a target unhealthy.
+                    format: int64
+                    maximum: 10
+                    minimum: 2
+                    type: integer
+                type: object
+              protocol:
+                description: "The protocol to use for routing traffic to the targets.
+                  Supported values are HTTP (default), HTTPS and TCP. \n Changes to
+                  this value results in a replacement of VPC Lattice target group."
+                type: string
+              protocolVersion:
+                description: "The protocol version to use. Supported values are HTTP1
+                  (default) and HTTP2. When a policy Protocol is TCP, you should not
+                  set this field. Otherwise, the whole TargetGroupPolicy will not
+                  take effect. When a policy is behind GRPCRoute, this field value
+                  will be ignored as GRPC is only supported through HTTP/2. \n Changes
+                  to this value results in a replacement of VPC Lattice target group."
+                type: string
+              targetRef:
+                description: "TargetRef points to the kubernetes Service resource
+                  that will have this policy attached. \n This field is following
+                  the guidelines of Kubernetes Gateway API policy attachment."
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the referent. When
+                      unspecified, the local namespace is inferred. Even when policy
+                      targets a resource in a different namespace, it MUST only apply
+                      to traffic originating from the same namespace as the policy.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - targetRef
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: NotReconciled
+                status: Unknown
+                type: Accepted
+            description: Status defines the current state of TargetGroupPolicy.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: "Conditions describe the current conditions of the TargetGroup.
+                  \n Implementations should prefer to express Policy conditions using
+                  the `PolicyConditionType` and `PolicyConditionReason` constants
+                  so that operators and tools can converge on a common vocabulary
+                  to describe TargetGroup state. \n Known condition types are: \n
+                  * \"Accepted\" * \"Ready\""
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.2.0-dev
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: tlsroutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: TLSRoute
+    listKind: TLSRouteList
+    plural: tlsroutes
+    singular: tlsroute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          The TLSRoute resource is similar to TCPRoute, but can be configured
+          to match against TLS-specific metadata. This allows more flexibility
+          in matching streams for a given TLS listener.
+
+
+          If you need to forward traffic to a single target for a TLS listener, you
+          could choose to use a TCPRoute with a TLS listener.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TLSRoute.
+            properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of SNI names that should match against the
+                  SNI attribute of TLS ClientHello message in TLS handshake. This matches
+                  the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                  1. IPs are not allowed in SNI names per RFC 6066.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                     label must appear by itself as the first label.
+
+
+                  If a hostname is specified by both the Listener and TLSRoute, there
+                  must be at least one intersecting hostname for the TLSRoute to be
+                  attached to the Listener. For example:
+
+
+                  * A Listener with `test.example.com` as the hostname matches TLSRoutes
+                    that have either not specified any hostnames, or have specified at
+                    least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches TLSRoutes
+                    that have either not specified any hostnames or have specified at least
+                    one hostname that matches the Listener hostname. For example,
+                    `test.example.com` and `*.example.com` would both match. On the other
+                    hand, `example.com` and `test.example.net` would not match.
+
+
+                  If both the Listener and TLSRoute have specified hostnames, any
+                  TLSRoute hostnames that do not match the Listener hostname MUST be
+                  ignored. For example, if a Listener specified `*.example.com`, and the
+                  TLSRoute specified `test.example.com` and `test.example.net`,
+                  `test.example.net` must not be considered for a match.
+
+
+                  If both the Listener and TLSRoute have specified hostnames, and none
+                  match with the criteria above, then the TLSRoute is not accepted. The
+                  implementation must raise an 'Accepted' Condition with a status of
+                  `False` in the corresponding RouteParentStatus.
+
+
+                  Support: Core
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+
+                  There are two kinds of parent resources with "Core" support:
+
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+
+                  ParentRefs must be _distinct_. This means either that:
+
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+
+                  Some examples:
+
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+
+                        There are two kinds of parent resources with "Core" support:
+
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of TLS matchers and actions.
+                items:
+                  description: TLSRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a non-existent resource or
+                        a Service with no endpoints), the rule performs no forwarding; if no
+                        filters are specified that would result in a response being sent, the
+                        underlying implementation must actively reject request attempts to this
+                        backend, by rejecting the connection or returning a 500 status code.
+                        Request rejections must respect weight; if an invalid backend is
+                        requested to have 80% of requests, then 80% of requests must be rejected
+                        instead.
+
+
+                        Support: Core for Kubernetes Service
+
+
+                        Support: Extended for Kubernetes ServiceImport
+
+
+                        Support: Implementation-specific for any other resource
+
+
+                        Support for weight: Extended
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+
+                          <gateway:experimental:description>
+
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                          </gateway:experimental:description>
+
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+
+                              Defaults to "Service" when not specified.
+
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+
+                              Support: Core (Services with a type other than ExternalName)
+
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TLSRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: vpcassociationpolicies.application-networking.k8s.aws
+spec:
+  group: application-networking.k8s.aws
+  names:
+    categories:
+    - gateway-api
+    kind: VpcAssociationPolicy
+    listKind: VpcAssociationPolicyList
+    plural: vpcassociationpolicies
+    shortNames:
+    - vap
+    singular: vpcassociationpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VpcAssociationPolicySpec defines the desired state of VpcAssociationPolicy.
+            properties:
+              associateWithVpc:
+                description: "AssociateWithVpc indicates whether the VpcServiceNetworkAssociation
+                  should be created for the current VPC of k8s cluster. \n This value
+                  will be considered true by default."
+                type: boolean
+              securityGroupIds:
+                description: "SecurityGroupIds defines the security groups enforced
+                  on the VpcServiceNetworkAssociation. Security groups does not take
+                  effect if AssociateWithVpc is set to false. \n For more details,
+                  please check the VPC Lattice documentation https://docs.aws.amazon.com/vpc-lattice/latest/ug/security-groups.html"
+                items:
+                  maxLength: 32
+                  minLength: 3
+                  pattern: ^sg-[0-9a-z]+$
+                  type: string
+                minItems: 1
+                type: array
+              targetRef:
+                description: "TargetRef points to the kubernetes Gateway resource
+                  that will have this policy attached. \n This field is following
+                  the guidelines of Kubernetes Gateway API policy attachment."
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the referent. When
+                      unspecified, the local namespace is inferred. Even when policy
+                      targets a resource in a different namespace, it MUST only apply
+                      to traffic originating from the same namespace as the policy.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - targetRef
+            type: object
+          status:
+            description: VpcAssociationPolicyStatus defines the observed state of
+              VpcAssociationPolicy.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                description: "Conditions describe the current conditions of the VpcAssociationPolicy.
+                  \n Implementations should prefer to express Policy conditions using
+                  the `PolicyConditionType` and `PolicyConditionReason` constants
+                  so that operators and tools can converge on a common vocabulary
+                  to describe VpcAssociationPolicy state. \n Known condition types
+                  are: \n * \"Accepted\""
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gateway-api-controller
+  namespace: aws-application-networking-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: aws-application-networking-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - patch
+  - update
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - patch
+  - update
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - grpcroutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - grpcroutes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - grpcroutes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tlsroutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tlsroutes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tlsroutes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - serviceexports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - serviceexports/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - serviceexports/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - serviceimports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - serviceimports/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - serviceimports/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - externaldns.k8s.io
+  resources:
+  - dnsendpoints
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - targetgrouppolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - targetgrouppolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - targetgrouppolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - vpcassociationpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - vpcassociationpolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - vpcassociationpolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - accesslogpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - accesslogpolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - accesslogpolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - iamauthpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - iamauthpolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - application-networking.k8s.aws
+  resources:
+  - iamauthpolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aws-application-networking-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-application-networking-controller
+subjects:
+- kind: ServiceAccount
+  name: gateway-api-controller
+  namespace: aws-application-networking-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: proxy-role
+subjects:
+- kind: ServiceAccount
+  name: gateway-api-controller
+  namespace: aws-application-networking-system
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: 6288bc47.amazon-vpc-lattice.io
+kind: ConfigMap
+metadata:
+  name: manager-config
+---
+apiVersion: v1
+data:
+  tls.crt: Cg==
+  tls.key: Cg==
+kind: Secret
+metadata:
+  name: webhook-cert
+  namespace: aws-application-networking-system
+type: kubernetes.io/tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: gateway-api-controller
+  name: gateway-api-controller-metrics-service
+  namespace: aws-application-networking-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: gateway-api-controller
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: aws-application-networking-system
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    control-plane: gateway-api-controller
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: gateway-api-controller
+  name: gateway-api-controller
+  namespace: aws-application-networking-system
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      control-plane: gateway-api-controller
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: gateway-api-controller
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=0.0.0.0:8080
+        - --leader-elect
+        command:
+        - /manager
+        env:
+        - name: WEBHOOK_ENABLED
+          value: ""
+        image: public.ecr.aws/aws-application-networking-k8s/aws-gateway-controller:v1.0.6
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /etc/webhook-cert
+          name: webhook-cert
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: gateway-api-controller
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: webhook-cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-cert
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: aws-appnet-gwc-mutating-webhook
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: aws-application-networking-system
+      path: /mutate-pod
+  failurePolicy: Fail
+  name: mpod.gwc.k8s.aws
+  namespaceSelector:
+    matchExpressions:
+    - key: application-networking.k8s.aws/pod-readiness-gate-inject
+      operator: In
+      values:
+      - enabled
+  objectSelector:
+    matchExpressions:
+    - key: app.kubernetes.io/name
+      operator: NotIn
+      values:
+      - gateway-api-controller
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None

--- a/common/tools/gateway-api-controller/gatewayclass.yaml
+++ b/common/tools/gateway-api-controller/gatewayclass.yaml
@@ -1,0 +1,7 @@
+# Create a new Gateway Class for AWS VPC lattice provider
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: GatewayClass
+metadata:
+  name: amazon-vpc-lattice
+spec:
+  controllerName: application-networking.k8s.aws/gateway-api-controller

--- a/terraform/modules/root/aws_gateway_api_controller.tf
+++ b/terraform/modules/root/aws_gateway_api_controller.tf
@@ -1,0 +1,84 @@
+resource "aws_iam_role" "gateway_api_controller_assumerole" {
+  name               = "eks-${var.name}-gateway-api-controller"
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "${local.irsa_id}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "${local.irsa_url}:sub": "system:serviceaccount:kube-system:gateway-api-controller"
+        }
+      }
+    }
+  ]
+}
+POLICY
+}
+
+# IAM Policy
+resource "aws_iam_policy" "gateway_api_controller" {
+  name   = "eks-${var.name}-gateway-api-controller-policy"
+  policy = <<-EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "vpc-lattice:*",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeTags",
+                "ec2:DescribeSecurityGroups",
+                "logs:CreateLogDelivery",
+                "logs:GetLogDelivery",
+                "logs:DescribeLogGroups",
+                "logs:PutResourcePolicy",
+                "logs:DescribeResourcePolicies",
+                "logs:UpdateLogDelivery",
+                "logs:DeleteLogDelivery",
+                "logs:ListLogDeliveries",
+                "tag:GetResources",
+                "firehose:TagDeliveryStream",
+                "s3:GetBucketPolicy",
+                "s3:PutBucketPolicy"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect" : "Allow",
+            "Action" : "iam:CreateServiceLinkedRole",
+            "Resource" : "arn:aws:iam::*:role/aws-service-role/vpc-lattice.amazonaws.com/AWSServiceRoleForVpcLattice",
+            "Condition" : {
+                "StringLike" : {
+                    "iam:AWSServiceName" : "vpc-lattice.amazonaws.com"
+                }
+            }
+        },
+        {
+            "Effect" : "Allow",
+            "Action" : "iam:CreateServiceLinkedRole",
+            "Resource" : "arn:aws:iam::*:role/aws-service-role/delivery.logs.amazonaws.com/AWSServiceRoleForLogDelivery",
+            "Condition" : {
+                "StringLike" : {
+                    "iam:AWSServiceName" : "delivery.logs.amazonaws.com"
+                }
+            }
+        }
+    ]
+}
+
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "gateway_api_controller" {
+  policy_arn = aws_iam_policy.gateway_api_controller.arn
+  role       = aws_iam_role.gateway_api_controller_assumerole.name
+}
+


### PR DESCRIPTION
ref) https://www.gateway-api-controller.eks.aws.dev/latest/
there is no helm chart in public eks-charts repository
in order to use helm chart we need to login to ECR repository
https://www.gateway-api-controller.eks.aws.dev/latest/guides/deploy/#__tabbed_2_1

so I embedded manifests and refer those in argocd application.