### PR TITLE
Use custom dns override for bridge-service

### DIFF
--- a/charts/all-in-one/templates/bridge-service.yaml
+++ b/charts/all-in-one/templates/bridge-service.yaml
@@ -145,6 +145,15 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: bridge-service-data
+          dnsPolicy: ClusterFirst
+          dnsConfig:
+            nameservers:
+            - 1.1.1.1
+            - 8.8.8.8
+            searches:
+            - nine-chronicles.com
+            options:
+            - ndots: 3
       {{- with $.Values.bridgeService.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Context

This pull request makes the `bridge-service` pod use Google and Cloudflare DNS when resolving `*.nine-chronicles.com` domains. Because it resolves `*.nine-chronicles.com` as the internal domain of the Kubernetes cluster via CoreDNS, it cannot access it as HTTPS. It makes me update custom `planets.json` (planet registry) for every update to `planets.json`. It takes too many times from me, so I made the bridge service communicate `*.nine-chronicles.com` as external traffic.

## References

 - https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
 - https://manned.org/resolv.conf.5