### PR TITLE
Enable dcc-bridge worker + cron jobs (RDS→iWinv cutover)

### DIFF
--- a/9c-main/dcc-bridge/values.yaml
+++ b/9c-main/dcc-bridge/values.yaml
@@ -26,18 +26,21 @@ api:
     node.kubernetes.io/type: general
 
   cronStatus:
-    # Off during Phase A — EC2 + EventBridge cron still running upstream.
-    # Flip on at cutover after the EventBridge rule is disabled.
-    enabled: false
+    # Cutover: EventBridge `dcc-bridge-lambda-event-rule` was disabled, k8s
+    # CronJob now takes over the per-minute /status check.
+    enabled: true
     schedule: "* * * * *"
   cronReport:
-    enabled: false
+    # Cutover: same — EventBridge `dcc-bridge-lambda-report-event-rule` was
+    # disabled, k8s CronJob takes over the daily report.
+    enabled: true
     schedule: "30 1 * * *"
 
 bridge:
-  # Phase A: keep bridge worker on EC2 to avoid double-processing Ethereum
-  # burn events. Set to true only at cutover (after stopping the EC2 worker).
-  enabled: false
+  # Cutover: EC2 worker stopped, k8s bridge worker takes over Ethereum burn
+  # event polling and 9c transaction signing. Replicas hard-coded to 1 in
+  # the chart with strategy=Recreate to prevent double-processing.
+  enabled: true
   image:
     repository: planetariumhq/dcc-bridge
     tag: bridge-dc8edccaa0013da82169daf6224ad61194d2030c


### PR DESCRIPTION
## Cutover step

기존 writer들이 모두 정지된 상태에서 k8s 워크로드 활성화:

- ✅ EC2 i-08d682618c7db6f1d **stopped**
- ✅ EventBridge `dcc-bridge-lambda-event-rule` **DISABLED**
- ✅ EventBridge `dcc-bridge-lambda-report-event-rule` **DISABLED**
- ✅ Secrets Manager `9c-main-v2/dcc-bridge.DATABASE_URL` → **iWinv** (`postgresql9c.sldb.iwinv.net`)
- ✅ pg_dump/restore RDS bridge schema → iWinv public schema (8.16M rows)
- ✅ k8s api Pod이 iWinv로 read 검증 완료

이 PR로 마지막 활성화:

```diff
 cronStatus:
-  enabled: false
+  enabled: true        # 매분 /status (Lambda EventBridge 대체)
 cronReport:
-  enabled: false
+  enabled: true        # 매일 01:30 UTC /report (Lambda EventBridge 대체)
 bridge:
-  enabled: false
+  enabled: true        # 이더리움 burn 이벤트 폴러 + KMS signer (EC2 대체)
```

## Test plan

- [x] helm template — 9 resources (api Deployment + Service, bridge Deployment, 2 CronJobs, SA, ExternalSecret, SecretStore)
- [x] 사전 인프라 (Secrets Manager, IAM, KMS Trust) 모두 적용 완료
- [x] api Pod이 iWinv로 read 정상 (`/v1/transfers/0xtest` → `{}`)
- [ ] 머지 후 ArgoCD sync 성공
- [ ] bridge worker pod이 iWinv에서 마지막 fetch_log 블록 이후부터 polling 재개
- [ ] 1~2분 내 새 fetch_log row가 iWinv에 추가됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)