### PR TITLE
chore(ygg-gateway): pin staging image to git-1b36f54

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -10,7 +10,7 @@ imagePullSecret:
 yggGateway:
   enabled: true
   image:
-    tag: git-52de4397412dbcc00f685cc1c681d48ca8054308
+    tag: git-1b36f5493f1c9fdd76c618c7ea381bcd91026c4e
   httpRoute:
     enabled: true
     hostnames:


### PR DESCRIPTION
Pin ygg-gateway image to `git-1b36f5493f1c9fdd76c618c7ea381bcd91026c4e` for staging.

## Test plan
- [ ] After sync, pods pull the pinned image successfully