### PR TITLE
rename gateway routes name to avoid gateway conflict

### DIFF
--- a/charts/all-in-one/templates/gateway-route.yaml
+++ b/charts/all-in-one/templates/gateway-route.yaml
@@ -6,7 +6,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: {{ $obj.kind | default "HTTPRoute" }}
 metadata:
-  name: 9c-gateway-{{ $obj.name }}
+  name: gateway-{{ $obj.name }}-{{ $.Release.Name }}
   namespace: {{ $.Release.Name }}
 spec:
   parentRefs:


### PR DESCRIPTION
though parentRefs resolves and are accepted well, it seems nginx gateway fabric conflicts if there's multiple routes with same name in other namespaces