### PR TITLE
chore(ragnarok-breaker): pin staging image to git-50966c9

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -2,7 +2,7 @@ externalSecretKey: ragnarok-breaker/staging
 
 image:
   repository: planetariumhq/ragnarok-breaker-worker
-  tag: develop
+  tag: git-50966c946b635489c9adbc2b6bf71836d825e02e
 
 imagePullSecret:
   secretKey: ragnarok-breaker/dockerhub


### PR DESCRIPTION
## Summary
Follow-up to #3344. Apply the same image pin to the staging overlay so both environments run the pre-built multi-arch image `planetariumhq/ragnarok-breaker-worker:git-50966c946b635489c9adbc2b6bf71836d825e02e`.

- Index digest: `sha256:e15f9550c2e30fe468e7e5d8c7a903da55f4a0f3b855eef32221a5aa098ccd4b`
- Platforms: `linux/amd64`, `linux/arm64`

## Test plan
- [x] `helm template` renders gs-gateway + 5 workers with the pinned tag
- [ ] After sync, staging workers pull the pinned image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)