### PR TITLE
feat(snapshot): cut over odin partition snapshots from baremetal-1 to pt6

### DIFF
--- a/9c-main/network/odin.yaml
+++ b/9c-main/network/odin.yaml
@@ -84,7 +84,7 @@ snapshot:
     enabled: false
 
   partition:
-    enabled: true
+    enabled: false
     schedule: "0 0 */3 * *"
     suspend: false
     zstd: false

--- a/9c-pt6/network/odin.yaml
+++ b/9c-pt6/network/odin.yaml
@@ -105,9 +105,7 @@ dataProviderDataMigrator:
 snapshot:
   slackChannel: "9c-mainnet"
   sourceLabel: "pt6"
-  # Publish to a test prefix during parallel validation against baremetal-1.
-  # Cut over to "main/partition" in a follow-up PR once outputs are verified.
-  path: "main/partition-pt6"
+  path: "main/partition"
 
   fullSnapshot:
     enabled: false


### PR DESCRIPTION
## Summary
pt6 has been producing daily snapshots to `main/partition-pt6` alongside baremetal-1's `main/partition` for the validation period. Outputs verified equivalent — switching pt6 to the production prefix and disabling baremetal-1's partition CronJob.

- `9c-pt6/network/odin.yaml`: `snapshot.path` `main/partition-pt6` → `main/partition`
- `9c-main/network/odin.yaml`: `snapshot.partition.enabled` `true` → `false`

## Effect after ArgoCD sync
- **9c-main odin**: baremetal-1 `snapshot-partition` CronJob is removed; any in-flight Job is pruned. PVC `snapshot-partition-data-baremetal` and node-label remain so we could re-enable in an emergency.
- **pt6 odin**: next 00:00 UTC run uploads to `main/partition` (production prefix). External consumers (`https://snapshots.nine-chronicles.com/main/partition/...`) start serving pt6 output.

## Dependency / merge order
1. **First merge #3370** (multiplanetary `applicationNamePrefix`). Without it, the existing `bootstrap-pt6` Application on 9c-main argocd will continue to collide with the existing `odin` Application on sync.
2. **Then merge this PR.**
3. Sync `bootstrap-pt6` (now produces `pt6-odin`).
4. Lift the existing CronJob suspend on pt6: `kubectl -n odin patch cronjob snapshot-partition -p '{"spec":{"suspend":false}}'` (or let ArgoCD recreate it from the chart with suspend off).
5. Sync `9c-main` odin Application — baremetal-1 CronJob disappears.

## Operational notes
- A baremetal-1 partition Job started ~3h ago (estimated 52h E2E) is currently running. ArgoCD prune on sync will delete it mid-flight — acceptable since pt6 will produce the next snapshot at 00:00 UTC and the production `latest.json` stays at the most recent successful baremetal-1 output until then.
- If anything goes wrong with pt6's first production run, revert this PR and resync.

## Test plan
- [ ] After both merges and syncs, confirm `kubectl --context default -n odin get cronjob snapshot-partition` returns NotFound
- [ ] Confirm pt6 cron triggers at 00:00 UTC (next run)
- [ ] `curl -sI https://snapshots.nine-chronicles.com/main/partition/latest.json` Last-Modified updates within 8h of trigger
- [ ] Slack alert in `#9c-mainnet` carries `[pt6]` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)