### PR TITLE
fix(remote-kv): apply changed variable path

### DIFF
--- a/charts/all-in-one/templates/test-headless-1.yaml
+++ b/charts/all-in-one/templates/test-headless-1.yaml
@@ -286,9 +286,9 @@ spec:
         - Libplanet.Store.Remote.Executable.dll
         - /data/headless/states
         - --port
-        - "{{ $.Values.testHeadless1.remoteKv.port }}"
+        - "{{ $.Values.testHeadless1.remoteKv.ports.rpc }}"
         - --http-port
-        - "{{ $.Values.testHeadless1.remoteKv.port }}"
+        - "{{ $.Values.testHeadless1.remoteKv.ports.http }}"
         command:
         - dotnet
         image: {{ $.Values.testHeadless1.remoteKv.image.repository | default $.Values.global.remoteKv.image.repository }}:{{ $.Values.testHeadless1.remoteKv.image.tag | default $.Values.global.remoteKv.image.tag }}


### PR DESCRIPTION
In #2275, I renamed `testHeadless.remoteKv.port` to `testHeadless.remoteKv.ports.rpc` but I didn't apply it in container spec well. This pull request corrects it.