### PR TITLE
chore(odin): restore rpc-2 endpoint

### DIFF
--- a/planets/mainnet.json
+++ b/planets/mainnet.json
@@ -13,15 +13,15 @@
         "https://api.9cscan.com"
       ],
       "headless.gql": [
+        "https://odin-rpc-1.nine-chronicles.com/graphql",        
         "https://odin-rpc-2.nine-chronicles.com/graphql",
-        "https://odin-rpc-1.nine-chronicles.com/graphql",
         "https://odin-rpc-3.nine-chronicles.com/graphql",
         "https://odin5.9capi.com/graphql",
         "https://odin6.9capi.com/graphql"
       ],
       "headless.grpc": [
+        "http://odin-rpc-1.nine-chronicles.com:31238",        
         "http://odin-rpc-2.nine-chronicles.com:31238",
-        "http://odin-rpc-1.nine-chronicles.com:31238",
         "http://odin-rpc-3.nine-chronicles.com:31238",
         "http://odin5.9capi.com:31238",
         "http://odin6.9capi.com:31238"

--- a/planets/mainnet.json
+++ b/planets/mainnet.json
@@ -13,13 +13,15 @@
         "https://api.9cscan.com"
       ],
       "headless.gql": [
-        "https://odin-rpc-1.nine-chronicles.com/graphql",        
+        "https://odin-rpc-2.nine-chronicles.com/graphql",
+        "https://odin-rpc-1.nine-chronicles.com/graphql",
         "https://odin-rpc-3.nine-chronicles.com/graphql",
         "https://odin5.9capi.com/graphql",
         "https://odin6.9capi.com/graphql"
       ],
       "headless.grpc": [
-        "http://odin-rpc-1.nine-chronicles.com:31238",        
+        "http://odin-rpc-2.nine-chronicles.com:31238",
+        "http://odin-rpc-1.nine-chronicles.com:31238",
         "http://odin-rpc-3.nine-chronicles.com:31238",
         "http://odin5.9capi.com:31238",
         "http://odin6.9capi.com:31238"


### PR DESCRIPTION
## Summary
- odin rpc-2 엔드포인트 재추가 (headless.gql + headless.grpc)
- rh-2 블록 catch-up 완료 확인 (gap=2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)