### PR TITLE
Use custom planets registry & Prepare thor-internal bridge

### DIFF
--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -23,7 +23,7 @@ bridgeService:
   image:
     repository: planetariumhq/9c-bridge
     pullPolicy: Always
-    tag: "git-1dc31e89b46eb590470efd181f9c339701057528"
+    tag: "git-0085c1e9e7d62b89ccb6d3a3cb83a4e9d89d7775"
 
 bridgeServiceApi:
   image:

--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -55,7 +55,7 @@ bridgeService:
   enabled: true
 
   multiplanetary:
-    registryEndpoint: "https://planets-internal.nine-chronicles.com/planets/"
+    registryEndpoint: "https://9c-dx.s3.ap-northeast-2.amazonaws.com/planets-internal.json"
     upstream: "0x100000000000"
     downstream: "0x100000000001"
 

--- a/9c-internal/multiplanetary/network/thor.yaml
+++ b/9c-internal/multiplanetary/network/thor.yaml
@@ -52,15 +52,15 @@ gateway:
       hostname: thor-internal-arena.9c.gg
 
 bridgeService:
-  enabled: false
+  enabled: true
 
   multiplanetary:
-    registryEndpoint: "https://planets-internal.nine-chronicles.com/planets/"
+    registryEndpoint: "https://9c-dx.s3.ap-northeast-2.amazonaws.com/planets-internal.json"
     upstream: "0x100000000000"
     downstream: "0x100000000003"
 
   serviceAccount:
-    roleArn: "arn:aws:iam::319679068466:role/9c-internal-v2-bridge-service"
+    roleArn: "arn:aws:iam::319679068466:role/9c-internal-v2-relay-bridge-odin-thor"
 
   storage:
     size: "10Gi"
@@ -70,8 +70,8 @@ bridgeService:
 
   account:
     type: "kms"
-    keyId: "7b912d9b-b682-4403-a794-2d6421d108c9"
-    publicKey: "04ab9e31a20d8dbf5042bfc26ce9d9ed9a0e32ad787a1e5aa3ae8188fa5143861535acc7132cd8e74d4c1f0b94f843575e3add6988d3ccb1f54d7c59fb9535d789"
+    keyId: "178553bb-ca39-4959-8e08-ec48a562a887"
+    publicKey: "047cfee101490623b3efae7062b7c915f467c8e996636dffb1696b51e2ae368c0ab096af7e2d4bc98561ee6dabe112d4804da352e310fe016f5b793d9241ba501b"
 
   txpool:
     type: "local"
@@ -89,8 +89,8 @@ bridgeService:
   rdb:
     enabled: true
     defaultStartBlockIndex:
-      upstream: "11902092"
-      downstream: "3415778"
+      upstream: "12190936"
+      downstream: "11755"
 
 bridgeServiceApi:
   enabled: false


### PR DESCRIPTION
I guess internal services cannot use headless without HTTPS (TLS) since https://github.com/planetarium/9c-infra/commit/af40f85c06c807cb3b5254cdd7498b0bfc68a013 commit.

So I make 9c-relay-bridge bypass with my custom planets registry. I updated `headless.gql` part's protocol scheme.