### PR TITLE
chore(ygg-gateway): bump staging + production image to git-c5a7576

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -10,7 +10,7 @@ imagePullSecret:
 yggGateway:
   enabled: true
   image:
-    tag: git-015c233d8a48c63292e6e565f5ea9639bec8f721
+    tag: git-c5a7576831e6210ca8da5293a6283e7142393579
   httpRoute:
     enabled: true
     hostnames:

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -10,7 +10,7 @@ imagePullSecret:
 yggGateway:
   enabled: true
   image:
-    tag: git-015c233d8a48c63292e6e565f5ea9639bec8f721
+    tag: git-c5a7576831e6210ca8da5293a6283e7142393579
   deployment:
     replicas: 2
   httpRoute:


### PR DESCRIPTION
Pin ygg-gateway image to \`git-c5a7576831e6210ca8da5293a6283e7142393579\` for staging + production.

## Test plan
- [ ] After sync, pods pull the pinned image successfully