### PR TITLE
feat(ragnarok-breaker): add gs-gateway proxy for V8 connection

### DIFF
--- a/charts/ragnarok-breaker/templates/gs-gateway.yaml
+++ b/charts/ragnarok-breaker/templates/gs-gateway.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.gsGateway.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: gs-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: gs-gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: gs-gateway
+spec:
+  type: ClusterIP
+  selector:
+    app: gs-gateway
+  ports:
+    - name: http
+      port: {{ .Values.gsGateway.port }}
+      targetPort: {{ .Values.gsGateway.port }}
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gs-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: gs-gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: gs-gateway
+spec:
+  replicas: {{ .Values.gsGateway.replicas }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: gs-gateway
+  template:
+    metadata:
+      labels:
+        app: gs-gateway
+    spec:
+      {{- if .Values.imagePullSecret.secretKey }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret.name }}
+      {{- end }}
+      containers:
+        - name: gs-gateway
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            {{- toYaml .Values.gsGateway.command | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.gsGateway.port }}
+          env:
+            - name: GS_GATEWAY_HOST
+              value: {{ .Values.gsGateway.host | quote }}
+            - name: GS_GATEWAY_PORT
+              value: {{ .Values.gsGateway.port | quote }}
+          envFrom:
+            - secretRef:
+                name: ragnarok-breaker-env
+          livenessProbe:
+            {{- toYaml .Values.gsGateway.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.gsGateway.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.gsGateway.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always
+{{- end }}

--- a/charts/ragnarok-breaker/templates/worker-deployments.yaml
+++ b/charts/ragnarok-breaker/templates/worker-deployments.yaml
@@ -25,12 +25,28 @@ spec:
       imagePullSecrets:
         - name: {{ $.Values.imagePullSecret.name }}
       {{- end }}
+      {{- if and $.Values.gsGateway.enabled $.Values.gsGateway.waitForReady }}
+      initContainers:
+        - name: wait-for-gs-gateway
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until wget -q -O /dev/null {{ $.Values.gsGateway.serviceUrl }}/health; do
+                echo "waiting for gs-gateway..."
+                sleep 2
+              done
+      {{- end }}
       containers:
         - name: worker
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           command:
             {{- toYaml $w.command | nindent 12 }}
+          env:
+            - name: GS_GATEWAY_URL
+              value: {{ $.Values.gsGateway.serviceUrl | quote }}
           envFrom:
             - secretRef:
                 name: ragnarok-breaker-env

--- a/charts/ragnarok-breaker/values.yaml
+++ b/charts/ragnarok-breaker/values.yaml
@@ -9,6 +9,38 @@ imagePullSecret:
   name: ragnarok-breaker-regcred
   secretKey: ""
 
+# Single-instance HTTP proxy that owns the V8 GameServer connection.
+# NEVER scale beyond 1 — duplicate connections cause V8 to kick both with 4009.
+gsGateway:
+  enabled: true
+  replicas: 1
+  command: ["bun", "run", "worker/src/entry/gs-gateway.entry.ts"]
+  host: "0.0.0.0"
+  port: 3000
+  serviceUrl: "http://gs-gateway:3000"
+  waitForReady: true
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: 3000
+    initialDelaySeconds: 30
+    periodSeconds: 15
+    failureThreshold: 3
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: 3000
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 3
+
 workers:
   scheduler:
     enabled: true


### PR DESCRIPTION
## Summary
Resolves the `duplicate_connection (4009)` / SDK `emitter.emit` TypeError crash loop that affects the 5 existing workers. Each worker was opening its own V8 GameServer SDK session with the same `(verse, account)` pair; V8 kicks both sides as soon as a second connection arrives.

Fix: introduce a **singleton** `gs-gateway` HTTP service that owns the V8 connection. Workers now call it over `http://gs-gateway:3000` using the new `GS_GATEWAY_URL` env (worker code for this was merged in verse8/JiwonRB@6d09df8 / @d27fdfd).

### Chart changes
- New `charts/ragnarok-breaker/templates/gs-gateway.yaml` — `Deployment` (replicas=1, `strategy: Recreate`, port 3000, `/health` liveness+readiness) + `Service` (ClusterIP:3000). Reuses the existing image, `ragnarok-breaker-env` secret, and `ragnarok-breaker-regcred` pull secret.
- `worker-deployments.yaml` — all 5 worker Deployments get:
  - `env: GS_GATEWAY_URL=http://gs-gateway:3000`
  - `initContainers: wait-for-gs-gateway` (busybox polls `/health` until it responds before starting the worker)
- `values.yaml` — new `gsGateway` section with probe/resource defaults. staging and production overlays need no changes.

### ⚠️ HPA / replicas must stay at 1
Running two `gs-gateway` pods reintroduces duplicate-connection 4009 on both sides. The chart intentionally omits any HPA field; please don't add one.

## Required secret rotation (before sync)
Both `ragnarok-breaker/staging` and `ragnarok-breaker/production` AWS Secrets Manager entries must have `AGENT8_AUTH` rotated:
- **old**: 1-hour base64 game token (`eyJtc2ciOi...fQ==`)
- **new**: long-lived V8 access token JWT (3-segment `eyJhbGc...`)

gs-gateway exchanges the JWT for a game token at boot via `POST https://v8-meme-api.verse8.io/v1/auth/game-token/{verseId}` and refreshes every ~25 min. V8 access tokens currently expire in ~7 days, so someone has to rotate them manually when they expire.

## Test plan
- [x] `helm template` — staging and production both render `Service/gs-gateway`, `Deployment/gs-gateway` (replicas=1, Recreate, probes), and the 5 worker Deployments with `GS_GATEWAY_URL` env + `wait-for-gs-gateway` initContainer
- [ ] Update `AGENT8_AUTH` to V8 JWT in AWS Secrets Manager (`ragnarok-breaker/staging`)
- [ ] ArgoCD sync staging
- [ ] `kubectl -n ragnarok-breaker-staging get pod` — `gs-gateway` 1 pod Ready 1/1
- [ ] `kubectl -n ragnarok-breaker-staging exec deploy/ragnarok-breaker-scheduler -- wget -qO- http://gs-gateway:3000/health` → `{"status":"ok","connected":true}`
- [ ] `kubectl logs deploy/gs-gateway` shows `[v8-connection] Connected` and `[gs-gateway-entry] Listening on http://0.0.0.0:3000`
- [ ] Worker logs no longer show `duplicate_connection` / `4009` / `Auth token required`
- [ ] Observe one `Refreshing game token` → `Token refreshed` cycle (~25 min)
- [ ] 24h soak → rotate `ragnarok-breaker/production` secret and sync production

## Rollback
Revert this PR and sync. The rotated JWT in `AGENT8_AUTH` is harmless for the old direct-connection workers as long as they're not redeployed — full rollback requires reverting the worker image too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)