### PR TITLE
fix validate-planets.js to allowMatchingProperties

### DIFF
--- a/.github/scripts/validate-planets.js
+++ b/.github/scripts/validate-planets.js
@@ -8,7 +8,7 @@ const baseUrl =
 const fetchJsonSchema = async (name) =>
   await (await fetch(path.join(baseUrl, `/${name}.schema.json`))).json();
 
-const ajv = new Ajv2019({ allErrors: true });
+const ajv = new Ajv2019({ allErrors: true, allowMatchingProperties: true });
 addFormats(ajv);
 
 ajv.addSchema(await fetchJsonSchema("PlanetSpec"), "PlanetSpec.schema.json");


### PR DESCRIPTION
```Error: strict mode: property headless.gql matches pattern .+.(gql|rest) (use allowMatchingProperties)```
arose due to schema update in https://github.com/planetarium/9c-infra/pull/2377
