### PR TITLE
chore(odin): migrate snapshot-partition to baremetal-1

### DIFF
--- a/9c-main/network/odin.yaml
+++ b/9c-main/network/odin.yaml
@@ -85,11 +85,12 @@ snapshot:
 
   partition:
     enabled: true
+    schedule: "0 0 */3 * *"
     suspend: false
     zstd: false
     volume:
       create: false
-      name: remote-headless-data-5-remote-headless-5-0
+      name: snapshot-partition-data-baremetal
     dp:
       enabled: false
 
@@ -97,15 +98,19 @@ snapshot:
     requests:
       cpu: "5"
       memory: 28Gi
+    limits:
+      memory: 32Gi
 
   uploadResources:
     requests:
       cpu: "1"
       memory: 4Gi
+    limits:
+      memory: 6Gi
 
   nodeSelector:
-    node.kubernetes.io/network: odin
-    node.kubernetes.io/node-index: '5'
+    node.kubernetes.io/type: baremetal
+    node.kubernetes.io/node-index: '1'
 
 # if you want to delete PVC with the volume provisioned together, set this value "Delete"
 volumeReclaimPolicy: "Retain"


### PR DESCRIPTION
## Summary

- Move odin `snapshot-partition` CronJob from **odin-5 (CloudV VM)** to **baremetal-1 (iwinV)**
- Change schedule from `0 0 */2 * *` (매 2일) → `0 0 */3 * *` (매 3일), 잡 전체 사이클이 52h라 3일 주기가 안전
- Reference a new PVC `snapshot-partition-data-baremetal` (pre-created, Ceph RBD backed, `odin-snapshot-baremetal-longhorn` storageClass)
- Add `resources.limits.memory: 32Gi` + `uploadResources.limits.memory: 6Gi` for node protection

## Why

**비용 절감:**
- odin-5 폐기 시 약 **월 218만원 절감** (단일 VM 청구액 1위)
- R2 업로드가 iwinV → 사내 네트워크 경유로 전환 (CloudV 400원/GB 트래픽 제거, 월 ~1.6M원 절감 기대)

**트레이드오프:**
- baremetal-1의 `/data`는 Ceph RBD(smile_pool)로 네트워크 블록 스토리지. 이로 인해 CopyStates가 odin-5 대비 7배 느림
- E2E 검증(test-run-v3, odin-snapshot-test namespace) 결과:
  - preload 3h 38m
  - create-snapshot **44h 09m** (odin-5 6h 20m 대비 7배)
  - upload 4h 35m
  - **총 52h 22m**, exitCode 0, R2 업로드 정상 (`main/partition-test/` 경로로 검증)
- 3일 주기 = 72h 이므로 52h 잡이 충분히 들어감

## PR 머지 전 사전 작업 (수동)

1. **기존 odin-5 CronJob suspend**
   ```bash
   kubectl -n odin patch cronjob snapshot-partition -p '{"spec":{"suspend":true}}'
   kubectl -n odin delete jobs -l app=snapshot-partition --ignore-not-found
   ```

2. **테스트 PVC 데이터 odin namespace로 이관** (preload 시간 3h → 30min 단축)
   ```bash
   PV=pvc-ef28e9b7-b3ea-46d3-9f1c-fd4b0ca032a0
   kubectl patch pv $PV -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
   kubectl -n odin-snapshot-test delete pvc snapshot-test-data
   kubectl delete ns odin-snapshot-test
   kubectl patch pv $PV --type json -p='[{"op": "remove", "path": "/spec/claimRef"}]'
   cat <<YAML | kubectl apply -f -
   apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     name: snapshot-partition-data-baremetal
     namespace: odin
   spec:
     accessModes: [ReadWriteOnce]
     resources:
       requests: { storage: 650Gi }
     storageClassName: odin-snapshot-baremetal-longhorn
     volumeName: $PV
   YAML
   kubectl -n odin get pvc snapshot-partition-data-baremetal   # Bound 확인
   ```

3. **기존 data-5 PVC/Longhorn volume 삭제**
   ```bash
   PVC=remote-headless-data-5-remote-headless-5-0
   OLDPV=$(kubectl -n odin get pvc $PVC -o jsonpath='{.spec.volumeName}')
   kubectl -n odin delete pvc $PVC
   kubectl delete pv $OLDPV
   kubectl -n longhorn-system delete volumes.longhorn.io $OLDPV
   ```

## 머지 후 절차

1. ArgoCD sync 확인 (현재 manual sync 운영)
2. 즉시 수동 트리거로 첫 잡 검증:
   ```bash
   kubectl -n odin create job --from=cronjob/snapshot-partition baremetal-migration-1
   ```
3. 52h 동안 모니터링 (phase 진행, `/data/headless/new_states` 크기, R2 업로드)
4. Slack `9c-mainnet` 채널 성공 알림 확인

## 이후 작업 (별도 PR/작업)

- odin-5 노드 drain + delete (이 PR의 2회 성공 후 1주일 관측 뒤)
- CloudV VM 해지
- `9c-main/network/odin.yaml` 의 `RKE2.loadBalancerIPs` 목록에서 odin-5 IP 제거 (있는 경우)
- `global.storage` 배열에서 `remote-headless-data-5-remote-headless-5-0` 엔트리 제거
- pt6(사내 물리 서버) 이전으로 CopyStates 추가 단축 (Phase 5 of plan)

## Test plan
- [x] E2E 테스트 (odin-snapshot-test namespace, 52h 22m 완주, R2 업로드 성공)
- [x] PVC 이관 후 bound 확인
- [ ] 수동 트리거 첫 잡 preload <1h (tip 근처면)
- [ ] create-snapshot 44h 내외 완료
- [ ] R2 `main/partition/` 업로드 성공
- [ ] Slack 성공 알림 수신
- [ ] baremetal-1 기존 워크로드(heimdall snapshot 등) 영향 없음
- [ ] 2회차 정기 잡(D+3) 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)