### PR TITLE
fix: correct broken chart

### DIFF
--- a/charts/all-in-one/templates/service.yaml
+++ b/charts/all-in-one/templates/service.yaml
@@ -271,7 +271,7 @@ spec:
     targetPort: {{ $.Values.testHeadless1.ports.graphql }}
   - name: libplanet-remote-kv-rpc
     port: {{ $.Values.testHeadless1.remoteKv.port }}
-    targetPort: {{ $.Values.testHeadless.remoteKv.port }}
+    targetPort: {{ $.Values.testHeadless1.remoteKv.port }}
   selector:
     app: test-headless-1
   type: LoadBalancer

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -386,6 +386,12 @@ testHeadless1:
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
+  remoteKv:
+    image:
+      repository: ""
+      tag: ""
+    port: 5000
+
   loggingEnabled: false
   datadog:
     enabled: false


### PR DESCRIPTION
I tested with the following command:

```
helm template name ./charts/all-in-one --values ./charts/all-in-one/values.yaml --values ./9c-main/multiplanetary/network/general.yaml --values ./9c-main/multiplanetary/network/9c-network.yaml
```

- Setup default value in `values.yaml`
- Fix typo (`.testHeadless.` → `.testHeadless1`)