### PR TITLE
chore(petpop): update main & internal image tags to 5ffad35

### DIFF
--- a/9c-internal/petpop/values.yaml
+++ b/9c-internal/petpop/values.yaml
@@ -4,20 +4,20 @@ server:
   enabled: true
   image:
     repository: planetariumhq/petpop
-    tag: server-2d6b71b388a3ad752fcc60fa4eb68bf949df66f7
+    tag: server-5ffad3540067174e68c77f53ed61517f3db933ea
   hostname: internal.petpop.fun
 
 backoffice:
   enabled: true
   image:
     repository: planetariumhq/petpop
-    tag: server-86ef01294a4435632cfd81a84b7ef23718e70352
+    tag: server-5ffad3540067174e68c77f53ed61517f3db933ea
   hostname: petpop-internal-backoffice.9c.gg
 
 workers:
   image:
     repository: planetariumhq/petpop
-    tag: worker-86ef01294a4435632cfd81a84b7ef23718e70352
+    tag: worker-5ffad3540067174e68c77f53ed61517f3db933ea
   rankingWorker:
     enabled: true
   blockResetWorker:

--- a/9c-main/petpop/values.yaml
+++ b/9c-main/petpop/values.yaml
@@ -4,7 +4,7 @@ server:
   enabled: true
   image:
     repository: planetariumhq/petpop
-    tag: server-b6b554b886b518642a67c6c01814481918f193cc
+    tag: server-5ffad3540067174e68c77f53ed61517f3db933ea
   hostnames:
     - petpop.fun
     - www.petpop.fun
@@ -20,7 +20,7 @@ backoffice:
   enabled: true
   image:
     repository: planetariumhq/petpop
-    tag: server-b6b554b886b518642a67c6c01814481918f193cc
+    tag: server-5ffad3540067174e68c77f53ed61517f3db933ea
   hostname: petpop-backoffice.9c.gg
   nodeSelector:
     node.kubernetes.io/type: general
@@ -28,7 +28,7 @@ backoffice:
 workers:
   image:
     repository: planetariumhq/petpop
-    tag: worker-b6b554b886b518642a67c6c01814481918f193cc
+    tag: worker-5ffad3540067174e68c77f53ed61517f3db933ea
   nodeSelector:
     node.kubernetes.io/type: general
   rankingWorker:


### PR DESCRIPTION
## Summary
- petpop main/internal의 server, backoffice, worker 이미지 태그를 `5ffad3540067174e68c77f53ed61517f3db933ea`로 업데이트

## Changes
- `9c-main/petpop/values.yaml`: server, backoffice, worker 태그 업데이트
- `9c-internal/petpop/values.yaml`: server, backoffice, worker 태그 업데이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)