### PR TITLE
update headless image to the latest feature/disable-serverGC branch commit

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -479,10 +479,6 @@ jwtHeadless:
 
   host: "9c-main-jwt.nine-chronicles.com"
 
-  image:
-    repository: planetariumhq/ninechronicles-headless
-    tag: git-f0d3519d514552ece82daec1b165b9c5a7f7aa16
-
   setupPyroscope: true
 
   headlessAppsettingsPath: "https://9c-cluster-config.s3.us-east-2.amazonaws.com/9c-main/odin/appsettings-nodeinfra.json"

--- a/9c-main/multiplanetary/network/general.yaml
+++ b/9c-main/multiplanetary/network/general.yaml
@@ -2,7 +2,7 @@ global:
   image:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
-    tag: "git-912034375407f57e2336e646d646bfbb7934e6c4"
+    tag: "git-76bfecabb5c5e501c89ba0c2bd6a4f62c2a86e47"
 
 seed:
   image:

--- a/9c-main/multiplanetary/network/general.yaml
+++ b/9c-main/multiplanetary/network/general.yaml
@@ -2,7 +2,7 @@ global:
   image:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
-    tag: "git-d6413632f3beffb703f8a0c614c927daed1cf7c4"
+    tag: "git-912034375407f57e2336e646d646bfbb7934e6c4"
 
 seed:
   image:

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -503,10 +503,6 @@ jwtHeadless:
 
   host: "heimdall-jwt.nine-chronicles.com"
 
-  image:
-    repository: planetariumhq/ninechronicles-headless
-    tag: git-f0d3519d514552ece82daec1b165b9c5a7f7aa16
-
   env:
   - name: IpRateLimiting__EnableEndpointRateLimiting
     value: "false"


### PR DESCRIPTION
~~https://github.com/planetarium/NineChronicles.Headless/commit/912034375407f57e2336e646d646bfbb7934e6c4~~

https://github.com/planetarium/NineChronicles.Headless/commit/76bfecabb5c5e501c89ba0c2bd6a4f62c2a86e47
(This commit includes the latest feature/disable-serverGC branch commit & the blockquery fix which has been causing high cpu usage in certain nodes).

This is just for jwt-headless but I put it in the general.yaml and removed the custom image tag so that we won't forget to remove it in tomorrow's release.