### PR TITLE
fix(pt6): isolate child Application name + bootstrap valueFiles typo

### DIFF
--- a/9c-pt6/bootstrap.yaml
+++ b/9c-pt6/bootstrap.yaml
@@ -15,5 +15,5 @@ spec:
     path: charts/multiplanetary
     targetRevision: main
     helm:
-      valuesFiles:
+      valueFiles:
         - /9c-pt6/multiplanetary.yaml

--- a/9c-pt6/multiplanetary.yaml
+++ b/9c-pt6/multiplanetary.yaml
@@ -2,6 +2,11 @@ targetRevision: main
 path: 9c-pt6
 destinationName: 9c-pt6
 
+# 9c-main 의 bootstrap 이 이미 `odin` 이라는 이름의 Application 을 같은 argocd
+# 네임스페이스에 만들기 때문에 prefix 로 격리. 이 prefix 가 없으면 두 Application
+# 이 같은 이름으로 충돌해 SharedResourceWarning 발생.
+applicationNamePrefix: pt6-
+
 # Inherit 9c-main odin base values (image tags, appProtocolVersion,
 # peerStrings, etc.) so RH image bumps propagate without touching pt6 files.
 # Per-path files (9c-pt6/network/{general,odin}.yaml) override specifics.

--- a/charts/multiplanetary/templates/network.yaml
+++ b/charts/multiplanetary/templates/network.yaml
@@ -11,7 +11,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: {{ $name }}
+  name: {{ printf "%s%s" ($.Values.applicationNamePrefix | default "") $name }}
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/charts/multiplanetary/values.yaml
+++ b/charts/multiplanetary/values.yaml
@@ -9,5 +9,11 @@ destinationName: ""
 # existing cluster directory and only override specific keys.
 sharedValueFiles: []
 
+# Optional prefix prepended to the generated child Application name. Required
+# when an overlay cluster reuses a network identifier (e.g. "odin") that is
+# already managed by another bootstrap on the same Argo CD instance, to avoid
+# Application-name collisions in the argocd namespace.
+applicationNamePrefix: ""
+
 network:
   - "sample1"


### PR DESCRIPTION
## Summary
- After #3363 merged, applying `9c-pt6/bootstrap.yaml` on 9c-main argocd produced a SharedResourceWarning on Application/odin and the manifest itself was rejected by kubectl due to a typo. This PR fixes both.

### Bug 1: child Application name collision
`charts/multiplanetary/templates/network.yaml` names children with the bare network id (`odin`). 9c-main's existing bootstrap already owns Application/odin in the argocd namespace, so `bootstrap-pt6` would conflict with it on sync — and worse, syncing would overwrite the mainnet odin destination.

Fix: add optional `applicationNamePrefix` to multiplanetary values. When set (only on pt6 today), it's prepended to the rendered Application name. 9c-main behaviour unchanged.

### Bug 2: `valuesFiles` typo
`9c-pt6/bootstrap.yaml` used `helm.valuesFiles` instead of `helm.valueFiles`. `kubectl apply` rejects with strict-decoding error.

## Verification
```
$ helm template charts/multiplanetary -f 9c-pt6/multiplanetary.yaml | grep "^  name:"
  name: pt6-odin
```

Tested by re-rendering — child Application renders as `pt6-odin`, isolated from 9c-main's `odin`.

## Test plan
- [ ] After merge, re-apply `9c-pt6/bootstrap.yaml` on 9c-main argocd
- [ ] `kubectl --context default -n argocd get applications | grep pt6` shows `bootstrap-pt6` and `pt6-odin`
- [ ] No SharedResourceWarning on either bootstrap-pt6 or the existing bootstrap
- [ ] 9c-main's `odin` Application unaffected (destination still in-cluster)

## Operational note
Currently `bootstrap-pt6` from a prior apply attempt is sitting OutOfSync on 9c-main argocd. After merge, ArgoCD will reconcile it to the new manifest (child becomes `pt6-odin`); only then is it safe to sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)