### PR TITLE
fix(cert): drop nine-chronicles.dev to unstick LE renewal

### DIFF
--- a/9c-main/values.yaml
+++ b/9c-main/values.yaml
@@ -23,8 +23,6 @@ certManager:
   dnsNames:
     - "nine-chronicles.com"
     - "*.nine-chronicles.com"
-    - "nine-chronicles.dev"
-    - "*.nine-chronicles.dev"
     - "*.planetarium.network"
     - "*.planetarium.team"
     - "*.9c.gg"


### PR DESCRIPTION
## Summary
LE cert in `traefik/certificate-secret` expires **2026-05-10** (12 days). cert-manager's renewal has been stuck for 20 days at:

```
Reason: Waiting for HTTP-01 challenge propagation:
        wrong status code '404', expected '200'
DnsName: nine-chronicles.dev
```

All other authorizations are valid; only `nine-chronicles.dev` blocks the order.

## Root cause
`nine-chronicles.dev` DNS is fronted by Cloudflare (proxy on — anycast `104.21.19.142` / `172.67.186.123`). HTTP-01 traffic never reaches baremetal-1, so cert-manager's solver Ingress at `nine-chronicles.dev` returns 404 from Cloudflare. The `.dev` SAN was added to dnsNames without configuring DNS-01 or disabling the proxy.

## Fix
Drop `nine-chronicles.dev` and `*.nine-chronicles.dev` from `9c-main/values.yaml` certManager.dnsNames. Next CertificateRequest covers only domains that resolve straight to baremetal-1 → fresh cert issued before expiry.

## Impact verification
- **End-user traffic to `*.nine-chronicles.dev`** (e.g. `9c-board.nine-chronicles.dev`): No change. Cloudflare presents its own Universal SSL cert (Google Trust Services).
- **Cloudflare ↔ origin**: Verified to be Full (Non-strict) or Flexible — origin currently presents a cert *without* `nine-chronicles.dev` SAN and `https://9c-board.nine-chronicles.dev` still returns HTTP 200. SAN mismatch is already tolerated.
- **Direct origin TLS hits**: nobody hits the origin IP directly under `nine-chronicles.dev` (DNS only points to Cloudflare).

## Reversibility
Fully reversible — adding the lines back via PR restores the previous state. To avoid the same stuck order, the revert PR should also configure either:
- Cloudflare DNS-01 solver in `cert-manager-letsencrypt-issuer`, or
- Disable Cloudflare proxy for `nine-chronicles.dev`.

## Sync flow after merge
1. ArgoCD `bootstrap` Application reconciles the Certificate spec change.
2. cert-manager replaces the stuck CertificateRequest with a new one (8 dnsNames).
3. LE order completes quickly (other authorizations cached for 30 days).
4. `certificate-secret` updated; Traefik picks up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)