### PR TITLE
chore(ragnarok-breaker): bump staging + production image to git-015c233

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -2,7 +2,7 @@ externalSecretKey: ragnarok-breaker/staging
 
 image:
   repository: planetariumhq/ragnarok-breaker-worker
-  tag: git-c670795f809242ce2bccab7447cf41fe801cc192
+  tag: git-015c233d8a48c63292e6e565f5ea9639bec8f721
 
 imagePullSecret:
   secretKey: ragnarok-breaker/dockerhub

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -2,7 +2,7 @@ externalSecretKey: ragnarok-breaker/production
 
 image:
   repository: planetariumhq/ragnarok-breaker-worker
-  tag: git-b3cf4800925e0ebb1dd422c5d46928d2e0934000
+  tag: git-015c233d8a48c63292e6e565f5ea9639bec8f721
 
 imagePullSecret:
   secretKey: ragnarok-breaker/dockerhub


### PR DESCRIPTION
Pin ragnarok-breaker-worker image to \`git-015c233d8a48c63292e6e565f5ea9639bec8f721\` for staging + production.

## Test plan
- [ ] After sync, pods pull the pinned image successfully