### PR TITLE
feat(ygg-gateway): add chart + staging/production deployments

### DIFF
--- a/9c-internal/ygg-gateway-staging/application.yaml
+++ b/9c-internal/ygg-gateway-staging/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ygg-gateway-staging
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/planetarium/9c-infra.git
+    targetRevision: main
+    path: charts/ygg-gateway
+    helm:
+      valueFiles:
+        - /9c-internal/ygg-gateway-staging/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ygg-gateway-staging
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/9c-internal/ygg-gateway-staging/values.yaml
+++ b/9c-internal/ygg-gateway-staging/values.yaml
@@ -1,0 +1,12 @@
+externalSecretKey: ygg-gateway/staging
+
+image:
+  tag: git-015c233d8a48c63292e6e565f5ea9639bec8f721
+
+imagePullSecret:
+  secretKey: ragnarok-breaker/dockerhub
+
+httpRoute:
+  enabled: true
+  hostnames:
+    - ygg-gateway-staging.9c.gg

--- a/9c-main/ygg-gateway-production/application.yaml
+++ b/9c-main/ygg-gateway-production/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ygg-gateway-production
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/planetarium/9c-infra.git
+    targetRevision: main
+    path: charts/ygg-gateway
+    helm:
+      valueFiles:
+        - /9c-main/ygg-gateway-production/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ygg-gateway
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/9c-main/ygg-gateway-production/values.yaml
+++ b/9c-main/ygg-gateway-production/values.yaml
@@ -1,0 +1,15 @@
+externalSecretKey: ygg-gateway/production
+
+image:
+  tag: git-015c233d8a48c63292e6e565f5ea9639bec8f721
+
+imagePullSecret:
+  secretKey: ragnarok-breaker/dockerhub
+
+deployment:
+  replicas: 2
+
+httpRoute:
+  enabled: true
+  hostnames:
+    - ygg-gateway.9c.gg

--- a/charts/ygg-gateway/Chart.yaml
+++ b/charts/ygg-gateway/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ygg-gateway
+description: Yggdrasil redemption gateway bridging YGG marketplace with Verse8 GameServer (Ragnarok Breaker)
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/charts/ygg-gateway/templates/deployment.yaml
+++ b/charts/ygg-gateway/templates/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ygg-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ygg-gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: ygg-gateway
+spec:
+  replicas: {{ .Values.deployment.replicas }}
+  selector:
+    matchLabels:
+      app: ygg-gateway
+  template:
+    metadata:
+      labels:
+        app: ygg-gateway
+    spec:
+      {{- if .Values.imagePullSecret.secretKey }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret.name }}
+      {{- end }}
+      containers:
+        - name: ygg-gateway
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.deployment.port }}
+          env:
+            - name: PORT
+              value: {{ .Values.deployment.port | quote }}
+          envFrom:
+            - secretRef:
+                name: ygg-gateway-env
+          livenessProbe:
+            {{- toYaml .Values.deployment.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.deployment.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.deployment.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always

--- a/charts/ygg-gateway/templates/httproute.yaml
+++ b/charts/ygg-gateway/templates/httproute.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.httpRoute.enabled .Values.httpRoute.hostnames }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ygg-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ygg-gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: ygg-gateway
+spec:
+  parentRefs:
+    - name: {{ .Values.httpRoute.gatewayName }}
+      namespace: {{ .Values.httpRoute.gatewayNamespace }}
+      sectionName: web
+    - name: {{ .Values.httpRoute.gatewayName }}
+      namespace: {{ .Values.httpRoute.gatewayNamespace }}
+      sectionName: websecure
+  hostnames:
+    {{- range .Values.httpRoute.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: ygg-gateway
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/ygg-gateway/templates/secrets.yaml
+++ b/charts/ygg-gateway/templates/secrets.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.externalSecretKey }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ygg-gateway-env
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: {{ .Release.Name }}-secretsmanager
+    kind: SecretStore
+  target:
+    name: ygg-gateway-env
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      key: {{ .Values.externalSecretKey }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: {{ .Release.Name }}-secretsmanager
+  namespace: {{ .Release.Namespace }}
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: us-east-2
+{{- end }}
+{{- if .Values.imagePullSecret.secretKey }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.imagePullSecret.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: {{ .Release.Name }}-secretsmanager
+    kind: SecretStore
+  target:
+    name: {{ .Values.imagePullSecret.name }}
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {"auths":{"{{ `{{ .registry }}` }}":{"username":"{{ `{{ .username }}` }}","password":"{{ `{{ .password }}` }}","auth":"{{ `{{ printf "%s:%s" .username .password | b64enc }}` }}"}}}
+  data:
+    - secretKey: registry
+      remoteRef:
+        key: {{ .Values.imagePullSecret.secretKey }}
+        property: registry
+    - secretKey: username
+      remoteRef:
+        key: {{ .Values.imagePullSecret.secretKey }}
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: {{ .Values.imagePullSecret.secretKey }}
+        property: password
+{{- end }}

--- a/charts/ygg-gateway/templates/service.yaml
+++ b/charts/ygg-gateway/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ygg-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ygg-gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: ygg-gateway
+spec:
+  type: ClusterIP
+  selector:
+    app: ygg-gateway
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.deployment.port }}
+      protocol: TCP

--- a/charts/ygg-gateway/values.yaml
+++ b/charts/ygg-gateway/values.yaml
@@ -1,0 +1,46 @@
+externalSecretKey: ""
+
+image:
+  repository: planetariumhq/ragnarok-breaker-ygg-gateway
+  tag: develop
+  pullPolicy: IfNotPresent
+
+imagePullSecret:
+  name: ygg-gateway-regcred
+  secretKey: ""
+
+service:
+  port: 8787
+
+deployment:
+  replicas: 1
+  port: 8787
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: 8787
+    initialDelaySeconds: 30
+    periodSeconds: 15
+    failureThreshold: 3
+  readinessProbe:
+    httpGet:
+      path: /healthz
+      port: 8787
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 3
+
+httpRoute:
+  enabled: false
+  hostnames: []
+  gatewayName: traefik-gateway
+  gatewayNamespace: traefik
+
+nodeSelector: {}

--- a/scripts/bump-modules/ygg.sh
+++ b/scripts/bump-modules/ygg.sh
@@ -1,0 +1,7 @@
+# ygg-gateway
+SERVICE_LABEL="ygg-gateway"
+COMMIT_SCOPE="ygg-gateway"
+BRANCH_PREFIX="ygg-gateway"
+STAGING_FILE="9c-internal/ygg-gateway-staging/values.yaml"
+PRODUCTION_FILE="9c-main/ygg-gateway-production/values.yaml"
+TAG_KEYS=(".image.tag")


### PR DESCRIPTION
## Summary
- Add `charts/ygg-gateway` Helm chart for the Yggdrasil redemption gateway (Bun/Hono HTTP service from the Ragnarok Breaker workspace). Resources: Deployment + ClusterIP Service (port 8787) + Gateway API HTTPRoute (Traefik) + ExternalSecret/SecretStore wired to AWS SecretsManager (`us-east-2`).
- Add staging overlay `9c-internal/ygg-gateway-staging/` (`ygg-gateway-staging.9c.gg`, 1 replica, secret key `ygg-gateway/staging`).
- Add production overlay `9c-main/ygg-gateway-production/` (`ygg-gateway.9c.gg`, 2 replicas, secret key `ygg-gateway/production`).
- Wire `scripts/bump-modules/ygg.sh` so `scripts/bump-image.sh ygg <hash>` works going forward.
- Initial image pinned to `git-015c233d8a48c63292e6e565f5ea9639bec8f721`, repo `planetariumhq/ragnarok-breaker-ygg-gateway`.

Pattern mirrors `charts/ragnarok-breaker` with one deviation: an `HTTPRoute` is added because YGG marketplace + YGG Quest call this service from **outside** the cluster (unlike `ragnarok-breaker`'s `gs-gateway` which is ClusterIP-only). TLS is handled by the existing cert-manager `*.9c.gg` wildcard already listed in both clusters' `certManager.dnsNames`.

## Pre-flight (before sync)
1. Populate AWS SecretsManager (`us-east-2`) with keys `ygg-gateway/staging` and `ygg-gateway/production`. Required env vars: `YGG_API_KEY`, `YGG_API_SECRET`, `YGG_QUEST_API_KEY`, `YGG_QUEST_BASE_URL`, `AGENT8_ACCOUNT`, `AGENT8_VERSE`, `V8_ACCESS_TOKEN`, `V8_ENV`. (All eight are required at boot — `server.ts` exits if any are missing.)
2. Ensure the `planetariumhq/ragnarok-breaker-ygg-gateway:git-015c233d8a48c63292e6e565f5ea9639bec8f721` image exists on Docker Hub.
3. After merge, register both ArgoCD apps manually (per `GUIDE.md`):
   ```
   kubectl apply -f 9c-internal/ygg-gateway-staging/application.yaml
   kubectl apply -f 9c-main/ygg-gateway-production/application.yaml
   ```

## Test plan
- [ ] `helm lint charts/ygg-gateway` passes (verified locally).
- [ ] `helm template` renders cleanly for both overlays (verified locally).
- [ ] After ArgoCD sync, pods are 1/1 Running; logs show `[ygg-gateway] listening on :8787`.
- [ ] `kubectl -n ygg-gateway-staging get externalsecret ygg-gateway-env` shows `Ready=True`.
- [ ] In-cluster `wget -qO- http://ygg-gateway:8787/healthz` returns `{"status":"ok","v8":true}`.
- [ ] External `curl https://ygg-gateway-staging.9c.gg/healthz` returns 200 with valid TLS.
- [ ] HMAC-signed smoke test against `/get-points-by-address` from outside returns 200.