### PR TITLE
chore(ragnarok-breaker): bump staging + production image to git-b3cf480

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -2,7 +2,7 @@ externalSecretKey: ragnarok-breaker/staging
 
 image:
   repository: planetariumhq/ragnarok-breaker-worker
-  tag: git-50966c946b635489c9adbc2b6bf71836d825e02e
+  tag: git-b3cf4800925e0ebb1dd422c5d46928d2e0934000
 
 imagePullSecret:
   secretKey: ragnarok-breaker/dockerhub

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -2,7 +2,7 @@ externalSecretKey: ragnarok-breaker/production
 
 image:
   repository: planetariumhq/ragnarok-breaker-worker
-  tag: git-50966c946b635489c9adbc2b6bf71836d825e02e
+  tag: git-b3cf4800925e0ebb1dd422c5d46928d2e0934000
 
 imagePullSecret:
   secretKey: ragnarok-breaker/dockerhub


### PR DESCRIPTION
Pin ragnarok-breaker-worker image to `git-b3cf4800925e0ebb1dd422c5d46928d2e0934000` for staging + production.

## Test plan
- [ ] After sync, workers pull the pinned image successfully