### PR TITLE
improve update paev action

### DIFF
--- a/.github/workflows/update-paev.yaml
+++ b/.github/workflows/update-paev.yaml
@@ -3,15 +3,20 @@ name: Update Pluggable Action Evaluator
 on:
   workflow_dispatch:
     inputs:
-      paev_url:
+      network_type:
         required: true
-        description: 'Insert the appsetting.json url to update (e.g. https://9c-cluster-config.s3.us-east-2.amazonaws.com/9c-main/odin/appsettings-test.json)'
-      end_value:
+        default: 'odin'
+        type: choice
+        options:
+        - odin
+        - heimdall
+        description: 'Choose the mainnet network to update the appsettings.json'
+      previous_version_block_index:
         required: true
         description: 'Insert the ending tip index of the previous version (e.g. 1115268)'
-      lib9c_plugin_url:
+      previous_version_lib9c_commit:
         required: true
-        description: 'Insert the lib9c plugin url of the previous version (e.g. https://9c-dx.s3.ap-northeast-2.amazonaws.com/Lib9c.Plugin/ff2c8ae6cfd030ffd20020e1a5bbc4e0caadfe97/linux-arm64.zip)'
+        description: 'Insert the lib9c commit of the previous version (e.g. ff2c8ae6cfd030ffd20020e1a5bbc4e0caadfe97)'
 
 jobs:
   update-paev:
@@ -33,7 +38,7 @@ jobs:
 
     - name: Update Pluggable Action Evaluator
       run: |
-        python cli.py update-paev ${{ github.event.inputs.paev_url }} ${{ github.event.inputs.end_value }} ${{ github.event.inputs.lib9c_plugin_url }}
+        python cli.py update-paev ${{ github.event.inputs.network_type }} ${{ github.event.inputs.previous_version_block_index }} ${{ github.event.inputs.previous_version_lib9c_commit }}
       working-directory: ./scripts
       env:
         GITHUB_TOKEN: ${{ secrets.P_GITHUB_TOKEN }}

--- a/scripts/app/update_paev.py
+++ b/scripts/app/update_paev.py
@@ -12,8 +12,41 @@ class PluggableActionEvaluatorUpdater:
             config.github_token, org="planetarium", repo="TEMP"
         )
 
-    def update(
+    def prep_update(
         self,
+        network_type,
+        previous_version_block_index,
+        previous_version_lib9c_commit):
+
+        # Define base URL and suffixes
+        base_url = "https://lib9c-plugin.s3.us-east-2.amazonaws.com/"
+        arm64_suffix = "/linux-arm64.zip"
+        x64_suffix = "/linux-x64.zip"
+
+        # Define URLs based on network type
+        if network_type == "odin":
+            paev_urls = [
+                "https://9c-cluster-config.s3.us-east-2.amazonaws.com/9c-main/odin/appsettings.json",
+                "https://9c-cluster-config.s3.us-east-2.amazonaws.com/9c-main/odin/appsettings-nodeinfra.json"
+            ]
+        else:
+            paev_urls = [
+                "https://9c-cluster-config.s3.us-east-2.amazonaws.com/9c-main/heimdall/appsettings.json",
+                "https://9c-cluster-config.s3.us-east-2.amazonaws.com/9c-main/heimdall/appsettings-nodeinfra.json"
+            ]
+
+        # Iterate over each URL in the list
+        for url in paev_urls:
+            # Choose the suffix based on the presence of "nodeinfra"
+            suffix = arm64_suffix if "nodeinfra" in url else x64_suffix
+
+            # Construct the plugin URL
+            plugin_url = f"{base_url}{previous_version_lib9c_commit}{suffix}"
+            
+            # Call update function
+            self.update(url, previous_version_block_index, plugin_url)
+
+    def update(
         paev_url,
         end_value,
         lib9c_plugin_url):

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -100,7 +100,7 @@ def update_paev(
     Run post deploy script
     """
 
-    PluggableActionEvaluatorUpdater().update(paev_url, end_value, lib9c_plugin_url)
+    PluggableActionEvaluatorUpdater().prep_update(network_type, previous_version_block_index, previous_version_lib9c_commit)
 
 if __name__ == "__main__":
     k8s_app()


### PR DESCRIPTION
### Changes
* Select network type (odin or heimdall) instead of separate appsettings.json urls.

* Input previous 9c version's lib9c commit hash instead of the entire plugin file urls.

* Example action screenshot:
![image](https://github.com/user-attachments/assets/569faca1-a444-45fa-9502-51020d6c4836)
