### PR TITLE
add volume-preloader

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -730,3 +730,41 @@ seasonpass:
   enabled: true
   serviceAccount:
     roleArn: "arn:aws:iam::319679068466:role/9c-main-v2-seasonpass-tracker"
+
+volumePreloader:
+  count: 0
+  replicas: 1
+
+  useTurnServer: true
+
+  env:
+  - name: Headless__AccessControlService__AccessControlServiceType
+    value: "local"
+  - name: Headless__AccessControlService__AccessControlServiceConnectionString
+    value: "https://9c-cluster-config.s3.us-east-2.amazonaws.com/9c-main/odin/whitelist.json"
+  - name: PLUGIN_PATH
+    value: "/data"
+  - name: DOTNET_gcServer
+    value: "1"
+
+  extraArgs:
+  - --tx-quota-per-signer=1
+
+  nodeSelector:
+    eks.amazonaws.com/nodegroup: 9c-main-r7g_xl_2c
+
+  resources:
+    requests:
+      cpu: '5'
+      memory: 25Gi
+
+  storage:
+    volumeNames:
+    - "volume-preloader-0"
+    - "volume-preloader-1"
+
+  tolerations:
+  - effect: NoSchedule
+    key: dedicated
+    operator: Equal
+    value: remote-headless-test

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -723,3 +723,39 @@ seasonpass:
   enabled: true
   serviceAccount:
     roleArn: "arn:aws:iam::319679068466:role/9c-main-v2-seasonpass-tracker"
+
+volumePreloader:
+  count: 0
+  replicas: 1
+
+  useTurnServer: true
+
+  env:
+  - name: Headless__AccessControlService__AccessControlServiceType
+    value: "local"
+  - name: Headless__AccessControlService__AccessControlServiceConnectionString
+    value: "https://9c-cluster-config.s3.us-east-2.amazonaws.com/9c-main/odin/whitelist.json"
+  - name: PLUGIN_PATH
+    value: "/data"
+  - name: DOTNET_gcServer
+    value: "1"
+
+  extraArgs:
+  - --tx-quota-per-signer=1
+
+  nodeSelector:
+    eks.amazonaws.com/nodegroup: heimdall-r7g_xl_2c_test
+
+  resources:
+    requests:
+      cpu: '3'
+      memory: 25Gi
+
+  storage:
+    data: 300Gi
+
+  tolerations:
+  - effect: NoSchedule
+    key: dedicated
+    operator: Equal
+    value: remote-headless-test

--- a/9c-main/multiplanetary/network/heimdall.yaml
+++ b/9c-main/multiplanetary/network/heimdall.yaml
@@ -749,7 +749,7 @@ volumePreloader:
   resources:
     requests:
       cpu: '3'
-      memory: 25Gi
+      memory: 20Gi
 
   storage:
     data: 300Gi

--- a/9c-main/multiplanetary/network/thor.yaml
+++ b/9c-main/multiplanetary/network/thor.yaml
@@ -26,7 +26,7 @@ global:
   planet: Thor
   consensusType: pbft
 
-  resetSnapshot: false
+  resetSnapshot: true
   rollbackSnapshot: false
 
 externalSecret:
@@ -600,10 +600,12 @@ volumePreloader:
   resources:
     requests:
       cpu: '3'
-      memory: 25Gi
+      memory: 20Gi
 
   storage:
     data: 100Gi
+    volumeNames:
+    - "volume-preloader-0"
 
   tolerations:
   - effect: NoSchedule

--- a/9c-main/multiplanetary/network/thor.yaml
+++ b/9c-main/multiplanetary/network/thor.yaml
@@ -574,3 +574,39 @@ seasonpass:
   enabled: true
   serviceAccount:
     roleArn: "arn:aws:iam::319679068466:role/9c-main-v2-seasonpass-tracker"
+
+volumePreloader:
+  count: 0
+  replicas: 1
+
+  useTurnServer: true
+
+  env:
+  - name: Headless__AccessControlService__AccessControlServiceType
+    value: "local"
+  - name: Headless__AccessControlService__AccessControlServiceConnectionString
+    value: "https://9c-cluster-config.s3.us-east-2.amazonaws.com/9c-main/odin/whitelist.json"
+  - name: PLUGIN_PATH
+    value: "/data"
+  - name: DOTNET_gcServer
+    value: "1"
+
+  extraArgs:
+  - --tx-quota-per-signer=1
+
+  nodeSelector:
+    eks.amazonaws.com/nodegroup: thor-r7g_xl_2c_test
+
+  resources:
+    requests:
+      cpu: '3'
+      memory: 25Gi
+
+  storage:
+    data: 100Gi
+
+  tolerations:
+  - effect: NoSchedule
+    key: dedicated
+    operator: Equal
+    value: remote-headless-test

--- a/charts/all-in-one/templates/volume-preloader.yaml
+++ b/charts/all-in-one/templates/volume-preloader.yaml
@@ -1,0 +1,258 @@
+{{- range $idx := until (int .Values.volumePreloader.count) }}
+{{- $index := add $idx 1 }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: volume-preloader-{{ $index }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+  name: volume-preloader-{{ $index }}
+  namespace: {{ $.Release.Name }}
+spec:
+  podManagementPolicy: OrderedReady
+  {{- if $.Values.volumePreloader.replicas }}
+  replicas: {{ $.Values.volumePreloader.replicas }}
+  {{- else }}
+  replicas: 1
+  {{- end }}
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: volume-preloader-{{ $index }}
+  serviceName: volume-preloader-{{ $index }}
+  template:
+    metadata:
+      labels:
+        app: volume-preloader-{{ $index }}
+      annotations:
+        prometheus.io/port: '80'
+        prometheus.io/scrape: 'true'
+      name: volume-preloader-{{ $index }}
+    spec:
+      initContainers:
+        {{- if $.Values.global.resetSnapshot }}
+        - args:
+          - 'https://snapshots.nine-chronicles.com/{{ $.Values.snapshot.path }}'  
+          - /data/headless
+          - $(RESET_SNAPSHOT_OPTION)
+          - volume-preloader-{{ $index }}
+          - $(SLACK_WEBHOOK_URL)
+          - $(SNAPSHOT_ROLLBACK_OPTION)
+          command:
+          - /bin/download_snapshot.sh
+          env:
+          - name: RESET_SNAPSHOT_OPTION  
+            value: "{{ $.Values.global.resetSnapshot }}"
+          - name: SNAPSHOT_ROLLBACK_OPTION
+            value: "{{ $.Values.global.rollbackSnapshot }}"
+          - name: SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                key: slack-webhook-url
+                name: slack
+          {{- if and $.Values.volumePreloader.image.repository $.Values.volumePreloader.image.tag }}
+          image: {{ $.Values.volumePreloader.image.repository }}:{{ $.Values.volumePreloader.image.tag }}
+          {{- else }}
+          image: {{ $.Values.global.image.repository }}:{{ $.Values.global.image.tag }}
+          {{- end }}
+          imagePullPolicy: Always
+          name: reset-snapshot
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /bin/download_snapshot.sh
+            name: download-snapshot-script
+            readOnly: true
+            subPath: download_snapshot.sh
+          - mountPath: /data
+            name: volume-preloader-data-{{ $index }}
+        {{- end }}
+        - command:
+          - sh
+          - '-c'
+          - >
+            apk --no-cache add curl
+
+            # Endpoint to check
+
+            SEED="http://{{ regexFind "^[^,]+" (toString (index $.Values.seed.hosts 0)) }}:{{ $.Values.seed.ports.graphql }}/playground.html"
+
+            echo Checking: ${SEED}
+
+            while [[ $(curl --silent --output /dev/null --request GET
+            --write-out "%{http_code}" ${SEED}) -ne 200 ]]; do
+              echo "Not ready"
+              sleep 5s
+            done
+
+            VALIDATOR="{{ $.Values.global.validatorPath }}/ui/playground"
+
+            echo Checking: ${VALIDATOR}
+
+            while [[ $(curl --silent --output /dev/null --request GET
+            --write-out "%{http_code}" ${VALIDATOR}) -ne 200 ]]; do
+              echo "Not ready"
+              sleep 5s
+            done
+
+            echo Ready
+          image: alpine
+          imagePullPolicy: Always
+          name: wait
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      containers:
+      - args:
+        - NineChronicles.Headless.Executable.dll
+        - run
+        - --app-protocol-version={{ $.Values.global.appProtocolVersion }}
+        - --trusted-app-protocol-version-signer={{ $.Values.global.trustedAppProtocolVersionSigner }}
+        - --genesis-block-path={{ $.Values.global.genesisBlockPath }}
+        - --port={{ $.Values.volumePreloader.ports.headless }}
+        - --no-miner
+        - --store-type=rocksdb
+        - --store-path=/data/headless
+        {{- if $.Values.volumePreloader.useTurnServer }}
+        {{- range $.Values.global.iceServers }}
+        - --ice-server={{ . }}
+        {{- end }}
+        {{- else }}
+        - --host={{ regexFind "^[^,]+" (toString (index $.Values.volumePreloader.hosts $idx)) }}
+        {{- end }}
+        {{- range $.Values.global.peerStrings }}
+        - --peer={{ . }}
+        {{- end }}
+        - --graphql-server
+        - --graphql-host=0.0.0.0
+        - --graphql-port={{ $.Values.volumePreloader.ports.graphql }}
+        - --rpc-server
+        - --rpc-remote-server
+        - --rpc-listen-host=0.0.0.0
+        - --rpc-listen-port={{ $.Values.volumePreloader.ports.rpc }}
+        - --no-cors
+        - --chain-tip-stale-behavior-type=reboot
+        - --tx-life-time=10
+        - --planet={{ $.Values.global.planet }}
+        {{- if $.Values.global.headlessAppsettingsPath }}
+        - --config={{ $.Values.global.headlessAppsettingsPath }}
+        {{- end }}
+        {{- with $.Values.volumePreloader.extraArgs }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        command:
+        - dotnet
+        {{- if and $.Values.volumePreloader.image.repository $.Values.volumePreloader.image.tag }}
+        image: {{ $.Values.volumePreloader.image.repository }}:{{ $.Values.volumePreloader.image.tag }}
+        {{- else }}
+        image: {{ $.Values.global.image.repository }}:{{ $.Values.global.image.tag }}
+        {{- end }}
+        imagePullPolicy: Always
+        name: volume-preloader-{{ $index }}
+        ports:
+        - containerPort: {{ $.Values.volumePreloader.ports.graphql }}
+          name: graphql
+          protocol: TCP
+        - containerPort: {{ $.Values.volumePreloader.ports.headless }}
+          name: headless
+          protocol: TCP
+        - containerPort: {{ $.Values.volumePreloader.ports.rpc }}
+          name: rpc
+          protocol: TCP
+        livenessProbe:
+          exec:
+            command:
+            {{- if eq $.Values.global.networkType "Main"  }}
+            - /bin/liveness_probe.sh
+            {{- else }}
+            - /bin/liveness_probe.sh
+            {{- end }}
+          failureThreshold: 5
+          initialDelaySeconds: 1800
+          periodSeconds: 60
+          timeoutSeconds: 60
+        readinessProbe:
+          exec:
+            command:
+            - /bin/readiness_probe.sh
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 10
+        resources:
+          {{- toYaml $.Values.volumePreloader.resources | nindent 10 }}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /data
+          name: volume-preloader-data-{{ $index }}
+        - mountPath: /bin/liveness_probe.sh
+          name: probe-script
+          readOnly: true
+          subPath: liveness_probe.sh
+        - mountPath: /bin/readiness_probe.sh
+          name: probe-script
+          readOnly: true
+          subPath: readiness_probe.sh
+        - mountPath: /app/appsettings.configmap.json
+          name: appsettings
+          subPath: appsettings.json
+        env:
+        {{- with $.Values.volumePreloader.env }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with $.Values.volumePreloader.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.volumePreloader.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 448
+          name: {{ $.Release.Name }}-probe-script
+        name: probe-script
+      - name: download-snapshot-script
+        configMap:
+          defaultMode: 0700
+          name: {{ $.Release.Name }}-download-snapshot-script
+      {{- if $.Values.volumePreloader.loggingEnabled }}
+      - hostPath:
+          path: /var/log/headless
+          type: DirectoryOrCreate
+        name: json-log
+      {{- end }}
+      - name: appsettings
+        configMap:
+          defaultMode: 0700
+          name: appsettings
+      {{- if and $.Values.volumePreloader.storage.volumeNames (gt (len $.Values.volumePreloader.storage.volumeNames) $idx) (ne (index $.Values.volumePreloader.storage.volumeNames $idx) "") }}
+      - name: volume-preloader-data-{{ $index }}
+        persistentVolumeClaim:
+          claimName: {{ index $.Values.volumePreloader.storage.volumeNames $idx }}
+      {{- else }}
+  volumeClaimTemplates:
+  - metadata:
+      name: volume-preloader-data-{{ $index }}
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ $.Values.volumePreloader.storage.data }}
+      {{- if eq $.Values.provider "AWS" }}
+      storageClassName: {{ $.Release.Name }}-gp3
+      {{- end }}
+      volumeMode: Filesystem
+      {{- end }}
+  updateStrategy:
+    type: RollingUpdate
+
+---
+{{- end }}

--- a/charts/all-in-one/templates/volume-preloader.yaml
+++ b/charts/all-in-one/templates/volume-preloader.yaml
@@ -222,12 +222,6 @@ spec:
         configMap:
           defaultMode: 0700
           name: {{ $.Release.Name }}-download-snapshot-script
-      {{- if $.Values.volumePreloader.loggingEnabled }}
-      - hostPath:
-          path: /var/log/headless
-          type: DirectoryOrCreate
-        name: json-log
-      {{- end }}
       - name: appsettings
         configMap:
           defaultMode: 0700
@@ -255,4 +249,29 @@ spec:
     type: RollingUpdate
 
 ---
+
+{{- if and $.Values.volumePreloader.storage.volumeNames (gt (len $.Values.volumePreloader.storage.volumeNames) $idx) (ne (index $.Values.volumePreloader.storage.volumeNames $idx) "") }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ index $.Values.volumePreloader.storage.volumeNames $idx }}
+  namespace: {{ $.Release.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+  annotations:
+    volume.beta.kubernetes.io/storage-provisioner: ebs.csi.aws.com
+    volume.kubernetes.io/storage-provisioner: ebs.csi.aws.com
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ $.Values.volumePreloader.storage.data }}
+  {{- if eq $.Values.provider "AWS" }}
+  storageClassName: {{ $.Release.Name }}-gp3
+  {{- end }}
+  volumeMode: Filesystem
+
+---
+{{- end }}
 {{- end }}

--- a/charts/all-in-one/templates/volume-preloader.yaml
+++ b/charts/all-in-one/templates/volume-preloader.yaml
@@ -201,6 +201,46 @@ spec:
         {{- with $.Values.volumePreloader.env }}
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      - name: preload-checker
+        image: alpine
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -e
+            GRAPHQL_URL="http://localhost:80/graphql"
+            INSTANCE_NAME="volume-preloader-{{ $index }}"
+
+            echo "Starting preload checker for $INSTANCE_NAME..."
+
+            while true; do
+              preloaded="$(curl -s -H 'Content-Type: application/json' --data '{"query":"query{nodeStatus{preloadEnded}}"}' $GRAPHQL_URL | jq .data.nodeStatus.preloadEnded)"
+
+              if [[ "$preloaded" == "true" ]]; then
+                echo "Preloading complete for $INSTANCE_NAME. Sending notification..."
+
+                curl -X POST -H 'Content-type: application/json' --data "{\"text\": \"@devops-team Preloading for $INSTANCE_NAME is complete\"}" $SLACK_WEBHOOK_URL
+
+                echo "Notification sent. Exiting..."
+                exit 0
+              fi
+
+              echo "Preloading not complete yet. Retrying in 10 seconds..."
+              sleep 10
+            done
+        imagePullPolicy: Always
+        env:
+          - name: SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                name: slack
+                key: slack-webhook-url
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "64Mi"
+          limits:
+            cpu: "100m"
+            memory: "128Mi"
       {{- with $.Values.volumePreloader.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -801,3 +801,36 @@ seasonpass:
     arenaServiceJwtPublicKey: ""
   serviceAccount:
     roleArn: ""
+
+volumePreloader:
+  count: 0
+  image:
+    # follow global imaged
+    repository: ""
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+    pullPolicy: Always
+
+  # dotnet args
+
+  extraArgs: []
+  # - --key=val
+
+  useTurnServer: true
+
+  ports:
+    headless: 31234
+    graphql: 80
+    rpc: 31238
+
+  storage:
+    data: 1000Gi
+
+  resources:
+    requests:
+      cpu: 2
+      memory: 20Gi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}


### PR DESCRIPTION
volume-preloader downloads snapshot to a designated pvc and syncs it to the mainnet tip. This will generally be used to switch pvc of a node due to full volume.