### PR TITLE
Continue jobs to reset bridge-service even if some jobs failed

### DIFF
--- a/.github/workflows/snapshot-reset.yaml
+++ b/.github/workflows/snapshot-reset.yaml
@@ -74,6 +74,7 @@ jobs:
   reset-bridge-service:
     needs: [reset-snapshot, set-targets]
     strategy:
+      fail-fast: false
       matrix:
         bridge_chain: ${{ fromJson(needs.set-targets.outputs.bridge_chains) }}
     uses: ./.github/workflows/reset-bridge-service.yaml

--- a/.github/workflows/snapshot-reset.yaml
+++ b/.github/workflows/snapshot-reset.yaml
@@ -75,7 +75,7 @@ jobs:
     needs: [reset-snapshot, set-targets]
     strategy:
       matrix:
-        bridge_chains: ${{ fromJson(needs.set-targets.outputs.bridge_chains) }}
+        bridge_chain: ${{ fromJson(needs.set-targets.outputs.bridge_chains) }}
     uses: ./.github/workflows/reset-bridge-service.yaml
     with:
-      network: ${{ matrix.bridge_chains }}
+      network: ${{ matrix.bridge_chain }}


### PR DESCRIPTION
## Reference

- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast