### PR TITLE
chore(ygg-gateway): bump staging + production image to git-7a92380

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -10,7 +10,7 @@ imagePullSecret:
 yggGateway:
   enabled: true
   image:
-    tag: git-899994ea8fc411ffd34d5a81f16d569104bf69b5
+    tag: git-7a923800ef25c942171a2e251a9814cb6d30d841
   httpRoute:
     enabled: true
     hostnames:

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -10,7 +10,7 @@ imagePullSecret:
 yggGateway:
   enabled: true
   image:
-    tag: git-899994ea8fc411ffd34d5a81f16d569104bf69b5
+    tag: git-7a923800ef25c942171a2e251a9814cb6d30d841
   deployment:
     replicas: 2
   httpRoute:


### PR DESCRIPTION
Pin ygg-gateway image to `git-7a923800ef25c942171a2e251a9814cb6d30d841` for staging + production.

## Test plan
- [ ] After sync, pods pull the pinned image successfully