### PR TITLE
chore(ragnarok-breaker): pin staging image to git-1b96071

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -2,7 +2,7 @@ externalSecretKey: ragnarok-breaker/staging
 
 image:
   repository: planetariumhq/ragnarok-breaker-worker
-  tag: git-2eb0c3c673649a2fedf8cb36fe98d654ef6f8990
+  tag: git-1b9607105dce45e6b945ce89d2a2387fb1054936
 
 imagePullSecret:
   secretKey: ragnarok-breaker/dockerhub


### PR DESCRIPTION
Pin ragnarok-breaker-worker image to `git-1b9607105dce45e6b945ce89d2a2387fb1054936` for staging.

## Test plan
- [ ] After sync, pods pull the pinned image successfully