### PR TITLE
chore(petpop): update main & internal image tags to 1434441

### DIFF
--- a/9c-internal/petpop/values.yaml
+++ b/9c-internal/petpop/values.yaml
@@ -4,20 +4,20 @@ server:
   enabled: true
   image:
     repository: planetariumhq/petpop
-    tag: server-5ffad3540067174e68c77f53ed61517f3db933ea
+    tag: server-14344417bdad1f0aacffc6a076c5910f69744901
   hostname: internal.petpop.fun
 
 backoffice:
   enabled: true
   image:
     repository: planetariumhq/petpop
-    tag: server-5ffad3540067174e68c77f53ed61517f3db933ea
+    tag: server-14344417bdad1f0aacffc6a076c5910f69744901
   hostname: petpop-internal-backoffice.9c.gg
 
 workers:
   image:
     repository: planetariumhq/petpop
-    tag: worker-5ffad3540067174e68c77f53ed61517f3db933ea
+    tag: worker-14344417bdad1f0aacffc6a076c5910f69744901
   rankingWorker:
     enabled: true
   blockResetWorker:

--- a/9c-main/petpop/values.yaml
+++ b/9c-main/petpop/values.yaml
@@ -4,7 +4,7 @@ server:
   enabled: true
   image:
     repository: planetariumhq/petpop
-    tag: server-5ffad3540067174e68c77f53ed61517f3db933ea
+    tag: server-14344417bdad1f0aacffc6a076c5910f69744901
   hostnames:
     - petpop.fun
     - www.petpop.fun
@@ -20,7 +20,7 @@ backoffice:
   enabled: true
   image:
     repository: planetariumhq/petpop
-    tag: server-5ffad3540067174e68c77f53ed61517f3db933ea
+    tag: server-14344417bdad1f0aacffc6a076c5910f69744901
   hostname: petpop-backoffice.9c.gg
   nodeSelector:
     node.kubernetes.io/type: general
@@ -28,7 +28,7 @@ backoffice:
 workers:
   image:
     repository: planetariumhq/petpop
-    tag: worker-5ffad3540067174e68c77f53ed61517f3db933ea
+    tag: worker-14344417bdad1f0aacffc6a076c5910f69744901
   nodeSelector:
     node.kubernetes.io/type: general
   rankingWorker:


### PR DESCRIPTION
## Summary
- petpop main/internal의 server, backoffice, worker 이미지 태그를 `14344417bdad1f0aacffc6a076c5910f69744901`로 업데이트

## Changes
- `9c-main/petpop/values.yaml`: server, backoffice, worker 태그 업데이트
- `9c-internal/petpop/values.yaml`: server, backoffice, worker 태그 업데이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)