### PR TITLE
update odin snapshot and dp-migrator to use spot instance

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -80,7 +80,7 @@ snapshot:
       memory: 28Gi
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-main-r7g_xl_2c
+    eks.amazonaws.com/nodegroup: 9c-main-spot-xl_2c
 
   storage: 1000Gi
 
@@ -241,7 +241,7 @@ dataProviderDataMigrator:
   enabled: true
 
   nodeSelector:
-    eks.amazonaws.com/nodegroup: 9c-main-r7g_2xl_2c_dp
+    eks.amazonaws.com/nodegroup: 9c-main-spot-xl_2c
 
   resources:
     requests:

--- a/terraform/environments/main/main.tf
+++ b/terraform/environments/main/main.tf
@@ -116,22 +116,6 @@ module "common" {
       }]
     }
 
-    "9c-main-r7g_2xl_2c_dp" = {
-      instance_types    = ["r7g.2xlarge"]
-      availability_zone = "us-east-2c"
-      capacity_type     = "ON_DEMAND"
-      desired_size      = 0
-      min_size          = 0
-      max_size          = 10
-      ami_type          = "AL2_ARM_64"
-      disk_size         = 50
-      taints = [{
-        key    = "dedicated"
-        value  = "remote-headless-test"
-        effect = "NO_SCHEDULE"
-      }]
-    }
-
     "9c-main-r7g_2xl_2c" = {
       instance_types    = ["r7g.2xlarge"]
       availability_zone = "us-east-2c"
@@ -484,6 +468,16 @@ module "common" {
   
     "9c-main-spot_2c" = {
       instance_types    = ["r7g.large", "r6g.large", "m8g.xlarge", "m7g.xlarge", "m6g.xlarge"]
+      availability_zone = "us-east-2c"
+      capacity_type     = "SPOT"
+      desired_size      = 0
+      min_size          = 0
+      max_size          = 15
+      ami_type          = "AL2_ARM_64"
+    }
+
+    "9c-main-spot-xl_2c" = {
+      instance_types    = ["r7g.xlarge", "r6g.xlarge", "m7g.2xlarge", "m6g.2xlarge"]
       availability_zone = "us-east-2c"
       capacity_type     = "SPOT"
       desired_size      = 0


### PR DESCRIPTION
Created `9c-main-spot-xl_2c` for services that need `32gb` ram.