### PR TITLE
feat(remote-kv): support http only port

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -425,8 +425,10 @@ testHeadless1:
 
   loggingEnabled: true
 
-  remoteKv:
-    port: 5000
+  remoteKv: 
+    ports:
+      rpc: 5000
+      http: 5001
 
   datadog:
     enabled: true

--- a/9c-main/multiplanetary/network/general.yaml
+++ b/9c-main/multiplanetary/network/general.yaml
@@ -6,7 +6,7 @@ global:
   remoteKv:
     image:
       repository: planetariumhq/libplanet-remote-kv
-      tag: "git-2031acb93249abb275c89f5019a34b22f303a74a"
+      tag: "git-b44d0dc23391aa45f354e57cc28f75bd130d9e70"
 
   service:
     annotations:

--- a/charts/all-in-one/templates/service.yaml
+++ b/charts/all-in-one/templates/service.yaml
@@ -270,8 +270,11 @@ spec:
     port: 443
     targetPort: {{ $.Values.testHeadless1.ports.graphql }}
   - name: libplanet-remote-kv-rpc
-    port: {{ $.Values.testHeadless1.remoteKv.port }}
-    targetPort: {{ $.Values.testHeadless1.remoteKv.port }}
+    port: {{ $.Values.testHeadless1.remoteKv.ports.rpc }}
+    targetPort: {{ $.Values.testHeadless1.remoteKv.ports.rpc }}
+  - name: libplanet-remote-kv-http
+    port: {{ $.Values.testHeadless1.remoteKv.ports.http }}
+    targetPort: {{ $.Values.testHeadless1.remoteKv.ports.http }}
   selector:
     app: test-headless-1
   type: LoadBalancer

--- a/charts/all-in-one/templates/test-headless-1.yaml
+++ b/charts/all-in-one/templates/test-headless-1.yaml
@@ -287,14 +287,19 @@ spec:
         - /data/headless/states
         - --port
         - "{{ $.Values.testHeadless1.remoteKv.port }}"
+        - --http-port
+        - "{{ $.Values.testHeadless1.remoteKv.port }}"
         command:
         - dotnet
         image: {{ $.Values.testHeadless1.remoteKv.image.repository | default $.Values.global.remoteKv.image.repository }}:{{ $.Values.testHeadless1.remoteKv.image.tag | default $.Values.global.remoteKv.image.tag }}
         imagePullPolicy: Always
         name: test-headless-1-remote-kv
         ports:
-        - containerPort: {{ $.Values.testHeadless1.remoteKv.port }}
+        - containerPort: {{ $.Values.testHeadless1.remoteKv.ports.rpc }}
           name: rpc
+          protocol: TCP
+        - containerPort: {{ $.Values.testHeadless1.remoteKv.ports.http }}
+          name: http
           protocol: TCP
         resources:
           {{- toYaml $.Values.testHeadless1.remoteKv.resources | nindent 10 }}

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -390,7 +390,9 @@ testHeadless1:
     image:
       repository: ""
       tag: ""
-    port: 5000
+    ports:
+      rpc: 5000
+      http: 5001
 
   loggingEnabled: false
   datadog:


### PR DESCRIPTION
Since https://github.com/planetarium/Libplanet.Store.Remote.Executable/commit/b44d0dc23391aa45f354e57cc28f75bd130d9e70, it becomes to open two independent ports, HTTP/1 only port and HTTP/2 only port, to make able to access `/metrics` endpoint.