### PR TITLE
fix(snapshot): keep create_snapshot sentinel in sync with output files

### DIFF
--- a/charts/all-in-one/scripts/snapshots/partition/create_snapshot.sh
+++ b/charts/all-in-one/scripts/snapshots/partition/create_snapshot.sh
@@ -25,14 +25,21 @@ function senderr() {
     --data '{"text":"[K8S] '"$1"'. Check snapshot in {{ $.Values.clusterName }} cluster at create_snapshot.sh."}' "$SLACK_WEBHOOK"
 }
 
-# Skip if recent snapshot already exists (restart safety for initContainer restarts)
+# Skip if recent snapshot already exists (restart safety for initContainer restarts).
+# Require both sentinel freshness AND actual output files on disk — sentinel alone
+# can lie when a prior upload ran with PRESERVE_PARTITIONS=false, which deletes the
+# snapshot files but leaves the sentinel behind, causing the next run to skip
+# create_snapshot and then fail in upload_snapshot with "No snapshot files found".
 if [ -f "$SENTINEL" ]; then
   created_at=$(cat "$SENTINEL")
   now=$(date +%s)
   age=$(( now - created_at ))
-  if [ "$age" -lt 43200 ]; then
-    echo "[INFO] Recent snapshot exists (${age}s ago), skipping creation."
+  if [ "$age" -lt 43200 ] && ls "$PARTITION_DIR"/*.z* >/dev/null 2>&1 && ls "$STATE_DIR"/*.z* >/dev/null 2>&1; then
+    echo "[INFO] Recent snapshot exists (${age}s ago) with files, skipping creation."
     exit 0
+  elif [ "$age" -lt 43200 ]; then
+    echo "[WARN] Sentinel is fresh (${age}s) but output files missing; running create_snapshot anyway."
+    rm -f "$SENTINEL"
   fi
 fi
 

--- a/charts/all-in-one/scripts/snapshots/partition/upload_snapshot.sh
+++ b/charts/all-in-one/scripts/snapshots/partition/upload_snapshot.sh
@@ -210,6 +210,9 @@ function make_and_upload_snapshot() {
 
   if [ "$PRESERVE_PARTITIONS" = "false" ]; then
     rm "$LATEST_SNAPSHOT" "$LATEST_STATE" "$LATEST_METADATA"
+    # Sentinel tracks whether output files are present; clear it alongside files
+    # so a subsequent create_snapshot run does not incorrectly skip as "recent".
+    rm -f "$OUTPUT_DIR/.snapshot-created"
   fi
   rm -rf "$METADATA_DIR"
 }


### PR DESCRIPTION
## Summary

Fix a bug where the `create_snapshot` sentinel file (`/data/snapshots/.snapshot-created`) could out-live the actual snapshot output files, causing `create_snapshot` to skip work and `upload_snapshot` to then CrashLoopBackOff while spamming Slack with *"No snapshot files found in /data/snapshots/partition. Was create_snapshot step completed?"*

## Root cause

- `create_snapshot.sh` writes the sentinel when it finishes, and on restart it skips creation if the sentinel is < 12h old.
- `upload_snapshot.sh` deletes the output `.zip` files after uploading (`PRESERVE_PARTITIONS=false`, the default), but leaves the sentinel untouched.
- Any follow-up run that reuses the same volume within 12h (e.g. a manual trigger, PVC migration, node move) sees a fresh sentinel, skips `create_snapshot`, and then fails at `upload_snapshot` because the partition directory is empty.

Observed this today on `odin/snapshot-partition-2604210937` after migrating the test-run-v3 volume into the production namespace: preload succeeded, `create_snapshot` skipped (sentinel was 10.7h old), and `upload_snapshot` CrashLoopBackOff'd 5 times, sending 5 "No snapshot files found" messages to `#9c-mainnet` before the job was deleted.

## Changes

1. **`upload_snapshot.sh`** — remove the sentinel alongside the files when `PRESERVE_PARTITIONS=false`. The sentinel only makes sense while the files it represents are on disk.
2. **`create_snapshot.sh`** — require both a fresh sentinel AND actual `.z*` files in `partition/` and `state/` before skipping. If the sentinel is fresh but the files are missing, proceed with creation (and clear the sentinel so a retry is idempotent).

## Test plan

- [x] Reproduced the failure mode on `odin/snapshot-partition-2604210937` (CrashLoopBackOff + 5 Slack alerts)
- [x] Manual recovery: delete broken job + sentinel + recreate — works
- [ ] With this fix deployed: simulate the scenario (leave stale sentinel + empty partition dir, run job) and verify it proceeds to create_snapshot instead of skipping
- [ ] Verify `heimdall` snapshot jobs continue to work unchanged (same script, same flow, just now cleaner)

## Scope

Touches only `charts/all-in-one/scripts/snapshots/partition/{create,upload}_snapshot.sh`. All planets (odin, heimdall, internal) share this chart and will receive the fix on sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)