### PR TITLE
Ignore common ELB subnet settings for rudolf-service

### DIFF
--- a/charts/all-in-one/templates/rudolf-service.yaml
+++ b/charts/all-in-one/templates/rudolf-service.yaml
@@ -80,6 +80,7 @@ metadata:
   annotations:
     {{- with (deepCopy $.Values.global.service.annotations) }}
       {{ $_ := unset . "service.beta.kubernetes.io/aws-load-balancer-scheme" }}
+      {{ $_ := unset . "service.beta.kubernetes.io/aws-load-balancer-subnets" }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- if .Values.rudolfService.service.public }}


### PR DESCRIPTION
At https://github.com/planetarium/9c-infra/commit/0e985486976bad499a07d2fddbb2e6cae9c55943#diff-a65dda7a55ea98aefdd1a76bd61775cfc18146cad657380c24b04cf81bb9dd53 commit, rudolf-service becomes to use common ELB annotations excluding `.../aws-load-balancer-scheme` annotation. Because there was an operation issue related with rudolf-service, I let the service exclude `service.beta.kubernetes.io/aws-load-balancer-subnets` annotation too.