### PR TITLE
feat(remote-headless): daily scheduled rolling restart to avoid NetMQ broadcast stale state

### DIFF
--- a/9c-main/network/heimdall.yaml
+++ b/9c-main/network/heimdall.yaml
@@ -175,6 +175,10 @@ remoteHeadless:
   count: 2
   replicas: 1
 
+  scheduledRestart:
+    enabled: true
+    schedule: "0 22 * * *"
+
   useTurnServer: false
 
   hosts:

--- a/9c-main/network/odin.yaml
+++ b/9c-main/network/odin.yaml
@@ -201,6 +201,10 @@ remoteHeadless:
   count: 3
   replicas: 1
 
+  scheduledRestart:
+    enabled: true
+    schedule: "0 22 * * *"
+
   useTurnServer: false
 
   hosts:

--- a/charts/all-in-one/templates/remote-headless-restart-cron.yaml
+++ b/charts/all-in-one/templates/remote-headless-restart-cron.yaml
@@ -1,0 +1,71 @@
+{{- $count := int $.Values.remoteHeadless.count -}}
+{{- if and $.Values.remoteHeadless.scheduledRestart.enabled (gt $count 0) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: remote-headless-restarter
+  namespace: {{ $.Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: remote-headless-restarter
+  namespace: {{ $.Release.Name }}
+rules:
+- apiGroups: ["apps"]
+  resources: ["statefulsets"]
+  verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: remote-headless-restarter
+  namespace: {{ $.Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: remote-headless-restarter
+subjects:
+- kind: ServiceAccount
+  name: remote-headless-restarter
+  namespace: {{ $.Release.Name }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: remote-headless-restart
+  namespace: {{ $.Release.Name }}
+spec:
+  schedule: {{ $.Values.remoteHeadless.scheduledRestart.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          serviceAccountName: remote-headless-restarter
+          restartPolicy: Never
+          containers:
+          - name: kubectl
+            image: bitnami/kubectl:1.31
+            command:
+            - sh
+            - -c
+            - |
+              set -e
+              {{- range $i := until $count }}
+              {{- $idx := add $i 1 }}
+              echo "[$(date -u +%FT%TZ)] rollout restart statefulset/remote-headless-{{ $idx }}"
+              kubectl -n {{ $.Release.Name }} rollout restart statefulset/remote-headless-{{ $idx }}
+              kubectl -n {{ $.Release.Name }} rollout status statefulset/remote-headless-{{ $idx }} --timeout=10m
+              {{- end }}
+              echo "[$(date -u +%FT%TZ)] all remote-headless StatefulSets restarted"
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+{{- end }}

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -235,6 +235,13 @@ validator:
 
 remoteHeadless:
   count: 1
+  # Periodic rolling restart of all remote-headless StatefulSets to mitigate
+  # NetMQ broadcast timeout accumulation (Libplanet hardcoded 1s timeout +
+  # per-broadcast DealerSocket lifecycle). Disabled by default; enable per
+  # network in 9c-main/network/{heimdall,odin}.yaml.
+  scheduledRestart:
+    enabled: false
+    schedule: "0 22 * * *"
   image:
     # follow global image
     repository: ""


### PR DESCRIPTION
## Summary
NetMQ broadcast in Libplanet 5.5.2 hardcodes a 1-second timeout ([NetMQTransport.cs:511](https://github.com/planetarium/libplanet/blob/main/src/Libplanet.Net/Transports/NetMQTransport.cs#L511)) and creates a fresh `DealerSocket` per outgoing message. Under heavy P2P traffic, slow-responding peers cause sockets to accumulate in a degraded state — over hours, broadcast timeout count climbs into the hundreds per minute even though chain tip and the current liveness/readiness probes still report healthy.

Today users on heimdall hit two consecutive tx-staging timeouts; manual restart of `remote-headless-1` dropped the timeout rate from **~27/min → ~1.4/min (~19x)**. The chain tip stayed in sync throughout, so the existing probes don't catch this state.

Until upstream fixes (configurable broadcast timeout, NetMQ socket pooling) land, schedule a daily rolling restart per network.

## Chart changes
- `charts/all-in-one/values.yaml`: new `remoteHeadless.scheduledRestart` block (default `enabled: false`, `schedule: "0 22 * * *"`).
- `charts/all-in-one/templates/remote-headless-restart-cron.yaml` (**new**): ServiceAccount + Role/RoleBinding scoped to `apps/statefulsets get,patch` in the release namespace, plus a CronJob that issues sequential `kubectl rollout restart statefulset/remote-headless-{N}` for each configured RH (1..count) and waits up to 10m per StatefulSet.
- Gated on `(scheduledRestart.enabled) AND (count > 0)` so overlay clusters that inherit values but run no remote-headless (e.g. pt6) don't render the cron.

## Network applications
- `9c-main/network/odin.yaml`: enable, 22:00 UTC daily.
- `9c-main/network/heimdall.yaml`: enable, 22:00 UTC daily.

## Schedule rationale
7-day Prometheus avg `ninechronicles_rpc_clients_count`:

| Network | Low (UTC) | Peak (UTC) | Ratio |
|---------|----------:|-----------:|------:|
| heimdall | 22-23h: 24.6 | 14h: 33.9 | 1.4× |
| odin     | 22-23h: 14.7 | 07h: 17.5 | 1.2× |

Both networks bottom out at 22-23h UTC (07-08h KST). Networks restart in parallel — separate namespaces, separate LBs — so staggering is unnecessary.

## Backward compatibility
- `9c-internal` and `pt6` unaffected — `scheduledRestart.enabled` stays at default `false`.
- `pt6` also has `remoteHeadless.count: 0`, so the `count > 0` guard suppresses the cron even if the toggle were inherited via `sharedValueFiles`.

## Operational impact at 22:00 UTC
- odin: 3 RH StatefulSets restart sequentially (~30-60s each) → ~2-3 min total. LB serves remaining RHs through readiness probe rollover.
- heimdall: 2 RH StatefulSets → ~1-2 min total.
- No validator / seed touched.

## Verification
```
$ helm template charts/all-in-one -f 9c-main/network/general.yaml \
                                  -f 9c-main/network/odin.yaml | grep -c remote-headless-restart
11      # CronJob + RBAC manifests rendered

$ helm template charts/all-in-one -f 9c-main/network/general.yaml \
                                  -f 9c-main/network/odin.yaml \
                                  -f 9c-pt6/network/general.yaml \
                                  -f 9c-pt6/network/odin.yaml | grep -c remote-headless-restart
0       # pt6 properly suppressed
```

## Follow-up (not in this PR)
- File Libplanet upstream issue / PR: configurable broadcast timeout (`NetMQTransport.cs:511`, line has `FIXME` already).
- Add Prometheus alert rule on `TimeoutException` log frequency (Loki) so off-cycle stale state still pages.
- Long term: instrument `ninechronicles_netmq_socket_count` / `_broadcast_timeout_total` in Headless so the probe can detect this directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)