### PR TITLE
chore(odin): swap validator-rh2 PVC and enable resetSnapshot

### DIFF
--- a/9c-main/network/odin.yaml
+++ b/9c-main/network/odin.yaml
@@ -17,7 +17,7 @@ global:
   planet: Odin
   consensusType: pbft
 
-  resetSnapshot: false
+  resetSnapshot: true
   rollbackSnapshot: false
 
   storage:


### PR DESCRIPTION
## Summary
- validator와 remote-headless-2 PVC 스왑 (data-2 ↔ data-1)
- `resetSnapshot: true` 활성화 — rh-1, rh-2, rh-3 스냅샷 다운로드 복구
- Longhorn PVC clone이 반복 stuck 되어 스냅샷 리셋 방식으로 전환

## 머지 후 TODO
- [ ] rh-1, rh-2, rh-3 스냅샷 다운로드 완료 확인
- [ ] `resetSnapshot: false`로 되돌리는 PR 생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)