### PR TITLE
clean up full snapshot directory to prevent files from stacking

### DIFF
--- a/charts/all-in-one/scripts/snapshots/full/upload_snapshot.sh
+++ b/charts/all-in-one/scripts/snapshots/full/upload_snapshot.sh
@@ -47,6 +47,8 @@ function make_and_upload_snapshot() {
     echo "URL does not exist: $URL"
   fi
 
+  rm -r "$FULL_DIR/*"
+
   if ! "$SNAPSHOT" --output-directory "$OUTPUT_DIR" --store-path "$STORE_PATH" --block-before 0 --apv "$1" --snapshot-type "full"; then
     senderr "Snapshot creation failed." "$SLACK_WEBHOOK"
     exit 1


### PR DESCRIPTION
Sometimes snapshot files aren't properly cleaned up after the upload and this has been causing the volume to be filled up, causing the new file creation to be corrupted. This clean up code just before the snapshot command ensures that there are no staked up files in the directory. 