### PR TITLE
fix(ragnarok-breaker): prefix worker commands with worker/ subdir

### DIFF
--- a/charts/ragnarok-breaker/values.yaml
+++ b/charts/ragnarok-breaker/values.yaml
@@ -13,7 +13,7 @@ workers:
   scheduler:
     enabled: true
     replicas: 1
-    command: ["bun", "run", "src/entry/scheduler.entry.ts"]
+    command: ["bun", "run", "worker/src/entry/scheduler.entry.ts"]
     resources:
       requests:
         cpu: 100m
@@ -24,7 +24,7 @@ workers:
   gameValidator:
     enabled: true
     replicas: 1
-    command: ["bun", "run", "src/entry/game-worker.entry.ts"]
+    command: ["bun", "run", "worker/src/entry/game-worker.entry.ts"]
     resources:
       requests:
         cpu: 200m
@@ -35,7 +35,7 @@ workers:
   gameplayValidator:
     enabled: true
     replicas: 1
-    command: ["bun", "run", "src/entry/gameplay-worker.entry.ts"]
+    command: ["bun", "run", "worker/src/entry/gameplay-worker.entry.ts"]
     resources:
       requests:
         cpu: 200m
@@ -46,7 +46,7 @@ workers:
   summonValidator:
     enabled: true
     replicas: 1
-    command: ["bun", "run", "src/entry/summon-worker.entry.ts"]
+    command: ["bun", "run", "worker/src/entry/summon-worker.entry.ts"]
     resources:
       requests:
         cpu: 200m
@@ -57,7 +57,7 @@ workers:
   leagueSnapshot:
     enabled: true
     replicas: 1
-    command: ["bun", "run", "src/entry/league-worker.entry.ts"]
+    command: ["bun", "run", "worker/src/entry/league-worker.entry.ts"]
     resources:
       requests:
         cpu: 200m


### PR DESCRIPTION
## Summary
Follow-up to #3339 / #3340. Worker Pods now pull the image successfully but crash with:

```
error: Module not found "src/entry/game-worker.entry.ts"
```

The worker [Dockerfile](https://github.com/verse8/JiwonRB/blob/main/worker/Dockerfile) sets `WORKDIR /app` and copies the worker source into `/app/worker/`. The sibling `docker-compose.yml` runs `bun run worker/src/entry/*.entry.ts` from `/app`. The chart values were using the unprefixed path.

Fix: prefix all five worker commands with `worker/`.

## Test plan
- [x] `helm template` renders commands as `["bun", "run", "worker/src/entry/*.entry.ts"]`
- [ ] After sync, worker Pods reach Running and log `[scheduler] Starting scheduler` / BullMQ consumer-ready messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)