### PR TITLE
chore(ygg-gateway): pin staging image to git-52de439

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -10,7 +10,7 @@ imagePullSecret:
 yggGateway:
   enabled: true
   image:
-    tag: git-7a923800ef25c942171a2e251a9814cb6d30d841
+    tag: git-52de4397412dbcc00f685cc1c681d48ca8054308
   httpRoute:
     enabled: true
     hostnames:


### PR DESCRIPTION
Pin ygg-gateway image to `git-52de4397412dbcc00f685cc1c681d48ca8054308` for staging.

## Test plan
- [ ] After sync, pods pull the pinned image successfully