### PR TITLE
feat(ragnarok-breaker): add dockerhub imagePullSecret

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -3,3 +3,6 @@ externalSecretKey: ragnarok-breaker/staging
 image:
   repository: planetariumhq/ragnarok-breaker-worker
   tag: develop
+
+imagePullSecret:
+  secretKey: ragnarok-breaker/dockerhub

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -3,3 +3,6 @@ externalSecretKey: ragnarok-breaker/production
 image:
   repository: planetariumhq/ragnarok-breaker-worker
   tag: develop
+
+imagePullSecret:
+  secretKey: ragnarok-breaker/dockerhub

--- a/charts/ragnarok-breaker/templates/secrets.yaml
+++ b/charts/ragnarok-breaker/templates/secrets.yaml
@@ -29,3 +29,39 @@ spec:
       service: SecretsManager
       region: us-east-2
 {{- end }}
+{{- if .Values.imagePullSecret.secretKey }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.imagePullSecret.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: {{ .Release.Name }}-secretsmanager
+    kind: SecretStore
+  target:
+    name: {{ .Values.imagePullSecret.name }}
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {"auths":{"{{ `{{ .registry }}` }}":{"username":"{{ `{{ .username }}` }}","password":"{{ `{{ .password }}` }}","auth":"{{ `{{ printf "%s:%s" .username .password | b64enc }}` }}"}}}
+  data:
+    - secretKey: registry
+      remoteRef:
+        key: {{ .Values.imagePullSecret.secretKey }}
+        property: registry
+    - secretKey: username
+      remoteRef:
+        key: {{ .Values.imagePullSecret.secretKey }}
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: {{ .Values.imagePullSecret.secretKey }}
+        property: password
+{{- end }}

--- a/charts/ragnarok-breaker/templates/worker-deployments.yaml
+++ b/charts/ragnarok-breaker/templates/worker-deployments.yaml
@@ -21,6 +21,10 @@ spec:
       labels:
         app: ragnarok-breaker-{{ $name | kebabcase }}
     spec:
+      {{- if $.Values.imagePullSecret.secretKey }}
+      imagePullSecrets:
+        - name: {{ $.Values.imagePullSecret.name }}
+      {{- end }}
       containers:
         - name: worker
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"

--- a/charts/ragnarok-breaker/values.yaml
+++ b/charts/ragnarok-breaker/values.yaml
@@ -5,6 +5,10 @@ image:
   tag: develop
   pullPolicy: IfNotPresent
 
+imagePullSecret:
+  name: ragnarok-breaker-regcred
+  secretKey: ""
+
 workers:
   scheduler:
     enabled: true


### PR DESCRIPTION
## Summary
- Follow-up to #3339. The `planetariumhq/ragnarok-breaker-worker` Docker Hub repository is private, so worker Pods currently fail with `ImagePullBackOff`.
- Add a templated ExternalSecret that pulls `registry`/`username`/`password` from AWS Secrets Manager and materializes a `kubernetes.io/dockerconfigjson` secret in the release namespace.
- Attach `imagePullSecrets` to every worker Deployment.
- Staging and production overlays point at the shared AWS key `ragnarok-breaker/dockerhub`.

## Test plan
- [x] `helm template` renders 5 worker Deployments with `imagePullSecrets: ragnarok-breaker-regcred` and the new ExternalSecret
- [ ] Create AWS Secrets Manager entry `ragnarok-breaker/dockerhub` with `registry`/`username`/`password` (Docker Hub PAT)
- [ ] After sync, confirm `kubectl -n ragnarok-breaker-staging get secret ragnarok-breaker-regcred -o jsonpath='{.type}'` returns `kubernetes.io/dockerconfigjson`
- [ ] Worker Pods transition out of `ImagePullBackOff` and pull `planetariumhq/ragnarok-breaker-worker:develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)