### PR TITLE
update heimdall fullstate nodegroup

### DIFF
--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -170,7 +170,7 @@ fullState:
     value: remote-headless-test
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: heimdall-m7g_2xl_2c_test
+    eks.amazonaws.com/nodegroup: heimdall-2c_spot
 
 validator:
   count: 1


### PR DESCRIPTION
heimdall's jwt is running fine with `heimdall-2c_spot` so I think full-state will also be fine with the same nodegroup.