### PR TITLE
fix(multiplanetary): pin helm releaseName to keep namespaces unprefixed

### DIFF
--- a/charts/multiplanetary/templates/network.yaml
+++ b/charts/multiplanetary/templates/network.yaml
@@ -22,6 +22,7 @@ spec:
     targetRevision: {{ $.Values.targetRevision | default "main" }}
     path: charts/all-in-one
     helm:
+      releaseName: {{ $name }}
       valueFiles:
       {{- range $f := $.Values.sharedValueFiles }}
       - {{ $f }}


### PR DESCRIPTION
## Summary
After #3370 added `applicationNamePrefix`, the rendered Application name becomes e.g. `pt6-odin`. ArgoCD then defaults the helm release name to that same `pt6-odin`, which leaks into `{{ .Release.Name }}` references throughout `charts/all-in-one`. Several manifests (secret-aws-keys, secret-store, secret-private-keys, …) use `namespace: {{ .Release.Name }}`, so resources land in a `pt6-odin` namespace instead of `odin`.

This was caught when bootstrap-pt6 sync produced ConfigMaps, Secrets, ExternalSecrets, and the snapshot CronJob in a `pt6-odin` namespace on the pt6 cluster.

## Fix
Pin `helm.releaseName: {{ $name }}` (the bare network id) so the helm release name stays `odin` regardless of the Application name. The Application metadata.name still uses applicationNamePrefix to avoid the SharedResourceWarning collision from #3370.

## Verification
```
$ helm template charts/multiplanetary -f 9c-pt6/multiplanetary.yaml
  name: pt6-odin            # Application metadata.name (prefixed)
  namespace: argocd
      releaseName: odin     # helm release name (unprefixed)
    namespace: odin         # Application destination
```

## Cleanup after merge
1. Sync `pt6-odin` Application — resources now generated for `odin` namespace on pt6.
2. Manually clean up the wrongly-created `pt6-odin` namespace on the pt6 cluster (ConfigMaps, Secrets, ExternalSecret, SecretStore, CronJob, Namespace itself).

## No effect on existing clusters
9c-main and 9c-internal don't set `applicationNamePrefix`, so their Application names equal the network id and `Release.Name` was already that. Behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)