### PR TITLE
chore(snapshot): apply GLACIER_IR + 91d lifecycle to archive bucket

### DIFF
--- a/charts/all-in-one/scripts/snapshots/partition/upload_snapshot.sh
+++ b/charts/all-in-one/scripts/snapshots/partition/upload_snapshot.sh
@@ -43,6 +43,7 @@ provider = AWS
 access_key_id = $ORIG_AWS_ACCESS_KEY_ID
 secret_access_key = $ORIG_AWS_SECRET_ACCESS_KEY
 region = us-east-2
+storage_class = GLACIER_IR
 no_check_bucket = true
 EOF
 

--- a/charts/snapshot/templates/configmap-partition.yaml
+++ b/charts/snapshot/templates/configmap-partition.yaml
@@ -212,9 +212,9 @@ data:
       "$AWS" s3 cp "$LATEST_METADATA" "s3://$S3_BUCKET_NAME/main/partition/$LATEST_METADATA_FILENAME" --quiet --acl public-read
       "$AWS" s3 cp "$LATEST_STATE" "s3://$S3_BUCKET_NAME/main/partition/$LATEST_STATE_FILENAME" --quiet --acl public-read
 
-      "$AWS" s3 cp "$LATEST_SNAPSHOT" "s3://$S3_ARCHIVE_BUCKET_NAME/main/partition/archive/snapshots/${NOW}_$LATEST_SNAPSHOT_FILENAME" --quiet --profile archive
-      "$AWS" s3 cp "$LATEST_METADATA" "s3://$S3_ARCHIVE_BUCKET_NAME/main/partition/archive/metadata/${NOW}_$LATEST_METADATA_FILENAME" --quiet --profile archive
-      "$AWS" s3 cp "$LATEST_STATE" "s3://$S3_ARCHIVE_BUCKET_NAME/main/partition/archive/states/${NOW}_$LATEST_STATE_FILENAME" --quiet --profile archive
+      "$AWS" s3 cp "$LATEST_SNAPSHOT" "s3://$S3_ARCHIVE_BUCKET_NAME/main/partition/archive/snapshots/${NOW}_$LATEST_SNAPSHOT_FILENAME" --quiet --profile archive --storage-class GLACIER_IR
+      "$AWS" s3 cp "$LATEST_METADATA" "s3://$S3_ARCHIVE_BUCKET_NAME/main/partition/archive/metadata/${NOW}_$LATEST_METADATA_FILENAME" --quiet --profile archive --storage-class GLACIER_IR
+      "$AWS" s3 cp "$LATEST_STATE" "s3://$S3_ARCHIVE_BUCKET_NAME/main/partition/archive/states/${NOW}_$LATEST_STATE_FILENAME" --quiet --profile archive --storage-class GLACIER_IR
 
       "$AWS" s3 cp "s3://$S3_BUCKET_NAME/main/partition/$LATEST_SNAPSHOT_FILENAME" "s3://$S3_BUCKET_NAME/$S3_LATEST_SNAPSHOT_PATH" --quiet --acl public-read --copy-props none --metadata-directive COPY
       "$AWS" s3 cp "s3://$S3_BUCKET_NAME/main/partition/$LATEST_METADATA_FILENAME" "s3://$S3_BUCKET_NAME/$S3_LATEST_METADATA_PATH" --quiet --acl public-read --copy-props none --metadata-directive COPY

--- a/terraform/environments/main/s3.tf
+++ b/terraform/environments/main/s3.tf
@@ -1,0 +1,33 @@
+resource "aws_s3_bucket" "snapshots_archive" {
+  bucket = "9c-snapshots-archive"
+}
+
+resource "aws_s3_bucket_public_access_block" "snapshots_archive" {
+  bucket = aws_s3_bucket.snapshots_archive.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "snapshots_archive" {
+  bucket = aws_s3_bucket.snapshots_archive.id
+
+  rule {
+    id     = "expire-after-91d"
+    status = "Enabled"
+
+    filter {
+      prefix = "main/"
+    }
+
+    expiration {
+      days = 91
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `9c-snapshots-archive` 버킷에 **Expiration.Days=91** lifecycle 룰 추가 (Terraform)
- 업로드 스크립트에서 아카이브 대상은 **GLACIER_IR**로 직접 PUT (aws-cli + rclone 양쪽)

IR 최소 보관 90일을 충족하면서 91일 후 만료 → **페널티 0 + 비용 최소**.

### 비용 영향 (Steady state)
- Before: 무한 누적 (현 23.89 TB, $0.004/GB/월 = ~$96/월, 계속 증가)
- After: 최근 91일치만 유지, 월 ~$32

### 각 객체 그룹 처리
| 그룹 | Storage | 만료 | 페널티 |
|---|---|---|---|
| 기존 IR 23.89 TB (2026-03-31 생성) | GLACIER_IR | 2026-06-30 | 없음 (IR 90일 충족) |
| 4/2 이후 STANDARD | STANDARD | creation+91일 | 없음 (STANDARD 최소 없음) |
| 신규 업로드 (머지 이후) | GLACIER_IR | creation+91일 | 없음 |

## ⚠️ Terraform apply caveat
`terraform/environments/main/` state에 **선존재 drift 있음** (51 add, 12 change, 1 destroy). 일반 `terraform apply` 실행 시 EKS/NAT/node groups 재생성 시도 위험. **반드시 `-target` 사용**.

이미 이 PR의 lifecycle 리소스는 `-target`으로 apply 완료 상태:
\`\`\`
aws_s3_bucket_lifecycle_configuration.snapshots_archive  # 113th state object
Rules[0].Expiration.Days = 91, Filter.Prefix = "main/"
\`\`\`

검증:
\`\`\`bash
aws s3api get-bucket-lifecycle-configuration --bucket 9c-snapshots-archive
\`\`\`

## Chart 배포
- \`charts/snapshot/\` (현재 운영): 머지 후 ArgoCD가 ConfigMap sync → 다음 CronJob부터 IR로 업로드
- \`charts/all-in-one/\` (미래 마이그레이션): rclone \`[s3]\` 프로파일에 \`storage_class = GLACIER_IR\` 선반영

## Test plan
- [x] `terraform plan -target=...` 로 1 add만 확인
- [x] 저장된 plan apply, lifecycle 룰 AWS 반영 확인
- [ ] ArgoCD sync 후 다음 snapshot-partition CronJob 실행 로그 확인
- [ ] CronJob 완료 후 신규 업로드 객체 StorageClass = GLACIER_IR 확인
  \`\`\`bash
  aws s3api list-objects-v2 --bucket 9c-snapshots-archive \
    --prefix main/partition/archive/snapshots/ \
    --query "reverse(sort_by(Contents,&LastModified))[0:3].{Key:Key,Storage:StorageClass}"
  \`\`\`
- [ ] 2026-06-30 경 기존 IR 23.89 TB 일괄 만료 확인 (객체 수 대폭 감소)
- [ ] Cost Explorer에서 \`GIR-EarlyDelete\` 청구 없는지 확인

## Follow-up (별도 이슈)
- terraform state drift 근본 해결 (이번 PR 범위 외)
- 버킷 versioning / SSE / ownership 명시적 Terraform 선언

🤖 Generated with [Claude Code](https://claude.com/claude-code)