### PR TITLE
Feat/add terraform gcp

### DIFF
--- a/terraform-gcp-test/auth.tf
+++ b/terraform-gcp-test/auth.tf
@@ -1,0 +1,20 @@
+# auth.tf
+# GKE 클러스터에 대한 인증을 구성한다.
+
+module "gke_auth" {
+  source               = "terraform-google-modules/kubernetes-engine/google//modules/auth"
+  version              = "35.0.1"
+  project_id           = var.project_id
+  location             = module.gke.location
+  cluster_name         = module.gke.name
+  use_private_endpoint = true
+  depends_on           = [module.gke] 
+  # module.gke에 의존한다. 즉 gke에 설정된 클러스터가 생성된 후 인증 정보가 설정된다.
+}
+
+# kubeconfig를 로컬 시스템에 저장하여, 쿠버네티스 클러스터에 접근할 수 있도록 한다.
+
+resource "local_file" "kubeconfig" {
+  content  = module.gke_auth.kubeconfig_raw
+  filename = "kubeconfig-${var.env_name}"
+}

--- a/terraform-gcp-test/gcs.sh
+++ b/terraform-gcp-test/gcs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+BUCKET_NAME="k8s-standard-bucket-tfstate-1"
+PROJECT_ID="devops-test-445104"
+LOCATION="ASIA-NORTHEAST3"
+
+# GCS 버킷 생성
+
+if gsutil ls -p $PROJECT_ID gs://$BUCKET_NAME 2>&1 | grep -q 'NotFound'; then
+    echo "Creating bucket $BUCKET_NAME"
+    gsutil mb -p $PROJECT_ID -l $LOCATION gs://$BUCKET_NAME
+    gsutil versioning set on gs://$BUCKET_NAME
+else
+    echo "Bucket $BUCKET_NAME already exists."
+fi

--- a/terraform-gcp-test/main.tf
+++ b/terraform-gcp-test/main.tf
@@ -1,0 +1,108 @@
+# main.tf
+# GKE 클러스터와, 별도로 관리되는 노드 풀을 생성한다.
+data "google_client_config" "default" {}
+
+provider "kubernetes" {
+  host                   = "https://${module.gke.endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(module.gke.ca_certificate)
+}
+
+resource "google_service_account" "default" {
+  # google_service_account 리소스의 account_id에는 서비스 계정의
+  # 전체 이메일 주소가 아니라 고유 ID 부분만 포함해야 한다.
+  account_id   = "k8s-standard-architecture"
+  project      = var.project_id
+  display_name = "K8s Standard Architecture Service Account"
+  description  = "Service account for K8s standard architecture"
+}
+
+module "gke" {
+  source                     = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
+  version                    = "35.0.1"
+  project_id                 = var.project_id
+  name                       = var.cluster_name
+  region                     = var.region
+  zones                      = var.zones
+  network                    = module.vpc.network_name
+  subnetwork                 = module.vpc.subnets_names[0]
+  ip_range_pods              = var.ip_range_pods_name
+  ip_range_services          = var.ip_range_services_name
+  http_load_balancing        = true
+  network_policy             = true
+  horizontal_pod_autoscaling = true
+  filestore_csi_driver       = false
+  enable_private_endpoint    = false
+  enable_private_nodes       = true
+  master_ipv4_cidr_block     = "10.0.0.0/28"
+  deletion_protection        = false 
+  # Terraform 등 다른 방법으로 클러스터가 삭제되는 것을 허용하지 않는다면 true로 설정
+
+  node_pools = [
+    {
+      name            = "default-node-pool"
+      machine_type    = "e2-standard-4"
+      node_locations  = "asia-northeast3-b,asia-northeast3-c"
+      min_count       = 2
+      max_count       = 5
+      disk_size_gb    = 30
+      spot            = false
+      image_type      = "COS_CONTAINERD"
+      disk_type       = "pd-standard"
+      logging_variant = "DEFAULT"
+      auto_repair     = true
+      auto_upgrade    = true
+      service_account = "k8s-standard-architecture@${var.project_id}.iam.gserviceaccount.com"
+    }
+  ]
+
+  node_pools_oauth_scopes = {
+    all = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/trace.append",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/servicecontrol"
+    ]
+  }
+
+  node_pools_labels = {
+    all = {}
+    default-node-pool = {
+      default-node-pool = true
+    }
+  }
+
+  node_pools_metadata = {
+    all = {}
+    default-node-pool = {
+      #노드가 종료될 때, kubectl drain 명령어를 사용하여 
+      # 파드를 안전하게 제거하고 필요하다면 다른 노드로 재스케줄링 되도록 하는 스크립트를 실행한다.
+      shutdown-script                 = "kubectl --kubeconfig=/var/lib/kubelet/kubeconfig drain --force=true --ignore-daemonsets=true --delete-local-data \"$HOSTNAME\""
+      node-pool-metadata-custom-value = "default-node-pool"
+    }
+  }
+
+  node_pools_taints = {
+    all = []
+
+    default-node-pool = [
+      {
+        key    = "default-node-pool"
+        value  = true
+        effect = "PREFER_NO_SCHEDULE"
+      }
+    ]
+  }
+
+  node_pools_tags = {
+    all = []
+
+    default-node-pool = [
+      "default-node-pool",
+    ]
+  }
+
+  depends_on = [module.vpc, google_service_account.default]
+}

--- a/terraform-gcp-test/output.tf
+++ b/terraform-gcp-test/output.tf
@@ -1,0 +1,99 @@
+# output.tf
+# 리소스에서 생성된 데이터를 출력하는데 사용된다. output을 사용하면 원하는 정보를 개발환경에서도 바로 확인할 수 있다.
+
+output "cluster_id" {
+  description = "cluster id"
+  value       = module.gke.cluster_id
+}
+
+output "cluster_name" {
+  description = "cluster name"
+  value       = module.gke.name
+}
+
+output "ca_certificate" {
+  sensitive   = true
+  description = "Cluster ca certificate (base64 encoded)"
+  value       = module.gke.ca_certificate
+}
+
+output "cluster_type" {
+  description = "cluster type (regional / zonal)"
+  value       = module.gke.type
+}
+
+output "cluster_location" {
+  description = "Cluster location (region if regional cluster, zone if zonal cluster)"
+  value       = module.gke.location
+}
+
+output "horizontal_pod_autoscaling_enabled" {
+  description = "Whether horizontal pod autoscaling enabled"
+  value       = module.gke.horizontal_pod_autoscaling_enabled
+}
+
+output "http_load_balancing_enabled" {
+  description = "Whether http load balancing enabled"
+  value       = module.gke.http_load_balancing_enabled
+}
+
+output "master_authorized_networks_config" {
+  description = "Networks from which access to master is permitted"
+  value       = module.gke.master_authorized_networks_config
+}
+
+output "cluster_region" {
+  description = "Cluster region"
+  value       = module.gke.region
+}
+
+output "cluster_zones" {
+  description = "List of zones in which the cluster resides"
+  value       = module.gke.zones
+}
+
+output "cluster_endpoint" {
+  sensitive   = true
+  description = "Cluster endpoint"
+  value       = module.gke.endpoint
+}
+
+output "min_master_version" {
+  description = "Minimum master kubernetes version"
+  value       = module.gke.min_master_version
+}
+
+output "logging_service" {
+  description = "Logging service used"
+  value       = module.gke.logging_service
+}
+
+output "monitoring_service" {
+  description = "Monitoring service used"
+  value       = module.gke.monitoring_service
+}
+
+output "master_version" {
+  description = "Current master kubernetes version"
+  value       = module.gke.master_version
+}
+
+output "network_policy_enabled" {
+  description = "Whether network policy enabled"
+  value       = module.gke.network_policy_enabled
+}
+
+output "node_pools_names" {
+  description = "List of node pools names"
+  value       = module.gke.node_pools_names
+}
+
+output "node_pools_versions" {
+  description = "Node pool versions by node pool name"
+  value       = module.gke.node_pools_versions
+}
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in node_pools."
+  value       = module.gke.service_account
+}

--- a/terraform-gcp-test/providers.tf
+++ b/terraform-gcp-test/providers.tf
@@ -1,0 +1,26 @@
+# providers.tf
+terraform {
+  # provider 파일을 통해 Terraform은 클라우드 공급자, SaaS 공급자 및 기타 API와 상호작용할 수 있다. 
+  # Terraform이 프로젝트에서 사용할 특정 프로바이더와 그들의 버전을 정의하여, 구성의 일관성과 호환성을 보장한다.
+
+  required_version = ">= 1.7" # 최소 Terraform 버전을 1.6.0 이상으로 지정
+  required_providers {
+    google = {
+      source  = "hashicorp/google" # Google 프로바이더의 출처를 HashiCorp 레지스트리에서 "hashicorp/google"으로 지정
+      version = "6.17.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.4.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.24.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "k8s-standard-bucket-tfstate-1"
+    prefix = "terraform/state"
+  }
+}

--- a/terraform-gcp-test/terraform.tfvars
+++ b/terraform-gcp-test/terraform.tfvars
@@ -1,0 +1,6 @@
+# terraform.tfvars
+project_id   = "devops-test-445104"
+cluster_name = "k8s-standard-architecture"
+region       = "asia-northeast3"
+
+# variables.tf 파일에 정의된 변수에 값을 주입한다. 보통 Variables = Value 형태로 정의한다.

--- a/terraform-gcp-test/variables.tf
+++ b/terraform-gcp-test/variables.tf
@@ -1,0 +1,72 @@
+# variables.tf
+# 변수를 정의한다.
+
+# Common variables
+
+variable "project_id" {
+  type        = string
+  description = "project id"
+  default     = ""
+
+  validation {
+    condition     = length(var.project_id) > 0
+    error_message = "The project_id must not be empty."
+  }
+}
+
+variable "region" {
+  type        = string
+  description = "cluster region"
+  default     = ""
+
+  validation {
+    condition     = can(regex("^asia-northeast3", var.region))
+    error_message = "The region must start with 'asia-northeast3'."
+  }
+}
+
+variable "env_name" {
+  type        = string
+  description = "The environment for the GKE cluster"
+  default     = "dev"
+}
+
+# Cluster variables
+
+
+variable "cluster_name" {
+  type        = string
+  description = "name of cluster"
+  default     = ""
+}
+
+variable "network" {
+  type        = string
+  description = "The VPC network"
+  default     = "gke-network"
+}
+
+variable "zones" {
+  type        = list(string)
+  description = "to host cluster in"
+  default     = ["asia-northeast3-a", "asia-northeast3-b", "asia-northeast3-c"]
+
+  validation {
+    condition     = length(var.zones) > 0
+    error_message = "At least one zone must be specified."
+  }
+}
+
+variable "ip_range_pods_name" {
+  type        = string
+  description = "The secondary ip ranges for pods"
+  default     = "subnet-01-pods"
+}
+
+variable "ip_range_services_name" {
+  type        = string
+  description = "The secondary ip ranges for services"
+  default     = "subnet-01-services"
+}
+
+# 변수를 정의한다. 정의한 변수에 값을 주입하기 위해서는 terraform.tfvars 파일을 이용한다.

--- a/terraform-gcp-test/vpc-network.tf
+++ b/terraform-gcp-test/vpc-network.tf
@@ -1,0 +1,32 @@
+# vpc-network.tf
+# VPC와 서브넷을 프로비저닝한다.
+module "vpc" {
+  source       = "terraform-google-modules/network/google"
+  version      = "10.0.0"
+  project_id   = var.project_id
+  network_name = "${var.network}-${var.env_name}"
+  routing_mode = "GLOBAL"
+  subnets = [
+    {
+      subnet_name           = "subnet-01"
+      subnet_ip             = "10.10.20.0/24"
+      subnet_region         = var.region
+      subnet_private_access = "true"
+      subnet_flow_logs      = true
+      description           = "For private subnet"
+    }
+  ]
+  # 클러스터 내부의 Pods와 Services에 IP 주소를 할당하기 위한 추가적인 IP 범위
+  secondary_ranges = {
+    subnet-01 = [
+      {
+        range_name    = var.ip_range_pods_name
+        ip_cidr_range = "10.20.0.0/16"
+      },
+      {
+        range_name    = var.ip_range_services_name
+        ip_cidr_range = "10.21.0.0/16"
+      }
+    ]
+  }
+}

--- a/terraform-gcp/environments/k8s-standard-architecture/backend.tf
+++ b/terraform-gcp/environments/k8s-standard-architecture/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "gcs" {
+    bucket = "k8s-standard-bucket-tfstate-1"
+    # Use a unique prefix so this environment's state doesn't clash with others
+    prefix = "terraform/state/k8s-standard-architecture"
+  }
+}

--- a/terraform-gcp/environments/k8s-standard-architecture/main.tf
+++ b/terraform-gcp/environments/k8s-standard-architecture/main.tf
@@ -1,0 +1,28 @@
+module "vpc" {
+  source = "../../modules/vpc"
+
+  project_id               = var.project_id
+  env_name                 = var.env_name
+  network                  = var.network
+  subnet_ip                = var.subnet_ip
+  region                   = var.region
+  ip_range_pods_name       = var.ip_range_pods_name
+  ip_range_services_name   = var.ip_range_services_name
+}
+
+module "gke" {
+  source = "../../modules/gke"
+
+  project_id             = var.project_id
+  cluster_name           = var.cluster_name
+  region                 = var.region
+  zones                  = var.zones
+  network_name           = module.vpc.network_name
+  subnet_name            = module.vpc.subnets_names[0]
+  ip_range_pods_name     = var.ip_range_pods_name
+  ip_range_services_name = var.ip_range_services_name
+
+  node_machine_type = var.node_machine_type
+  node_min_count    = var.node_min_count
+  node_max_count    = var.node_max_count
+}

--- a/terraform-gcp/environments/k8s-standard-architecture/providers.tf
+++ b/terraform-gcp/environments/k8s-standard-architecture/providers.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.17.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.24.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "2.4.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+}

--- a/terraform-gcp/environments/k8s-standard-architecture/terraform.tfvars
+++ b/terraform-gcp/environments/k8s-standard-architecture/terraform.tfvars
@@ -1,0 +1,12 @@
+project_id               = "devops-test-445104"
+env_name                 = "dev"
+network                  = "gke-network"
+subnet_ip                = "10.10.20.0/24"
+cluster_name             = "k8s-standard-architecture"
+region                   = "asia-northeast3"
+zones                    = ["asia-northeast3-a", "asia-northeast3-b", "asia-northeast3-c"]
+ip_range_pods_name       = "subnet-01-pods"
+ip_range_services_name   = "subnet-01-services"
+node_machine_type        = "e2-standard-4"
+node_min_count           = 2
+node_max_count           = 5

--- a/terraform-gcp/environments/k8s-standard-architecture/variables.tf
+++ b/terraform-gcp/environments/k8s-standard-architecture/variables.tf
@@ -1,0 +1,58 @@
+variable "project_id" {
+  type = string
+}
+
+variable "env_name" {
+  type    = string
+  default = "dev"
+}
+
+variable "network" {
+  type    = string
+  default = "gke-network"
+}
+
+variable "subnet_ip" {
+  type    = string
+  default = "10.10.20.0/24"
+}
+
+variable "cluster_name" {
+  type    = string
+  default = "k8s-standard-architecture"
+}
+
+variable "region" {
+  type    = string
+  default = "asia-northeast3"
+}
+
+variable "zones" {
+  type    = list(string)
+  default = ["asia-northeast3-a", "asia-northeast3-b", "asia-northeast3-c"]
+}
+
+variable "ip_range_pods_name" {
+  type    = string
+  default = "subnet-01-pods"
+}
+
+variable "ip_range_services_name" {
+  type    = string
+  default = "subnet-01-services"
+}
+
+variable "node_machine_type" {
+  type    = string
+  default = "e2-standard-4"
+}
+
+variable "node_min_count" {
+  type    = number
+  default = 2
+}
+
+variable "node_max_count" {
+  type    = number
+  default = 5
+}

--- a/terraform-gcp/modules/gke/auth.tf
+++ b/terraform-gcp/modules/gke/auth.tf
@@ -1,0 +1,14 @@
+module "gke_auth" {
+  source               = "terraform-google-modules/kubernetes-engine/google//modules/auth"
+  version              = "35.0.1"
+  project_id           = var.project_id
+  location             = var.region
+  cluster_name         = var.cluster_name
+  use_private_endpoint = true
+  depends_on           = [module.cluster]
+}
+
+resource "local_file" "kubeconfig" {
+  content  = module.gke_auth.kubeconfig_raw
+  filename = "kubeconfig-${var.cluster_name}"
+}

--- a/terraform-gcp/modules/gke/main.tf
+++ b/terraform-gcp/modules/gke/main.tf
@@ -1,0 +1,97 @@
+# Create a service account for the nodes
+resource "google_service_account" "default" {
+  account_id   = "k8s-standard-architecture"
+  project      = var.project_id
+  display_name = "K8s Standard Architecture Service Account"
+  description  = "Service account for K8s standard architecture"
+}
+
+# Create a private GKE cluster
+module "cluster" {
+  source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
+  version = "35.0.1"
+
+  project_id                 = var.project_id
+  name                       = var.cluster_name
+  region                     = var.region
+  zones                      = var.zones
+  network                    = var.network_name
+  subnetwork                 = var.subnet_name
+  ip_range_pods              = var.ip_range_pods_name
+  ip_range_services          = var.ip_range_services_name
+  http_load_balancing        = true
+  network_policy             = true
+  horizontal_pod_autoscaling = true
+  filestore_csi_driver       = false
+
+  enable_private_endpoint = false
+  enable_private_nodes    = true
+  master_ipv4_cidr_block  = "10.0.0.0/28"
+
+  deletion_protection = false
+
+  node_pools = [
+    {
+      name            = "default-node-pool"
+      machine_type    = var.node_machine_type
+      node_locations  = join(",", var.zones)
+      min_count       = var.node_min_count
+      max_count       = var.node_max_count
+      disk_size_gb    = 30
+      spot            = false
+      image_type      = "COS_CONTAINERD"
+      disk_type       = "pd-standard"
+      logging_variant = "DEFAULT"
+      auto_repair     = true
+      auto_upgrade    = true
+      service_account = "k8s-standard-architecture@${var.project_id}.iam.gserviceaccount.com"
+    }
+  ]
+
+  node_pools_oauth_scopes = {
+    all = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/trace.append",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/servicecontrol"
+    ]
+  }
+
+  node_pools_labels = {
+    all = {}
+    default-node-pool = {
+      default-node-pool = true
+    }
+  }
+
+  node_pools_metadata = {
+    all = {}
+    default-node-pool = {
+      # When the node shuts down, automatically drain Pods
+      shutdown-script                 = "kubectl --kubeconfig=/var/lib/kubelet/kubeconfig drain --force=true --ignore-daemonsets=true --delete-local-data \"$HOSTNAME\""
+      node-pool-metadata-custom-value = "default-node-pool"
+    }
+  }
+
+  node_pools_taints = {
+    all = []
+    default-node-pool = [
+      {
+        key    = "default-node-pool"
+        value  = true
+        effect = "PREFER_NO_SCHEDULE"
+      }
+    ]
+  }
+
+  node_pools_tags = {
+    all = []
+    default-node-pool = [
+      "default-node-pool",
+    ]
+  }
+
+  depends_on = [google_service_account.default]
+}

--- a/terraform-gcp/modules/gke/outputs.tf
+++ b/terraform-gcp/modules/gke/outputs.tf
@@ -1,0 +1,16 @@
+output "cluster_endpoint" {
+  description = "Cluster endpoint"
+  value       = module.cluster.endpoint
+  sensitive   = true
+}
+
+output "cluster_ca_certificate" {
+  description = "Cluster CA certificate"
+  value       = module.cluster.ca_certificate
+  sensitive   = true
+}
+
+output "cluster_name" {
+  description = "Cluster name"
+  value       = module.cluster.name
+}

--- a/terraform-gcp/modules/gke/variables.tf
+++ b/terraform-gcp/modules/gke/variables.tf
@@ -1,0 +1,49 @@
+variable "project_id" {
+  type = string
+}
+
+variable "cluster_name" {
+  type    = string
+  default = "k8s-standard-architecture"
+}
+
+variable "region" {
+  type    = string
+  default = "asia-northeast3"
+}
+
+variable "zones" {
+  type    = list(string)
+  default = ["asia-northeast3-a", "asia-northeast3-b", "asia-northeast3-c"]
+}
+
+variable "network_name" {
+  type = string
+}
+
+variable "subnet_name" {
+  type = string
+}
+
+variable "ip_range_pods_name" {
+  type = string
+}
+
+variable "ip_range_services_name" {
+  type = string
+}
+
+variable "node_machine_type" {
+  type    = string
+  default = "e2-standard-4"
+}
+
+variable "node_min_count" {
+  type    = number
+  default = 2
+}
+
+variable "node_max_count" {
+  type    = number
+  default = 5
+}

--- a/terraform-gcp/modules/vpc/main.tf
+++ b/terraform-gcp/modules/vpc/main.tf
@@ -1,0 +1,33 @@
+module "vpc" {
+  source  = "terraform-google-modules/network/google"
+  version = "10.0.0"
+
+  project_id   = var.project_id
+  network_name = "${var.network}-${var.env_name}"
+  routing_mode = "GLOBAL"
+
+  subnets = [
+    {
+      subnet_name           = "subnet-01"
+      subnet_ip             = var.subnet_ip
+      subnet_region         = var.region
+      subnet_private_access = "true"
+      subnet_flow_logs      = true
+      description           = "For private subnet"
+    }
+  ]
+
+  # Secondary ranges for Pods and Services
+  secondary_ranges = {
+    subnet-01 = [
+      {
+        range_name    = var.ip_range_pods_name
+        ip_cidr_range = "10.20.0.0/16"
+      },
+      {
+        range_name    = var.ip_range_services_name
+        ip_cidr_range = "10.21.0.0/16"
+      }
+    ]
+  }
+}

--- a/terraform-gcp/modules/vpc/outputs.tf
+++ b/terraform-gcp/modules/vpc/outputs.tf
@@ -1,0 +1,9 @@
+output "network_name" {
+  description = "VPC name"
+  value       = module.vpc.network_name
+}
+
+output "subnets_names" {
+  description = "List of subnets"
+  value       = module.vpc.subnets_names
+}

--- a/terraform-gcp/modules/vpc/variables.tf
+++ b/terraform-gcp/modules/vpc/variables.tf
@@ -1,0 +1,33 @@
+variable "project_id" {
+  type = string
+}
+
+variable "env_name" {
+  type    = string
+  default = "dev"
+}
+
+variable "network" {
+  type    = string
+  default = "gke-network"
+}
+
+variable "subnet_ip" {
+  type    = string
+  default = "10.10.20.0/24"
+}
+
+variable "region" {
+  type    = string
+  default = "asia-northeast3"
+}
+
+variable "ip_range_pods_name" {
+  type    = string
+  default = "subnet-01-pods"
+}
+
+variable "ip_range_services_name" {
+  type    = string
+  default = "subnet-01-services"
+}


### PR DESCRIPTION
* terraform-gcp-test dir is a standalone configuration for a single cluster formation.
* terraform-gcp dir is a scaled out version so that multiple clusters can be added to the environment dir.