### PR TITLE
Migrate bridge-api.dccnft.com to k8s (cert + HTTPRoute)

### DIFF
--- a/9c-main/dcc-bridge/values.yaml
+++ b/9c-main/dcc-bridge/values.yaml
@@ -14,7 +14,8 @@ api:
     # by docker.yml on dcc-bridge develop/main.
     tag: api-dc8edccaa0013da82169daf6224ad61194d2030c
   replicas: 1
-  hostnames: []  # Filled in only after Phase A verification (e.g., bridge-api.dccnft.com)
+  hostnames:
+    - bridge-api.dccnft.com
   resources:
     requests:
       cpu: 100m

--- a/9c-main/values.yaml
+++ b/9c-main/values.yaml
@@ -28,6 +28,8 @@ certManager:
     - "*.9c.gg"
     - "petpop.fun"
     - "*.petpop.fun"
+    - "dccnft.com"
+    - "*.dccnft.com"
   issuer:
     email: devops@planetariumhq.com
 traefik:


### PR DESCRIPTION
## Summary

DCC bridge 도메인 이전. 두 변경 코디네이션:

1. **`9c-main/values.yaml`** — cert-manager dnsNames에 `dccnft.com`, `*.dccnft.com` 추가. cert-manager가 Let's Encrypt DNS-01로 발급 (gke-external-dns Role이 Route 53 권한 보유, petpop과 동일 패턴).

2. **`9c-main/dcc-bridge/values.yaml`** — `api.hostnames: [bridge-api.dccnft.com]` 추가 → HTTPRoute가 traefik-gateway에 등록됨.

## Why

- DCC bridge worker는 이미 k8s에서 iWinv 사용 중 (이전 PR #3389 cutover)
- 외부 사용자 트래픽 endpoint(`bridge-api.dccnft.com`)는 아직 AWS API Gateway → Lambda → RDS 경로
- 이 PR로 k8s 라우팅 활성화 + TLS 준비
- DNS는 별도 Route 53 작업으로 전환 (이 PR과 분리, 안전)

## Sequencing

```
1. 이 PR 머지
2. ArgoCD sync → cert-manager가 *.dccnft.com 발급 (몇 분)
3. cert Ready 확인 (kubectl get cert -A | grep dccnft)
4. --resolve curl로 검증 (DNS 안 바꿔도 가능)
5. Route 53 bridge-api.dccnft.com을 ALIAS → A 115.68.199.177로 교체 (실제 트래픽 전환)
6. 기존 AWS API Gateway, Lambda 정리 (1주일 후)
```

## Test plan

- [x] helm template, HTTPRoute manifest 정상
- [ ] 머지 + ArgoCD sync 후 cert Ready 확인
- [ ] `curl --resolve bridge-api.dccnft.com:443:115.68.199.177 https://bridge-api.dccnft.com/v1/transfers/0xtest` 응답 정상
- [ ] Route 53 변경 (별도)

🤖 Generated with [Claude Code](https://claude.com/claude-code)