### PR TITLE
update 9c-internal and 9c-main configuration to latest

### DIFF
--- a/9c-internal/multiplanetary/network/9c-network.yaml
+++ b/9c-internal/multiplanetary/network/9c-network.yaml
@@ -282,6 +282,8 @@ worldBoss:
 acc:
   enabled: false
 
+  local: false
+
   redis:
     enabled: false
 

--- a/9c-internal/multiplanetary/network/heimdall-preview.yaml
+++ b/9c-internal/multiplanetary/network/heimdall-preview.yaml
@@ -292,6 +292,8 @@ testHeadless1:
 acc:
   enabled: false
 
+  local: false
+
   redis:
     enabled: false
 

--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -298,6 +298,8 @@ testHeadless1:
 acc:
   enabled: false
 
+  local: false
+
   redis:
     enabled: false
 

--- a/9c-internal/multiplanetary/network/odin-preview.yaml
+++ b/9c-internal/multiplanetary/network/odin-preview.yaml
@@ -270,6 +270,8 @@ worldBoss:
 acc:
   enabled: false
 
+  local: false
+
   redis:
     enabled: false
 

--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -45,7 +45,7 @@ ingress:
 
 snapshot:
   slackChannel: "9c-mainnet"
-  image: "planetariumhq/ninechronicles-snapshot:git-26ace851e53100001efbc7ba9282478269fde0f6"
+  image: "planetariumhq/ninechronicles-snapshot:git-96c1475107e14eeb81ed2a8fbba492952fbac99c"
   path: "main/partition"
 
   fullSnapshot:
@@ -233,7 +233,7 @@ dataProviderDataMigrator:
       cpu: '5'
       memory: 56Gi
 
-  storage: 1500Gi
+  storage: 1000Gi
 
   tolerations:
   - effect: NoSchedule
@@ -573,6 +573,8 @@ patrolRewardService:
 
 acc:
   enabled: false
+
+  local: true
 
   redis:
     enabled: false

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -44,7 +44,7 @@ ingress:
 
 snapshot:
   slackChannel: "9c-mainnet"
-  image: "planetariumhq/ninechronicles-snapshot:git-26ace851e53100001efbc7ba9282478269fde0f6"
+  image: "planetariumhq/ninechronicles-snapshot:git-96c1475107e14eeb81ed2a8fbba492952fbac99c"
   path: "main/heimdall/partition"
 
   fullSnapshot:
@@ -597,6 +597,8 @@ patrolRewardService:
 
 acc:
   enabled: false
+
+  local: true
 
   redis:
     enabled: false

--- a/charts/all-in-one/scripts/common/appsettings.json
+++ b/charts/all-in-one/scripts/common/appsettings.json
@@ -115,7 +115,7 @@
         "GraphQLPort": 31280,
         "NoCors": true,
         "Confirmations": 0,
-        {{- if .Values.acc.enabled }}
+        {{- if .Values.acc.local }}
         "AccessControlService": {
             "AccessControlServiceType": "local",
             "AccessControlServiceConnectionString": "https://9c-cluster-config.s3.us-east-2.amazonaws.com/9c-main/odin/whitelist.json"

--- a/charts/all-in-one/scripts/snapshots/full/preload_headless.sh
+++ b/charts/all-in-one/scripts/snapshots/full/preload_headless.sh
@@ -64,6 +64,7 @@ function run_headless() {
       {{- end }}
       {{- range $i, $s := $.Values.global.peerStrings }}
       --peer "$SEED{{ add $i 1 }}" \
+      --arena-participants-sync=false \
       {{- end }}
       > "$HEADLESS_LOG" 2>&1 &
 

--- a/charts/all-in-one/scripts/snapshots/partition/preload_headless.sh
+++ b/charts/all-in-one/scripts/snapshots/partition/preload_headless.sh
@@ -67,6 +67,7 @@ function run_headless() {
       --peer "$SEED{{ add $i 1 }}" \
       {{- end }}
       --network-type=Default \
+      --arena-participants-sync=false \
       > "$HEADLESS_LOG" 2>&1 &
 
   PID="$!"


### PR DESCRIPTION
- Update mainnet snapshot image
- Add local option to acc
- Adjust dp-migrator volume to 1000Gi
- Disable arena sync in snapshot preload