### PR TITLE
revert(all-in-one): roll ExternalSecret API back to v1beta1

### DIFF
--- a/charts/all-in-one/templates/secret-arena.yaml
+++ b/charts/all-in-one/templates/secret-arena.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.arenaService.enabled }}
 {{ if .Values.externalSecret.enabled }}
-apiVersion: "external-secrets.io/v1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: arena

--- a/charts/all-in-one/templates/secret-aws-keys.yaml
+++ b/charts/all-in-one/templates/secret-aws-keys.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.externalSecret.enabled }}
-apiVersion: "external-secrets.io/v1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: aws-keys

--- a/charts/all-in-one/templates/secret-bridge-env.yaml
+++ b/charts/all-in-one/templates/secret-bridge-env.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.bridgeService.enabled }}
 {{ if .Values.externalSecret.enabled }}
-apiVersion: "external-secrets.io/v1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: bridge-env

--- a/charts/all-in-one/templates/secret-bridge-service-api.yaml
+++ b/charts/all-in-one/templates/secret-bridge-service-api.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.bridgeServiceApi.enabled }}
-apiVersion: "external-secrets.io/v1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: bridge-service-api

--- a/charts/all-in-one/templates/secret-bridge.yaml
+++ b/charts/all-in-one/templates/secret-bridge.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.bridge.enabled }}
 {{ if .Values.externalSecret.enabled }}
-apiVersion: "external-secrets.io/v1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: bridge

--- a/charts/all-in-one/templates/secret-data-provider.yaml
+++ b/charts/all-in-one/templates/secret-data-provider.yaml
@@ -1,6 +1,6 @@
 {{ if or .Values.dataProvider.enabled (and .Values.snapshot.partition.enabled .Values.snapshot.partition.dp.enabled) }}
 {{ if .Values.externalSecret.enabled }}
-apiVersion: "external-secrets.io/v1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: data-provider

--- a/charts/all-in-one/templates/secret-iap.yaml
+++ b/charts/all-in-one/templates/secret-iap.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.externalSecret.enabled }}
 {{ if .Values.iap.backoffice.enabled }}
-apiVersion: "external-secrets.io/v1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: iap-env

--- a/charts/all-in-one/templates/secret-market-db.yaml
+++ b/charts/all-in-one/templates/secret-market-db.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.marketService.enabled }}
 {{ if .Values.externalSecret.enabled }}
-apiVersion: "external-secrets.io/v1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: market-db

--- a/charts/all-in-one/templates/secret-mimir.yaml
+++ b/charts/all-in-one/templates/secret-mimir.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.mimir.enabled }}
 {{ if .Values.externalSecret.enabled }}
-apiVersion: "external-secrets.io/v1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: mimir

--- a/charts/all-in-one/templates/secret-private-keys.yaml
+++ b/charts/all-in-one/templates/secret-private-keys.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.externalSecret.enabled }}
-apiVersion: "external-secrets.io/v1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: private-keys

--- a/charts/all-in-one/templates/secret-rudolf-service.yaml
+++ b/charts/all-in-one/templates/secret-rudolf-service.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.rudolfService.enabled }}
-apiVersion: "external-secrets.io/v1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: rudolf-service

--- a/charts/all-in-one/templates/secret-slack-token.yaml
+++ b/charts/all-in-one/templates/secret-slack-token.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.externalSecret.enabled }}
-apiVersion: "external-secrets.io/v1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: slack

--- a/charts/all-in-one/templates/secret-state-migration.yaml
+++ b/charts/all-in-one/templates/secret-state-migration.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.stateMigrationService.enabled }}
 {{ if .Values.externalSecret.enabled }}
-apiVersion: "external-secrets.io/v1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: state-migration

--- a/charts/all-in-one/templates/secret-store.yaml
+++ b/charts/all-in-one/templates/secret-store.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.externalSecret.enabled }}
 {{- $provider := ($.Values.externalSecret.provider | default $.Values.provider) }}
-apiVersion: "external-secrets.io/v1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: SecretStore
 metadata:
   name: {{ $.Release.Name }}-secretsmanager

--- a/charts/all-in-one/templates/secret-world-boss.yaml
+++ b/charts/all-in-one/templates/secret-world-boss.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.worldBoss.enabled }}
 {{ if .Values.externalSecret.enabled }}
-apiVersion: "external-secrets.io/v1"
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: world-boss-env


### PR DESCRIPTION
## Summary
- Reverts 3143c09d (part of #3362). That commit bumped ExternalSecret/SecretStore to `external-secrets.io/v1` claiming ESO v0.12.x served it — that was wrong.
- Both 9c-main (rke2-main) and 9c-internal (rke2) run **ESO v0.12.1**, whose CRD only serves `v1alpha1` and `v1beta1`. ArgoCD sync now fails with `Resource not found in cluster: external-secrets.io/v1/ExternalSecret:arena` and similar for every secret in odin/heimdall/thor.
- Affected on 9c-main: odin, heimdall, thor, shared-services, 9c-external-services, batch-jobs, loki, prometheus, bootstrap (all OutOfSync as of 2026-04-28).
- pt6 ESO is v2.3.0 and still serves v1beta1, so this revert is compatible across all three clusters.

## Path forward
Separate PR will upgrade 9c-main / 9c-internal ESO past v0.13 (which makes v1 the default served version). After that, the v1 bump can be reapplied cleanly.

## Test plan
- [ ] After merge, run ArgoCD sync on 9c-main odin and confirm ExternalSecrets sync clean (no `not found in cluster` errors)
- [ ] Same for heimdall, thor, batch-jobs
- [ ] Confirm pt6 odin still syncs (ESO v2.3.0 accepts v1beta1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)