### PR TITLE
토르 아레나 서비스 이미지 업데이트

### DIFF
--- a/9c-main/multiplanetary/network/thor.yaml
+++ b/9c-main/multiplanetary/network/thor.yaml
@@ -549,7 +549,7 @@ rudolfCurrencyNotifier:
 
 arenaService:
   image:
-    tag: "git-9ae74c7d4ad52829497ffa338bd9c4ddfc310563"
+    tag: "git-27c23f90a6fe3f859b078838e64c77afe34b80ab"
 
   enabled: true
   rwMode: true


### PR DESCRIPTION
- 블록렌더대신 직접 GetTip을 호출하는 이미지 적용 https://github.com/planetarium/ArenaService/pull/65/commits/27c23f90a6fe3f859b078838e64c77afe34b80ab