### PR TITLE
Enable iap backoffice in eks cluster

### DIFF
--- a/9c-main/multiplanetary/network/9c-network.yaml
+++ b/9c-main/multiplanetary/network/9c-network.yaml
@@ -60,6 +60,9 @@ gateway:
   - name: seasonpass-api
     hostnames:
     - season-pass.9c.gg
+  - name: iap-backoffice
+    hostnames:
+    - iap-internal-backoffice.9c.gg
 
 snapshot:
   slackChannel: "9c-mainnet"
@@ -777,3 +780,9 @@ volumePreloader:
 
 backoffice:
   enabled: true
+
+iap:
+  backoffice:
+    enabled: true
+    image:
+      tag: "git-c96c5117c0f8687d77e656e0e870f42fe546100a"

--- a/charts/all-in-one/templates/iap-backoffice.yaml
+++ b/charts/all-in-one/templates/iap-backoffice.yaml
@@ -1,0 +1,227 @@
+{{- if $.Values.iap.backoffice.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: iap-backoffice
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+  name: iap-backoffice
+  namespace: {{ $.Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: iap-backoffice
+  template:
+    metadata:
+      labels:
+        app: iap-backoffice
+    spec:
+      containers:
+        - name: iap-backoffice
+          env:
+            - name: STAGE
+              valueFrom:
+                secretKeyRef:
+                  key: STAGE
+                  name: iap-env
+            - name: REGION_NAME
+              valueFrom:
+                secretKeyRef:
+                  key: REGION_NAME
+                  name: iap-env
+            - name: HEADLESS
+              valueFrom:
+                secretKeyRef:
+                  key: HEADLESS
+                  name: iap-env
+            - name: GOOGLE_PACKAGE_NAME
+              valueFrom:
+                secretKeyRef:
+                  key: GOOGLE_PACKAGE_NAME
+                  name: iap-env
+            - name: FORM_SHEET
+              valueFrom:
+                secretKeyRef:
+                  key: FORM_SHEET
+                  name: iap-env
+            - name: CDN_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: CDN_HOST
+                  name: iap-env
+            - name: ACCOUNT_ID
+              valueFrom:
+                secretKeyRef:
+                  key: ACCOUNT_ID
+                  name: iap-env
+            - name: KMS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: KMS_KEY_ID
+                  name: iap-env
+            - name: GOOGLE_CREDENTIAL
+              valueFrom:
+                secretKeyRef:
+                  key: GOOGLE_CREDENTIAL
+                  name: iap-env
+            - name: GOLDEN_DUST_REQUEST_SHEET_ID
+              valueFrom:
+                secretKeyRef:
+                  key: GOLDEN_DUST_REQUEST_SHEET_ID
+                  name: iap-env
+            - name: GOLDEN_DUST_WORK_SHEET_ID
+              valueFrom:
+                secretKeyRef:
+                  key: GOLDEN_DUST_WORK_SHEET_ID
+                  name: iap-env
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  key: DATABASE_URL
+                  name: iap-env
+            - name: PRODUCTS_FILE_PATH
+              valueFrom:
+                secretKeyRef:
+                  key: PRODUCTS_FILE_PATH
+                  name: iap-env
+            - name: CATEGORY_PRODUCTS_FILE_PATH
+              valueFrom:
+                secretKeyRef:
+                  key: CATEGORY_PRODUCTS_FILE_PATH
+                  name: iap-env
+            - name: FUNGIBLE_ITEM_FILE_PATH
+              valueFrom:
+                secretKeyRef:
+                  key: FUNGIBLE_ITEM_FILE_PATH
+                  name: iap-env
+            - name: FUNGIBLE_ASSET_FILE_PATH
+              valueFrom:
+                secretKeyRef:
+                  key: FUNGIBLE_ASSET_FILE_PATH
+                  name: iap-env
+            - name: L10N_FILE_PATH
+              valueFrom:
+                secretKeyRef:
+                  key: L10N_FILE_PATH
+                  name: iap-env
+            - name: IMAGES_FOLDER_PATH
+              valueFrom:
+                secretKeyRef:
+                  key: IMAGES_FOLDER_PATH
+                  name: iap-env
+            - name: S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  key: S3_BUCKET
+                  name: iap-env
+            - name: DB_URI
+              valueFrom:
+                secretKeyRef:
+                  key: DB_URI
+                  name: iap-env
+            - name: APPLE_BUNDLE_ID
+              valueFrom:
+                secretKeyRef:
+                  key: APPLE_BUNDLE_ID
+                  name: iap-env
+            - name: APPLE_ISSUER_ID
+              valueFrom:
+                secretKeyRef:
+                  key: APPLE_ISSUER_ID
+                  name: iap-env
+            - name: APPLE_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: APPLE_KEY_ID
+                  name: iap-env
+            - name: APPLE_VALIDATION_URL
+              valueFrom:
+                secretKeyRef:
+                  key: APPLE_VALIDATION_URL
+                  name: iap-env
+            - name: APPLE_CREDENTIAL
+              valueFrom:
+                secretKeyRef:
+                  key: APPLE_CREDENTIAL
+                  name: iap-env
+            - name: SEASON_PASS_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: SEASON_PASS_JWT_SECRET
+                  name: iap-env
+            - name: HEADLESS_GQL_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: HEADLESS_GQL_JWT_SECRET
+                  name: iap-env
+            - name: CLOUDFLARE_ASSETS_ZONE_ID
+              valueFrom:
+                secretKeyRef:
+                  key: CLOUDFLARE_ASSETS_ZONE_ID
+                  name: iap-env
+            - name: CLOUDFLARE_ASSETS_K_ZONE_ID
+              valueFrom:
+                secretKeyRef:
+                  key: CLOUDFLARE_ASSETS_K_ZONE_ID
+                  name: iap-env
+            - name: CLOUDFLARE_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  key: CLOUDFLARE_EMAIL
+                  name: iap-env
+            - name: CLOUDFLARE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: CLOUDFLARE_API_KEY
+                  name: iap-env
+            - name: R2_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: R2_ACCESS_KEY_ID
+                  name: iap-env
+            - name: R2_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: R2_SECRET_ACCESS_KEY
+                  name: iap-env
+            - name: R2_ACCOUNT_ID
+              valueFrom:
+                secretKeyRef:
+                  key: R2_ACCOUNT_ID
+                  name: iap-env
+            - name: R2_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  key: R2_BUCKET
+                  name: iap-env
+            - name: BACKOFFICE_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  key: BACKOFFICE_OAUTH_CLIENT_ID
+                  name: iap-env
+            - name: BACKOFFICE_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: BACKOFFICE_OAUTH_CLIENT_SECRET
+                  name: iap-env
+            - name: BACKOFFICE_OAUTH_REDIRECT_URI
+              valueFrom:
+                secretKeyRef:
+                  key: BACKOFFICE_OAUTH_REDIRECT_URI
+                  name: iap-env
+            - name: SESSION_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: SESSION_SECRET_KEY
+                  name: iap-env
+          image: {{ $.Values.iap.backoffice.image.repository }}:{{ $.Values.iap.backoffice.image.tag }}
+          ports:
+            - containerPort: 8000
+          name: iap-backoffice
+      {{- with $.Values.iap.backoffice.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always
+{{- end }}

--- a/charts/all-in-one/templates/iap-backoffice.yaml
+++ b/charts/all-in-one/templates/iap-backoffice.yaml
@@ -218,7 +218,6 @@ spec:
           image: {{ $.Values.iap.backoffice.image.repository }}:{{ $.Values.iap.backoffice.image.tag }}
           ports:
             - containerPort: 8000
-          name: iap-backoffice
       {{- with $.Values.iap.backoffice.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/all-in-one/templates/secret-iap.yaml
+++ b/charts/all-in-one/templates/secret-iap.yaml
@@ -1,0 +1,77 @@
+{{ if .Values.externalSecret.enabled }}
+{{ if .Values.iap.backoffice.enabled }}
+apiVersion: "external-secrets.io/v1beta1"
+kind: ExternalSecret
+metadata:
+  name: iap-env
+  namespace: {{ $.Release.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: {{ $.Release.Name }}-secretsmanager
+    kind: SecretStore
+  target:
+    name: iap-env
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      {{- if .Values.externalSecret.prefix }}
+      key: {{ .Values.externalSecret.prefix }}/iap-env
+      {{- else }}
+      key: {{ .Values.clusterName }}/iap-env
+      {{- end }}
+{{- else }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: iap-env
+  namespace: {{ $.Release.Name }}
+stringData:
+  STAGE: ""
+  REGION_NAME: ""
+  HEADLESS: ""
+  GOOGLE_PACKAGE_NAME: ""
+  FORM_SHEET: ""
+  CDN_HOST: ""
+  ACCOUNT_ID: ""
+  AWS_ACCESS_KEY_ID: ""
+  AWS_SECRET_ACCESS_KEY: ""
+  KMS_KEY_ID: ""
+  GOOGLE_CREDENTIAL: ""
+  GOLDEN_DUST_REQUEST_SHEET_ID: ""
+  GOLDEN_DUST_WORK_SHEET_ID: ""
+  DATABASE_URL: ""
+  PRODUCTS_FILE_PATH: ""
+  CATEGORY_PRODUCTS_FILE_PATH: ""
+  FUNGIBLE_ITEM_FILE_PATH: ""
+  FUNGIBLE_ASSET_FILE_PATH: ""
+  L10N_FILE_PATH: ""
+  IMAGES_FOLDER_PATH: ""
+  S3_BUCKET: ""
+  CLOUDFRONT_DISTRIBUTION_1: ""
+  CLOUDFRONT_DISTRIBUTION_2: ""
+  DB_URI: ""
+  APPLE_BUNDLE_ID: ""
+  APPLE_ISSUER_ID: ""
+  APPLE_KEY_ID: ""
+  APPLE_VALIDATION_URL: ""
+  APPLE_CREDENTIAL: ""
+  SEASON_PASS_JWT_SECRET: ""
+  HEADLESS_GQL_JWT_SECRET: ""
+  CLOUDFLARE_ASSETS_ZONE_ID: ""
+  CLOUDFLARE_ASSETS_K_ZONE_ID: ""
+  CLOUDFLARE_EMAIL: ""
+  CLOUDFLARE_API_KEY: ""
+  R2_ACCESS_KEY_ID: ""
+  R2_SECRET_ACCESS_KEY: ""
+  R2_ACCOUNT_ID: ""
+  R2_BUCKET: ""
+  BACKOFFICE_OAUTH_CLIENT_ID: ""
+  BACKOFFICE_OAUTH_CLIENT_SECRET: ""
+  BACKOFFICE_OAUTH_REDIRECT_URI: ""
+  SESSION_SECRET_KEY: ""
+type: Opaque
+{{- end }}
+{{- end }}

--- a/charts/all-in-one/templates/service.yaml
+++ b/charts/all-in-one/templates/service.yaml
@@ -819,3 +819,29 @@ spec:
 ---
 
 {{ end }}
+
+{{ if .Values.iap.backoffice.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: iap-backoffice
+  namespace: {{ $.Release.Name }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 8000
+  selector:
+    app: iap-backoffice
+  type: ClusterIP
+
+---
+
+{{ end }}

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -869,3 +869,20 @@ backoffice:
     mainHeimdallUrl: ""
     mainThorId: ""
     mainThorUrl: ""
+
+iap:
+  backoffice:
+    enabled: false
+    image:
+      repository: planetariumhq/ninechronicles-iap
+      pullPolicy: Always
+    nodeSelector: {}
+    env:
+      region: ""
+      gqlUrl: ""
+      currentPlanet: ""
+      dbUri: ""
+      sqsUrl: ""
+      arenaServiceJwtPublicKey: ""
+    serviceAccount:
+      roleArn: ""

--- a/charts/external-services/templates/iap-backoffice.yaml
+++ b/charts/external-services/templates/iap-backoffice.yaml
@@ -55,16 +55,6 @@ spec:
                 secretKeyRef:
                   key: ACCOUNT_ID
                   name: iap-env
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  key: AWS_ACCESS_KEY_ID
-                  name: iap-env
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: AWS_SECRET_ACCESS_KEY
-                  name: iap-env
             - name: KMS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -124,16 +114,6 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: S3_BUCKET
-                  name: iap-env
-            - name: CLOUDFRONT_DISTRIBUTION_1
-              valueFrom:
-                secretKeyRef:
-                  key: CLOUDFRONT_DISTRIBUTION_1
-                  name: iap-env
-            - name: CLOUDFRONT_DISTRIBUTION_2
-              valueFrom:
-                secretKeyRef:
-                  key: CLOUDFRONT_DISTRIBUTION_2
                   name: iap-env
             - name: DB_URI
               valueFrom:

--- a/charts/external-services/templates/iap-backoffice.yaml
+++ b/charts/external-services/templates/iap-backoffice.yaml
@@ -218,7 +218,6 @@ spec:
           image: {{ $.Values.iap.backoffice.image.repository }}:{{ $.Values.iap.backoffice.image.tag }}
           ports:
             - containerPort: 8000
-          name: iap-backoffice
       {{- with $.Values.iap.backoffice.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/external-services/values.yaml
+++ b/charts/external-services/values.yaml
@@ -81,7 +81,7 @@ iap:
   backoffice:
     enabled: false
     image:
-      repository: planetariumhq/iap-backoffice
+      repository: planetariumhq/ninechronicles-iap
       pullPolicy: Always
     nodeSelector: {}
     env:

--- a/rke2-9c-internal/external-services/values.yaml
+++ b/rke2-9c-internal/external-services/values.yaml
@@ -38,6 +38,6 @@ seasonpass:
 
 iap:
   backoffice:
-    enabled: true
+    enabled: false
     image:
       tag: "git-9d98f43bbef5e5dadc3d30c26b7cdae482e01baf"


### PR DESCRIPTION
현재 테스트용으로 띄운 백오피스가 db latency로 테스트가 불가능한 상황이라 RKE2 -> eks로 이주합니다.

- RKE2 인터널에 띄워둔 iap backoffice를 비활성화합니다.
- EKS노드에 iap backoffice를 활성화합니다.