### PR TITLE
Bump bridge-service (hotfix)

### DIFF
--- a/9c-internal/multiplanetary/network/general.yaml
+++ b/9c-internal/multiplanetary/network/general.yaml
@@ -23,7 +23,7 @@ bridgeService:
   image:
     repository: planetariumhq/9c-bridge
     pullPolicy: Always
-    tag: "git-0085c1e9e7d62b89ccb6d3a3cb83a4e9d89d7775"
+    tag: "git-0f30871bdbc1765388e80b2f64f5a92400592c14"
 
 bridgeServiceApi:
   image:

--- a/9c-main/multiplanetary/network/general.yaml
+++ b/9c-main/multiplanetary/network/general.yaml
@@ -59,7 +59,7 @@ bridgeService:
   image:
     repository: planetariumhq/9c-bridge
     pullPolicy: Always
-    tag: "git-d3e909e8856ae3b417061a9b50c6992152361395"
+    tag: "git-0f30871bdbc1765388e80b2f64f5a92400592c14"
 
 bridgeServiceApi:
   image:


### PR DESCRIPTION
Now, there is a bug where downstream (e.g., heimdall, thor) to transfer non-NCG assets to upstream (i.e., odin). This pull request bumps bridge-service's image with fixed version.