### PR TITLE
add spot instance type nodegroups for internal heimdall and loki

### DIFF
--- a/9c-internal/argocd/bootstrap.yaml
+++ b/9c-internal/argocd/bootstrap.yaml
@@ -36,7 +36,7 @@ spec:
         accountId: "319679068466"
         prometheus:
           server:
-            nodeGroup: 9c-internal-ondemand-r7g_l_2c
+            nodeGroup: 9c-internal-spot_2c
             extraScrapeConfigs:
               - job_name: scrape-headlesses
                 metrics_path: /metrics
@@ -103,17 +103,17 @@ spec:
           bucketName: loki-dev.planetariumhq.com
           write:
             count: 2
-            nodeGroup: 9c-internal-ondemand-r7g_l_2c
+            nodeGroup: 9c-internal-spot_2c
           read:
             count: 3
-            nodeGroup: 9c-internal-ondemand-r7g_l_2c
+            nodeGroup: 9c-internal-spot_2c
         opentelemetry:
           enabled: true
         tempo:
           enabled: true
         pyroscope:
           enabled: true
-          nodeGroup: 9c-internal-ondemand-r7g_l_2c
+          nodeGroup: 9c-internal-spot_2c
         traefik:
           enabled: true
           awsLoadBalancerSubnets: public-us-east-2c-9c-internal

--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -72,7 +72,7 @@ bridgeService:
     size: "50Gi"
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
+    eks.amazonaws.com/nodegroup: heimdall-spot_2c
 
   account:
     type: "kms"
@@ -121,7 +121,7 @@ dataProvider:
     password: ""
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: heimdall-internal-r7g_l_2c
+    eks.amazonaws.com/nodegroup: heimdall-spot_2c
 
 marketService:
   enabled: true
@@ -131,7 +131,7 @@ marketService:
     size: 1Gi
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
+    eks.amazonaws.com/nodegroup: heimdall-spot_2c
 
   env:
   - name: DOTNET_gcServer
@@ -145,7 +145,7 @@ patrolRewardService:
   enabled: true
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
+    eks.amazonaws.com/nodegroup: heimdall-spot_2c
 
   db:
     local: true
@@ -165,7 +165,7 @@ remoteHeadless:
   - "heimdall-internal-rpc-1.nine-chronicles.com"
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: heimdall-internal-r7g_l_2c
+    eks.amazonaws.com/nodegroup: heimdall-spot_2c
 
   loggingEnabled: true
 
@@ -204,7 +204,7 @@ seed:
   - "heimdall-internal-tcp-seed-1.nine-chronicles.com"
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
+    eks.amazonaws.com/nodegroup: heimdall-spot_2c
 
 snapshot:
   partition:
@@ -222,7 +222,7 @@ snapshot:
       memory: 10Gi
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: heimdall-internal-r7g_l_2c
+    eks.amazonaws.com/nodegroup: heimdall-spot_2c
 
 validator:
   count: 1
@@ -234,7 +234,7 @@ validator:
   - "heimdall-internal-validator-1.nine-chronicles.com"
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: heimdall-internal-r7g_l_2c
+    eks.amazonaws.com/nodegroup: heimdall-spot_2c
 
   resources:
     requests:
@@ -268,7 +268,7 @@ worldBoss:
     slackSigningSecret: ""
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
+    eks.amazonaws.com/nodegroup: heimdall-spot_2c
 
 testHeadless1:
   enabled: false
@@ -290,7 +290,7 @@ testHeadless1:
       memory: 12Gi
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-ondemand-r7g_l_2c
+    eks.amazonaws.com/nodegroup: heimdall-spot_2c
 
   loggingEnabled: true
 
@@ -306,7 +306,7 @@ acc:
     enabled: false
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-t3_medium
+    eks.amazonaws.com/nodegroup: heimdall-spot_2c
 
   env:
   - name: AccessControlServiceType
@@ -318,14 +318,14 @@ stateMigrationService:
   enabled: false
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
+    eks.amazonaws.com/nodegroup: heimdall-spot_2c
 
 arenaService:
   enabled: true
   rwMode: false
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-internal-m5_xl_2c_ondemand
+    eks.amazonaws.com/nodegroup: heimdall-spot_2c
 
   env:
     - name: Worker

--- a/terraform/environments/internal/main.tf
+++ b/terraform/environments/internal/main.tf
@@ -152,6 +152,26 @@ node_groups = {
       max_size          = 1
     }
 
+    "heimdall-spot_2c" = {
+      instance_types    = ["r7g.large", "r6g.large", "m8g.xlarge", "m7g.xlarge", "m6g.xlarge"]
+      availability_zone = "us-east-2c"
+      capacity_type     = "SPOT"
+      desired_size      = 1
+      min_size          = 0
+      max_size          = 15
+      ami_type          = "AL2_ARM_64"
+    }
+
+    "9c-internal-spot_2c" = {
+      instance_types    = ["r7g.large", "r6g.large", "m8g.xlarge", "m7g.xlarge", "m6g.xlarge"]
+      availability_zone = "us-east-2c"
+      capacity_type     = "SPOT"
+      desired_size      = 1
+      min_size          = 0
+      max_size          = 15
+      ami_type          = "AL2_ARM_64"
+    }
+
     "heimdall-preview-r7g_l_2c" = {
       instance_types    = ["r7g.large"]
       availability_zone = "us-east-2c"


### PR DESCRIPTION
loki will use `9c-internal-spot_2c` and heimdall will use `heimdall-spot_2c`.