### PR TITLE
Use `npx` instead of `yarn`

### DIFF
--- a/charts/all-in-one/templates/bridge-service.yaml
+++ b/charts/all-in-one/templates/bridge-service.yaml
@@ -36,7 +36,7 @@ spec:
         - migrate
         - deploy
         command:
-        - /usr/local/bin/yarn
+        - /usr/local/bin/npx
         image: {{ $.Values.bridgeService.image.repository }}:{{ $.Values.bridgeService.image.tag }}
         name: run-prisma-migrate-deploy
         env:


### PR DESCRIPTION
To use `yarn` command, it requires running `corepack enable` first. But `yarn` is not necessary to run `prisma` package. So I replaced it with `npx`.