### PR TITLE
feat(all-in-one): add externalSecret.privateKeys.enabled toggle

### DIFF
--- a/9c-pt6/network/general.yaml
+++ b/9c-pt6/network/general.yaml
@@ -5,6 +5,11 @@ externalSecret:
   enabled: true
   provider: AWS
   prefix: "9c-main-v2"
+  # pt6 runs no validator/seed/jwt-headless, so the private-keys Secret has
+  # no consumer. Suppress its rendering to avoid a SecretSyncedError on the
+  # IAM role (least-privilege policy excludes 9c-main-v2/private-keys).
+  privateKeys:
+    enabled: false
 
 # pt6 is a standalone single-node cluster; MetalLB-backed load balancers
 # from 9c-main are not reachable. Override to empty.

--- a/charts/all-in-one/templates/secret-private-keys.yaml
+++ b/charts/all-in-one/templates/secret-private-keys.yaml
@@ -1,3 +1,5 @@
+{{- $pkEnabled := dig "privateKeys" "enabled" true .Values.externalSecret -}}
+{{- if $pkEnabled }}
 {{ if .Values.externalSecret.enabled }}
 apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
@@ -40,3 +42,4 @@ stringData:
   {{- end }}
 type: Opaque
 {{ end }}
+{{- end }}

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -57,6 +57,11 @@ externalSecret:
   prefix: ""
   separator: /
   provider: ""
+  # Per-secret render toggles (default true). Set false to suppress that
+  # specific Secret/ExternalSecret manifest, useful when a cluster does not
+  # run any consumer of the secret (e.g. snapshot-only deployments).
+  privateKeys:
+    enabled: true
 
 snapshot:
   downloadSnapshot: false


### PR DESCRIPTION
## Summary
The chart unconditionally renders a `private-keys` Secret/ExternalSecret for every cluster. On pt6 (snapshot-only, no validator/seed/jwt-headless consumer) this produces a `SecretSyncedError` because the IAM role's least-privilege policy excludes `9c-main-v2/private-keys`.

This PR adds `externalSecret.privateKeys.enabled` (default true) and gates the template on it. Disabled on pt6.

## Changes
- `charts/all-in-one/values.yaml`: new toggle (default true)
- `charts/all-in-one/templates/secret-private-keys.yaml`: gate on `dig "privateKeys" "enabled" true .Values.externalSecret`
- `9c-pt6/network/general.yaml`: set false

## Verification
```
$ helm template charts/all-in-one -f 9c-main/network/general.yaml -f 9c-main/network/odin.yaml | grep "name: private-keys" -B1 | head
                key: seed-private-key-1
                name: private-keys
                key: jwt
                name: private-keys

$ helm template charts/all-in-one -f 9c-main/... -f 9c-pt6/network/general.yaml -f 9c-pt6/network/odin.yaml | grep -c "name: private-keys"
0
```

9c-main / 9c-internal unchanged (default true). pt6 no longer renders the manifest.

## Effect after merge
- pt6 ArgoCD sync prunes `private-keys` ExternalSecret/Secret on pt6's `odin` namespace.
- ArgoCD Application `pt6-odin` returns to Healthy (was Degraded due to private-keys SecretSyncedError).

🤖 Generated with [Claude Code](https://claude.com/claude-code)