### PR TITLE
feat: introduce `libplanet-remote-kv` container

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -425,6 +425,9 @@ testHeadless1:
 
   loggingEnabled: true
 
+  remoteKv: 
+    port: 5000
+
   datadog:
     enabled: true
 

--- a/9c-main/multiplanetary/network/general.yaml
+++ b/9c-main/multiplanetary/network/general.yaml
@@ -3,6 +3,11 @@ global:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
     tag: "git-25d383fc0d2cc75a7e262329b6587c2bd40bd6d1"
+  
+  remoteKv:
+    image:
+      repository: planetariumhq/libplanet-remote-kv
+      tag: "git-3a20dd33221894be5764e38a0024a29ecb1a023b"
 
   service:
     annotations:

--- a/charts/all-in-one/templates/service.yaml
+++ b/charts/all-in-one/templates/service.yaml
@@ -269,6 +269,9 @@ spec:
   - name: https
     port: 443
     targetPort: {{ $.Values.testHeadless1.ports.graphql }}
+  - name: libplanet-remote-kv-rpc
+    port: {{ $.Values.testHeadless1.remoteKv.port }}
+    targetPort: {{ $.Values.testHeadless.remoteKv.port }}
   selector:
     app: test-headless-1
   type: LoadBalancer

--- a/charts/all-in-one/templates/test-headless-1.yaml
+++ b/charts/all-in-one/templates/test-headless-1.yaml
@@ -282,6 +282,44 @@ spec:
         {{- with $.Values.testHeadless1.env }}
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      - args:
+        - Libplanet.Store.Remote.Executable.dll
+        - /data/headless/states
+        command:
+        - dotnet
+        image: {{ $.Values.testHeadless1.remoteKv.image.repository | default $.Values.global.remoteKv.image.repository }}:{{ $.Values.testHeadless1.remoteKv.image.tag | default $.Values.global.remoteKv.image.tag }}
+        imagePullPolicy: Always
+        name: test-headless-1-remote-kv
+        ports:
+        - containerPort: {{ $.Values.testHeadless1.remoteKv.port }}
+          name: rpc
+          protocol: TCP
+        resources:
+          {{- toYaml $.Values.testHeadless1.remoteKv.resources | nindent 10 }}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /data
+          name: test-headless-data-1
+        {{- if $.Values.testHeadless1.loggingEnabled }}
+        - mountPath: /app/logs
+          name: json-log
+        {{- end }}
+        env:
+          - name: ASPNETCORE_URLS
+            value: http://*:{{ $.Values.testHeadless1.remoteKv.port }}/
+          {{- if $.Values.testHeadless1.loggingEnabled }}
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: NAMESPACE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: JSON_LOG_PATH
+            value: ./logs/$(POD_NAME)_$(NAMESPACE_NAME)_test-headless-1.json
+          {{- end }}
       {{- with $.Values.testHeadless1.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
# Overview

NineChronicles.Headless.Executable provides a gRPC API to access the state key-value store. And it is an API that provides both read-write. However, in the general case, we don't want to open up the nodes that compute and provide the actual state to arbitrary writes, so this needs to be addressed.

Also, the reason for using the above functionality is primarily to utilize the `replay remote-tx` feature. For the aforementioned security reasons, we need to take the Pod down and put it back up again with an option like `--remote-key-value-store` to turn it on when we need it, even if we don't normally turn it on.

This is very inconvenient, so I created the `Libplanet.Store.Remote.Executable` project as an alternative. It provides the same gRPC interface as NineChronicles.Headless.Executable, and utilizes the RocksDB Secondary feature to follow the `<store-path>/states` at no extra cost, and writes are prevented (since we don't support writes in Secondary mode).

Since this is an experimental feature, we only added the value to test-headless-1. This can be controlled by `.Values.testHeadless1.remoteKv.image` or `.Values.global.remoteKv.image`.

The Kubernetes manifest may not work well yet, but we're testing and fixing it as we go.

## References

https://github.com/planetarium/Libplanet.Store.Remote.Executable