### PR TITLE
Add dcc-bridge Helm chart for k8s migration (Phase A)

### DIFF
--- a/9c-main/dcc-bridge/application.yaml
+++ b/9c-main/dcc-bridge/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dcc-bridge
+  namespace: argocd
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: dcc-bridge
+  source:
+    repoURL: https://github.com/planetarium/9c-infra.git
+    targetRevision: main
+    path: charts/dcc-bridge
+    helm:
+      valueFiles:
+        - /9c-main/dcc-bridge/values.yaml
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/9c-main/dcc-bridge/values.yaml
+++ b/9c-main/dcc-bridge/values.yaml
@@ -1,0 +1,52 @@
+externalSecretKey: 9c-main-v2/dcc-bridge
+
+serviceAccount:
+  # Existing role from EC2; trust policy was extended to allow RKE2 OIDC,
+  # so the same role is reused for k8s pods until full cutover.
+  roleArn: arn:aws:iam::319679068466:role/dcc-bridge-kms-user
+
+api:
+  # Phase A: bring up api/ first against existing RDS; bridge stays on EC2.
+  enabled: true
+  image:
+    repository: planetariumhq/dcc-bridge
+    # Tag updated automatically by docker.yml workflow on push to main/develop.
+    # Initial value will be filled in once PR #43 lands in develop.
+    tag: api-PLACEHOLDER
+  replicas: 1
+  hostnames: []  # Filled in only after Phase A verification (e.g., bridge-api.dccnft.com)
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+  nodeSelector:
+    node.kubernetes.io/type: general
+
+  cronStatus:
+    # Off during Phase A — EC2 + EventBridge cron still running upstream.
+    # Flip on at cutover after the EventBridge rule is disabled.
+    enabled: false
+    schedule: "* * * * *"
+  cronReport:
+    enabled: false
+    schedule: "30 1 * * *"
+
+bridge:
+  # Phase A: keep bridge worker on EC2 to avoid double-processing Ethereum
+  # burn events. Set to true only at cutover (after stopping the EC2 worker).
+  enabled: false
+  image:
+    repository: planetariumhq/dcc-bridge
+    tag: bridge-PLACEHOLDER
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+  nodeSelector:
+    node.kubernetes.io/type: general

--- a/9c-main/dcc-bridge/values.yaml
+++ b/9c-main/dcc-bridge/values.yaml
@@ -10,9 +10,9 @@ api:
   enabled: true
   image:
     repository: planetariumhq/dcc-bridge
-    # Tag updated automatically by docker.yml workflow on push to main/develop.
-    # Initial value will be filled in once PR #43 lands in develop.
-    tag: api-PLACEHOLDER
+    # Bumped by hand following the petpop pattern when a new SHA is published
+    # by docker.yml on dcc-bridge develop/main.
+    tag: api-dc8edccaa0013da82169daf6224ad61194d2030c
   replicas: 1
   hostnames: []  # Filled in only after Phase A verification (e.g., bridge-api.dccnft.com)
   resources:
@@ -40,7 +40,7 @@ bridge:
   enabled: false
   image:
     repository: planetariumhq/dcc-bridge
-    tag: bridge-PLACEHOLDER
+    tag: bridge-dc8edccaa0013da82169daf6224ad61194d2030c
   resources:
     requests:
       cpu: 100m

--- a/charts/dcc-bridge/Chart.yaml
+++ b/charts/dcc-bridge/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: dcc-bridge
+description: D:CC NFT Ethereum bridge (api + worker) for Nine Chronicles
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/charts/dcc-bridge/templates/api-cron.yaml
+++ b/charts/dcc-bridge/templates/api-cron.yaml
@@ -1,0 +1,59 @@
+{{- if and .Values.api.enabled .Values.api.cronStatus.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: dcc-bridge-api-status
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+spec:
+  schedule: {{ .Values.api.cronStatus.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: caller
+              image: curlimages/curl:8.10.1
+              command: ["sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  curl -fsS -m 30 -A "dcc-bridge-cron" \
+                    "http://dcc-bridge-api.{{ $.Release.Namespace }}.svc.cluster.local/status"
+{{- end }}
+---
+{{- if and .Values.api.enabled .Values.api.cronReport.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: dcc-bridge-api-report
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+spec:
+  schedule: {{ .Values.api.cronReport.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: caller
+              image: curlimages/curl:8.10.1
+              command: ["sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  curl -fsS -m 60 -A "dcc-bridge-cron" \
+                    "http://dcc-bridge-api.{{ $.Release.Namespace }}.svc.cluster.local/report"
+{{- end }}

--- a/charts/dcc-bridge/templates/api-deployment.yaml
+++ b/charts/dcc-bridge/templates/api-deployment.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.api.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dcc-bridge-api
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: dcc-bridge-api
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+spec:
+  replicas: {{ .Values.api.replicas }}
+  selector:
+    matchLabels:
+      app: dcc-bridge-api
+  template:
+    metadata:
+      labels:
+        app: dcc-bridge-api
+    spec:
+      serviceAccountName: {{ $.Release.Name }}
+      containers:
+        - name: api
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          ports:
+            - name: http
+              containerPort: 3000
+          envFrom:
+            - secretRef:
+                name: dcc-bridge-env
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+      {{- with .Values.api.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always
+{{- end }}

--- a/charts/dcc-bridge/templates/api-httproute.yaml
+++ b/charts/dcc-bridge/templates/api-httproute.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.api.enabled .Values.api.hostnames }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: dcc-bridge-api
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+spec:
+  parentRefs:
+    - name: traefik-gateway
+      namespace: traefik
+      sectionName: web
+    - name: traefik-gateway
+      namespace: traefik
+      sectionName: websecure
+  hostnames:
+    {{- toYaml .Values.api.hostnames | nindent 4 }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: dcc-bridge-api
+          port: 80
+{{- end }}

--- a/charts/dcc-bridge/templates/api-service.yaml
+++ b/charts/dcc-bridge/templates/api-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.api.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: dcc-bridge-api
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+spec:
+  selector:
+    app: dcc-bridge-api
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 3000
+{{- end }}

--- a/charts/dcc-bridge/templates/bridge-deployment.yaml
+++ b/charts/dcc-bridge/templates/bridge-deployment.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.bridge.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dcc-bridge-worker
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: dcc-bridge-worker
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+spec:
+  # Hard-coded to 1 — running multiple bridge workers would race on
+  # FetchLog updates and double-process Ethereum burn events.
+  replicas: 1
+  strategy:
+    # rolling-update with 2 replicas during transition is unsafe; recreate
+    # ensures only one worker is alive at any time.
+    type: Recreate
+  selector:
+    matchLabels:
+      app: dcc-bridge-worker
+  template:
+    metadata:
+      labels:
+        app: dcc-bridge-worker
+    spec:
+      serviceAccountName: {{ $.Release.Name }}
+      containers:
+        - name: worker
+          image: "{{ .Values.bridge.image.repository }}:{{ .Values.bridge.image.tag }}"
+          envFrom:
+            - secretRef:
+                name: dcc-bridge-env
+          resources:
+            {{- toYaml .Values.bridge.resources | nindent 12 }}
+      {{- with .Values.bridge.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always
+{{- end }}

--- a/charts/dcc-bridge/templates/secrets.yaml
+++ b/charts/dcc-bridge/templates/secrets.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.externalSecretKey }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dcc-bridge-env
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: {{ $.Release.Name }}-secretsmanager
+    kind: SecretStore
+  target:
+    name: dcc-bridge-env
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: {{ .Values.externalSecretKey }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: {{ $.Release.Name }}-secretsmanager
+  namespace: {{ $.Release.Namespace }}
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: us-east-2
+{{- end }}

--- a/charts/dcc-bridge/templates/serviceaccount.yaml
+++ b/charts/dcc-bridge/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.roleArn }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Release.Name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.serviceAccount.roleArn }}
+{{- end }}

--- a/charts/dcc-bridge/templates/serviceaccount.yaml
+++ b/charts/dcc-bridge/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.serviceAccount.roleArn }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,6 +5,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     app.kubernetes.io/instance: {{ $.Release.Name }}
+  {{- if .Values.serviceAccount.roleArn }}
   annotations:
     eks.amazonaws.com/role-arn: {{ .Values.serviceAccount.roleArn }}
-{{- end }}
+  {{- end }}

--- a/charts/dcc-bridge/values.yaml
+++ b/charts/dcc-bridge/values.yaml
@@ -1,0 +1,47 @@
+# Override these in 9c-main/dcc-bridge/values.yaml.
+externalSecretKey: ""
+
+serviceAccount:
+  # IAM Role used by both api and bridge for KMS Sign (via IRSA).
+  roleArn: ""
+
+api:
+  enabled: false
+  image:
+    repository: planetariumhq/dcc-bridge
+    tag: ""
+  replicas: 1
+  hostnames: []
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+  nodeSelector: {}
+
+  cronStatus:
+    # Replaces the EventBridge rule `dcc-bridge-lambda-event-rule`
+    # (cron(0/1 * * * ? *) on AWS = every minute UTC)
+    enabled: false
+    schedule: "* * * * *"
+  cronReport:
+    # Replaces the EventBridge rule `dcc-bridge-lambda-report-event-rule`
+    # (cron(30 1 * * ? *) on AWS = daily 01:30 UTC)
+    enabled: false
+    schedule: "30 1 * * *"
+
+bridge:
+  enabled: false
+  image:
+    repository: planetariumhq/dcc-bridge
+    tag: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+  nodeSelector: {}


### PR DESCRIPTION
## Summary

DCC NFT Ethereum bridge를 AWS Lambda(api/) + EC2(bridge worker)에서 k8s로 옮기는 마이그레이션의 인프라 코드 추가입니다. 코드와 도커 이미지는 [planetarium/dcc-bridge#43](https://github.com/planetarium/dcc-bridge/pull/43)에 있고, 이 PR은 그 이미지를 띄우기 위한 ArgoCD/Helm 정의입니다.

### 구조

- **`charts/dcc-bridge/`** — petpop 차트 패턴을 그대로 따라간 Helm chart
  - `serviceaccount.yaml` — IRSA 어노테이션. 기존 `dcc-bridge-kms-user` Role을 그대로 사용 (Trust policy에 RKE2 OIDC provider 추가 완료)
  - `secrets.yaml` — `9c-main-v2/dcc-bridge` Secrets Manager 시크릿을 ExternalSecret으로 가져옴
  - `api-deployment.yaml`, `api-service.yaml`, `api-httproute.yaml` — Fastify HTTP 서버 (포트 3000), traefik-gateway 라우팅
  - `api-cron.yaml` — 두 EventBridge 규칙을 대체하는 CronJob 두 개
    - `dcc-bridge-api-status`: 매분 → `/status` (현재 EventBridge `dcc-bridge-lambda-event-rule = cron(0/1 * * * ? *)` 대체)
    - `dcc-bridge-api-report`: `30 1 * * *` → `/report` (현재 `dcc-bridge-lambda-report-event-rule` 대체)
  - `bridge-deployment.yaml` — 이더리움 burn 이벤트 폴러 + KMS signer. `replicas: 1`, `strategy: Recreate`로 동시 실행 방지

- **`9c-main/dcc-bridge/`**
  - `application.yaml` — ArgoCD Application
  - `values.yaml` — Phase A 기본값 (api만 켜져있고 bridge/cron/HTTPRoute는 꺼진 상태). EC2 워커가 계속 운영 중인 동안 api/만 띄워서 검증

### Phase 단계 매핑

이 PR을 머지하면 Phase A 형태로 시작하고, 컷오버 시점에 values 값만 바꿔서 단계 진행합니다.

| 단계 | api | bridge | cron | hostnames |
|---|---|---|---|---|
| **Phase A** (이 PR 기본값) | ✅ | ❌ | ❌ | (없음, 임시 도메인으로 검증) |
| **Phase B** (전환 검증) | ✅ | ❌ | ❌ | 임시 호스트네임 |
| **Phase C 컷오버** | ✅ | ✅ | ✅ | bridge-api.dccnft.com |

### 사전 인프라 (이미 적용됨)

- ✅ AWS Secrets Manager `9c-main-v2/dcc-bridge` (16 keys: DATABASE_URL, KMS_*, ETH_*, JWT_*, SLACK_ENDPOINT, BRIDGE_ADDRESS, ERC1155_*, GQL_ENDPOINTS, NETWORK_ENV, TOTAL_AMOUNT_*)
- ✅ `dcc-bridge-kms-user` IAM Role의 Trust Policy 확장 (EC2 + RKE2 OIDC 둘 다 신뢰)
- ⏸️ Docker image 게시 대기 중 — `image.tag`는 `api-PLACEHOLDER` / `bridge-PLACEHOLDER`로 두고, [dcc-bridge PR #43](https://github.com/planetarium/dcc-bridge/pull/43) 머지 후 자동 게시되는 SHA로 교체

### 검증

- [x] `helm lint charts/dcc-bridge` 통과
- [x] `helm template` Phase A / Phase C 양쪽 시나리오 manifest 정상 (5 / 9 리소스)
- [ ] 이미지 게시 후 image.tag 교체 (별도 PR 또는 직접 push)
- [ ] ArgoCD가 Application을 픽업하고 Phase A 자원 생성 확인
- [ ] api Pod가 RDS에 연결, `/v1/transfers/...` 응답 확인

## Test plan

- [x] `helm lint`: 0 errors
- [x] `helm template` (Phase A): ServiceAccount + ExternalSecret + SecretStore + Service + Deployment = 5 resources
- [x] `helm template` (Phase C): + HTTPRoute + 2 CronJobs + bridge Deployment = 9 resources
- [ ] dcc-bridge#43 머지 후 image.tag 교체 PR
- [ ] ArgoCD sync 결과 확인
- [ ] Phase A 임시 호스트네임으로 `/v1/transfers/0xabc` 호출 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)