### PR TITLE
chore(ragnarok-breaker): pin production image to git-50966c9

### DIFF
--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -2,7 +2,7 @@ externalSecretKey: ragnarok-breaker/production
 
 image:
   repository: planetariumhq/ragnarok-breaker-worker
-  tag: develop
+  tag: git-50966c946b635489c9adbc2b6bf71836d825e02e
 
 imagePullSecret:
   secretKey: ragnarok-breaker/dockerhub


### PR DESCRIPTION
## Summary
Pin the ragnarok-breaker production overlay to the pre-built multi-arch image `planetariumhq/ragnarok-breaker-worker:git-50966c946b635489c9adbc2b6bf71836d825e02e` instead of the mutable `develop` tag.

- Index digest: `sha256:e15f9550c2e30fe468e7e5d8c7a903da55f4a0f3b855eef32221a5aa098ccd4b`
- Platforms: `linux/amd64`, `linux/arm64`
- Staging overlay is untouched — it still tracks `develop`.

## Test plan
- [x] `helm template` renders gs-gateway + 5 workers with `image: planetariumhq/ragnarok-breaker-worker:git-50966c946b635489c9adbc2b6bf71836d825e02e`
- [ ] After sync, production workers pull the pinned image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)