### PR TITLE
fix(snapshot): handle download and extraction failures

### DIFF
--- a/charts/all-in-one/scripts/download_snapshot.sh
+++ b/charts/all-in-one/scripts/download_snapshot.sh
@@ -22,8 +22,13 @@ function download_with_retry() {
   local save_dir=$2
   local output_file=$3
 
-  aria2c "$url" -d "$2" -o "$3" -s1 --force-sequential=true --continue=true \
-    --show-console-readout=false --summary-interval=30 --max-tries=10
+  if ! aria2c "$url" -d "$2" -o "$3" -s1 --force-sequential=true --continue=true \
+    --show-console-readout=false --summary-interval=30 --max-tries=10; then
+    echo "[WARN] Download failed with --continue=true, retrying without resume..."
+    rm -f "$2/$3" "$2/$3.aria2"
+    aria2c "$url" -d "$2" -o "$3" -s1 --force-sequential=true \
+      --show-console-readout=false --summary-interval=30 --max-tries=10
+  fi
 }
 
 function download_partition() {
@@ -97,11 +102,21 @@ function download_partition() {
     done
     wait
 
+    for part_file in "$save_dir/$filename.$extension.part"*; do
+      if [ -f "$part_file.aria2" ]; then
+        echo "[ERROR] Incomplete part download: $part_file"
+        return 1
+      fi
+    done
+
     cat "$save_dir/$filename.$extension.part"* > "$save_dir/$filename.$extension"
     rm "$save_dir/$filename.$extension.part"*
   else
     local extension=$(test_ext "$archive_path")
-    download_with_retry "$archive_path" "$save_dir" "$filename.$extension"
+    if ! download_with_retry "$archive_path" "$save_dir" "$filename.$extension"; then
+      echo "[ERROR] Failed to download $archive_path"
+      return 1
+    fi
   fi
 
   echo "$save_dir/$filename.$extension"
@@ -202,11 +217,17 @@ if [ $download_option = "true" ]; then
 
       if [[ "$rollback_snapshot" = "true" ]] || [[ "$has_archive" = "false" ]] || [[ "$has_archive_part" = "true" ]]; then
         echo "Downloading $base_url/$snapshot_zip_filename"
-        download_partition "$base_url" "$snapshot_zip_filename" "$snapshot_partition_dir"
+        if ! download_partition "$base_url" "$snapshot_zip_filename" "$snapshot_partition_dir"; then
+          echo "[ERROR] Failed to download $snapshot_zip_filename"
+          exit 1
+        fi
       fi
 
       echo "Extracting $snapshot_zip_filename"
-      bsdtar -C "$save_dir" -xf "$snapshot_partition_dir/$snapshot_zip_filename."*z*
+      if ! bsdtar -C "$save_dir" -xf "$snapshot_partition_dir/$snapshot_zip_filename."*z*; then
+        echo "[ERROR] Failed to extract $snapshot_zip_filename"
+        exit 1
+      fi
     done
 
     mkdir -p "$snapshot_state_dir"


### PR DESCRIPTION
## Summary
- `download_snapshot.sh`에서 다운로드/추출 실패 시 에러를 무시하고 exit 0으로 완료되는 버그 수정
- Heimdall internal validator가 `state_latest.tar.zst` 다운로드 중 Cloudflare R2 range request 실패로 truncated 파일이 추출되어 genesis block을 찾을 수 없는 `KeyNotFoundException`으로 CrashLoopBackOff 발생

### 변경 사항
- **`download_with_retry`**: aria2 resume(`--continue=true`) 실패 시 partial 파일 삭제 후 fresh download 재시도
- **`download_partition`**: part 다운로드 후 `.aria2` 파일이 남아있으면 (불완전 다운로드) 에러 반환
- **`download_unzip_snapshot`**: `download_partition` 또는 `bsdtar` 추출 실패 시 `exit 1`로 init container 실패 처리

### 근본 원인
```
aria2 ERROR: Invalid range header.
Request: 17330864128-27178746582/27178746583
Response: 0-27178746582/27178746583

bsdtar: Truncated input file (needed 67387392 bytes, only 0 available)
```
R2가 range request를 정상 처리하지 못해 aria2 resume이 실패했지만, 스크립트가 이를 무시하고 진행 → truncated `state_latest` 추출 → `block/blockindex` 불완전 → genesis block hash 조회 실패

## Test plan
- [ ] 머지 후 Heimdall internal `resetSnapshot: true`로 재트리거
- [ ] init container가 다운로드 실패 시 non-zero exit으로 종료되는지 확인
- [ ] 정상 다운로드 시 노드가 genesis block을 찾아 정상 시작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)