### PR TITLE
chore(odin): move seed to validator node (odin-3)

### DIFF
--- a/9c-main/network/odin.yaml
+++ b/9c-main/network/odin.yaml
@@ -133,8 +133,7 @@ seed:
 
   nodeSelector:
   - node.kubernetes.io/network: odin
-    node.kubernetes.io/node-index: '1'
-    node.kubernetes.io/type: seed
+    node.kubernetes.io/node-index: '3'
 
 validator:
   count: 1


### PR DESCRIPTION
## Summary
- odin seed를 odin-seed-1 → odin-3(validator) 노드로 이동
- odin-seed-1 노드 제거 준비
- LoadBalancer Service는 유지되어 외부 IP/DNS 변경 없음

## Test plan
- [ ] seed pod가 odin-3에서 정상 실행 확인
- [ ] 다른 노드가 seed에 정상 연결 확인
- [ ] odin-seed-1에 pod 없는 것 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)