### PR TITLE
chore(ragnarok-breaker): bump staging + production image to git-7a92380

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -2,7 +2,7 @@ externalSecretKey: ragnarok-breaker/staging
 
 image:
   repository: planetariumhq/ragnarok-breaker-worker
-  tag: git-899994ea8fc411ffd34d5a81f16d569104bf69b5
+  tag: git-7a923800ef25c942171a2e251a9814cb6d30d841
 
 imagePullSecret:
   secretKey: ragnarok-breaker/dockerhub

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -2,7 +2,7 @@ externalSecretKey: ragnarok-breaker/production
 
 image:
   repository: planetariumhq/ragnarok-breaker-worker
-  tag: git-899994ea8fc411ffd34d5a81f16d569104bf69b5
+  tag: git-7a923800ef25c942171a2e251a9814cb6d30d841
 
 imagePullSecret:
   secretKey: ragnarok-breaker/dockerhub


### PR DESCRIPTION
Pin ragnarok-breaker-worker image to `git-7a923800ef25c942171a2e251a9814cb6d30d841` for staging + production.

## Test plan
- [ ] After sync, pods pull the pinned image successfully