### PR TITLE
chore(ragnarok-breaker,ygg-gateway): bump worker + ygg image to git-899994e

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -2,7 +2,7 @@ externalSecretKey: ragnarok-breaker/staging
 
 image:
   repository: planetariumhq/ragnarok-breaker-worker
-  tag: git-015c233d8a48c63292e6e565f5ea9639bec8f721
+  tag: git-899994ea8fc411ffd34d5a81f16d569104bf69b5
 
 imagePullSecret:
   secretKey: ragnarok-breaker/dockerhub
@@ -10,7 +10,7 @@ imagePullSecret:
 yggGateway:
   enabled: true
   image:
-    tag: git-c5a7576831e6210ca8da5293a6283e7142393579
+    tag: git-899994ea8fc411ffd34d5a81f16d569104bf69b5
   httpRoute:
     enabled: true
     hostnames:

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -2,7 +2,7 @@ externalSecretKey: ragnarok-breaker/production
 
 image:
   repository: planetariumhq/ragnarok-breaker-worker
-  tag: git-015c233d8a48c63292e6e565f5ea9639bec8f721
+  tag: git-899994ea8fc411ffd34d5a81f16d569104bf69b5
 
 imagePullSecret:
   secretKey: ragnarok-breaker/dockerhub
@@ -10,7 +10,7 @@ imagePullSecret:
 yggGateway:
   enabled: true
   image:
-    tag: git-c5a7576831e6210ca8da5293a6283e7142393579
+    tag: git-899994ea8fc411ffd34d5a81f16d569104bf69b5
   deployment:
     replicas: 2
   httpRoute:


### PR DESCRIPTION
Sync both \`ragnarok-breaker-worker\` and \`ragnarok-breaker-ygg-gateway\` to commit \`899994ea8fc411ffd34d5a81f16d569104bf69b5\` for staging + production. Single PR because both images come from the same monorepo cut.

## Heads-up: SecretsManager re-keying required before sync
This commit ships the V8 env-var prefix split. The two services no longer share \`AGENT8_*\` — they read service-specific names instead. Update both \`ragnarok-breaker/staging\` and \`ragnarok-breaker/production\` keys in AWS SecretsManager (us-east-2):

| Old key | New keys (both must exist) |
|---|---|
| \`AGENT8_ACCOUNT\` | \`YGG_AGENT8_ACCOUNT\`, \`WORKER_AGENT8_ACCOUNT\` |
| \`AGENT8_VERSE\` | \`YGG_AGENT8_VERSE\`, \`WORKER_AGENT8_VERSE\` |
| \`V8_ACCESS_TOKEN\` | \`YGG_AGENT8_AUTH\`, \`WORKER_AGENT8_AUTH\` |
| \`V8_ENV\` | \`YGG_AGENT8_ENV\`, \`WORKER_AGENT8_ENV\` |

There is no fallback to the old names — pods will \`process.exit(1)\` at boot if the prefixed names are missing.

## Test plan
- [ ] SecretsManager re-keyed for both staging and production
- [ ] After ArgoCD sync, both deployments pull the pinned image
- [ ] Worker pods (\`ragnarok-breaker-{scheduler,game-validator,gameplay-validator,summon-validator,league-snapshot}\`) start and process jobs
- [ ] ygg-gateway pod starts and \`/healthz\` returns 200 (note: separate readiness/liveness lazy-init issue still tracked separately)