### PR TITLE
fix(portal): remove broken nodeSelector blocking 9c-internal portal pods

### DIFF
--- a/9c-internal/portal/values.yaml
+++ b/9c-internal/portal/values.yaml
@@ -5,9 +5,6 @@ portalService:
   service:
     type: ClusterIP
     port: 3000
-  nodeSelector:
-    node.kubernetes.io/type: general
-    node.kubernetes.io/node-index: "2"
   image:
     repository: planetariumhq/9c-portal
     tag: "internal-latest"
@@ -32,9 +29,6 @@ backofficeService:
   service:
     type: ClusterIP
     port: 3001
-  nodeSelector:
-    node.kubernetes.io/type: general
-    node.kubernetes.io/node-index: "2"
   image:
     repository: planetariumhq/9c-portal-backoffice
     tag: "internal-latest"


### PR DESCRIPTION
## Summary
- PR #3319 added `nodeSelector: {type=general, node-index="2"}` to `portal` and `backoffice` in `9c-internal/portal/values.yaml`, but no node in 9c-internal carries that combination — `type=general` lives only on `localhost` (node-index=1), and `node-index=2` is on `9c-internal-2` which has no `type` label.
- The selector has matched zero nodes since PR #3319 merged on 2026-04-06. Old pods scheduled before the merge kept the service alive, masking the issue.
- New ReplicaSets accumulated FailedScheduling: `portal-backoffice` was Pending for 20 days (6,030 events); `portal` got stuck on today's image rehash.
- Removing the selector restores pre-#3319 behavior. Verified by patching live deployments — `portal` rescheduled to `localhost` immediately, backoffice's stuck RS settled with the existing Running pod.

## Why this is the right fix
- Author of #3319 likely intended to pin to a "general" worker, but the only `type=general` node is `node-index=1`. The selector should have been `node-index="1"` or `type: general` alone. Removing both reverts to the working pre-#3319 state and matches all other 9c-internal apps that don't constrain placement.
- If pinning is desired later, follow-up PR can re-add `type: general` only.

## Test plan
- [x] Confirmed pod schedules after manual nodeSelector removal on live deployments
- [ ] ArgoCD `portal` app on 9c-internal goes Synced/Healthy after merge
- [ ] No new FailedScheduling events for portal/backoffice ReplicaSets

🤖 Generated with [Claude Code](https://claude.com/claude-code)