### PR TITLE
[9c-dev cluster] Arena service test infra

### DIFF
--- a/9c-dev/arena-service-test-20241218/application.yaml
+++ b/9c-dev/arena-service-test-20241218/application.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: arena-service-test-20241218
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/planetarium/9c-infra.git
+    targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: arena-service-test-20241218

--- a/9c-dev/arena-service-test-20241218/application.yaml
+++ b/9c-dev/arena-service-test-20241218/application.yaml
@@ -8,6 +8,7 @@ spec:
   source:
     repoURL: https://github.com/planetarium/9c-infra.git
     targetRevision: main
+    path: 9c-dev/arena-service-test-20241218
   destination:
     server: https://kubernetes.default.svc
     namespace: arena-service-test-20241218

--- a/9c-dev/arena-service-test-20241218/arena-service-deployment.yaml
+++ b/9c-dev/arena-service-test-20241218/arena-service-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: arena-service
-          image: planetariumhq/arena-service:latest
+          image: planetariumhq/arena-service:git-eb849c21d287be4ffefd276264fc53a2391dee7f
           ports:
             - containerPort: 80
           env:

--- a/9c-dev/arena-service-test-20241218/arena-service-deployment.yaml
+++ b/9c-dev/arena-service-test-20241218/arena-service-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: arena-service
+    app.kubernetes.io/instance: arena-service-test-20241218
+  name: arena-service-deployment
+  namespace: arena-service-test-20241218
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: arena-service
+  template:
+    metadata:
+      labels:
+        app: arena-service
+    spec:
+      containers:
+        - name: arena-service
+          image: planetariumhq/arena-service:latest
+          ports:
+            - containerPort: 80
+          env:
+            - name: ConnectionStrings__DefaultConnection
+              value: "Host=psql-service;Database=arena;Username=testuser;Password=$(POSTGRES_PASSWORD)"
+            - name: Logging__LogLevel__Default
+              value: "Information"
+            - name: Logging__LogLevel__Microsoft.AspNetCore
+              value: "Warning"
+            - name: AllowedHosts
+              value: "*"
+          envFrom:
+            - secretRef:
+                name: arena-service-secret

--- a/9c-dev/arena-service-test-20241218/arena-service-secret.yaml
+++ b/9c-dev/arena-service-test-20241218/arena-service-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: arena-service
+    app.kubernetes.io/instance: arena-service-test-20241218
+  name: arena-service-secret
+  namespace: arena-service-test-20241218
+type: Opaque
+stringData: {}

--- a/9c-dev/arena-service-test-20241218/arena-service-service.yaml
+++ b/9c-dev/arena-service-test-20241218/arena-service-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: arena-service
+    app.kubernetes.io/instance: arena-service-test-20241218
+  name: arena-service-service
+  namespace: arena-service-test-20241218
+spec:
+  type: ClusterIP
+  selector:
+    app: arena-service
+  ports:
+    - port: 80
+      targetPort: 80

--- a/9c-dev/arena-service-test-20241218/arena-service-service.yaml
+++ b/9c-dev/arena-service-test-20241218/arena-service-service.yaml
@@ -6,8 +6,12 @@ metadata:
     app.kubernetes.io/instance: arena-service-test-20241218
   name: arena-service-service
   namespace: arena-service-test-20241218
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: stickiness.enabled=true,stickiness.type=source_ip,preserve_client_ip.enabled=true
+    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: Environment=development,Team=game,Owner=jiwon,Service=arena-service-test-20241218,Name=arena-service
 spec:
-  type: ClusterIP
+  externalTrafficPolicy: Local
+  type: LoadBalancer
   selector:
     app: arena-service
   ports:

--- a/9c-dev/arena-service-test-20241218/psql-deployment.yaml
+++ b/9c-dev/arena-service-test-20241218/psql-deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: psql
+    app.kubernetes.io/instance: arena-service-test-20241218
+  name: psql-deployment
+  namespace: arena-service-test-20241218
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: psql
+  template:
+    metadata:
+      labels:
+        app: psql
+    spec:
+      containers:
+        - name: psql
+          image: postgres:15
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: "arena"
+            - name: POSTGRES_USER
+              value: "testuser"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: arena-service-secret
+                  key: POSTGRES_PASSWORD
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: psql-data
+      volumes:
+        - name: psql-data
+          emptyDir: {}

--- a/9c-dev/arena-service-test-20241218/psql-service.yaml
+++ b/9c-dev/arena-service-test-20241218/psql-service.yaml
@@ -6,10 +6,14 @@ metadata:
     app.kubernetes.io/instance: arena-service-test-20241218
   name: psql-service
   namespace: arena-service-test-20241218
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: stickiness.enabled=true,stickiness.type=source_ip,preserve_client_ip.enabled=true
+    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: Environment=development,Team=game,Owner=jiwon,Service=arena-service-test-20241218,Name=psql
 spec:
+  externalTrafficPolicy: Local
   ports:
     - port: 5432
       targetPort: 5432
   selector:
     app: psql
-  type: ClusterIP
+  type: LoadBalancer

--- a/9c-dev/arena-service-test-20241218/psql-service.yaml
+++ b/9c-dev/arena-service-test-20241218/psql-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: psql
+    app.kubernetes.io/instance: arena-service-test-20241218
+  name: psql-service
+  namespace: arena-service-test-20241218
+spec:
+  ports:
+    - port: 5432
+      targetPort: 5432
+  selector:
+    app: psql
+  type: ClusterIP


### PR DESCRIPTION
I'm setting up infrastructure for the new arena service under the folder `arena-service-test-20241218`.
For now, a simple PostgreSQL setup has been configured (to be migrated to RDS later) along with a basic REST API, deployed as a standalone service.

In the future, we’ll also need to configure a headless. 

This setup is intended for use until early January.