### PR TITLE
Disable patrol reward service on internal network

### DIFF
--- a/9c-internal/multiplanetary/network/9c-network.yaml
+++ b/9c-internal/multiplanetary/network/9c-network.yaml
@@ -215,7 +215,7 @@ marketService:
     value: "true"
 
 patrolRewardService:
-  enabled: true
+  enabled: false
 
   nodeSelector:
     eks.amazonaws.com/nodegroup: odin-spot_2c

--- a/9c-internal/multiplanetary/network/heimdall.yaml
+++ b/9c-internal/multiplanetary/network/heimdall.yaml
@@ -145,7 +145,7 @@ marketService:
     value: "true"
 
 patrolRewardService:
-  enabled: true
+  enabled: false
 
   nodeSelector:
     eks.amazonaws.com/nodegroup: heimdall-spot_2c

--- a/9c-internal/multiplanetary/network/thor.yaml
+++ b/9c-internal/multiplanetary/network/thor.yaml
@@ -149,7 +149,7 @@ marketService:
     value: "true"
 
 patrolRewardService:
-  enabled: true
+  enabled: false
 
   nodeSelector:
     eks.amazonaws.com/nodegroup: thor-spot_2c


### PR DESCRIPTION
- https://github.com/planetarium/lib9c/pull/3088 의 적용으로 patrol-reward-service 의존성이 사라집니다. 인터널에서 우선적으로 비활성화하고 메인넷 배포시에 해당 파일을 정리하겠습니다.