### PR TITLE
prepare volume for heimdall eks rpc1

### DIFF
--- a/9c-main-eks/multiplanetary/network/heimdall.yaml
+++ b/9c-main-eks/multiplanetary/network/heimdall.yaml
@@ -721,7 +721,7 @@ seasonpass:
       repository: planetariumhq/season-pass
 
 volumePreloader:
-  count: 0
+  count: 1
   replicas: 1
 
   useTurnServer: true


### PR DESCRIPTION
heimdall eks rpc1 volume currently at 96%.