### PR TITLE
Scope dccnft.com cert to bridge-api only (drop wildcard)

### DIFF
--- a/9c-main/values.yaml
+++ b/9c-main/values.yaml
@@ -28,8 +28,7 @@ certManager:
     - "*.9c.gg"
     - "petpop.fun"
     - "*.petpop.fun"
-    - "dccnft.com"
-    - "*.dccnft.com"
+    - "bridge-api.dccnft.com"
   issuer:
     email: devops@planetariumhq.com
 traefik:


### PR DESCRIPTION
## Summary

`certManager.dnsNames`에서 `dccnft.com` + `*.dccnft.com`을 빼고 specific subdomain `bridge-api.dccnft.com`만 남깁니다.

```diff
-    - "dccnft.com"
-    - "*.dccnft.com"
+    - "bridge-api.dccnft.com"
```

## 왜

이전 PR(#3390)에서 와일드카드를 추가했지만 발급 실패:
- `*.dccnft.com` (와일드카드) → DNS-01 필수 → cert-manager solver pod이 Route 53 접근 못함 (IRSA 환경변수 미주입, IMDS fallback 타임아웃)
- `dccnft.com` (apex) → HTTP-01 시도 → 도메인이 어디로도 안 가서(A 레코드 없음) 실패

specific subdomain만 넣으면:
- HTTP-01 가능 (와일드카드 아님)
- DNS를 k8s로 옮기면 traefik이 ACME challenge 응답
- IAM/IRSA 디버깅 불필요

## Sequencing

```
1. 이 PR 머지 + ArgoCD sync (cert-manager가 새 Certificate request)
2. cert-manager는 bridge-api.dccnft.com에 HTTP-01 challenge 시작
3. 아직 DNS가 AWS API Gateway라 challenge 실패 (계속 retry)
4. 별도 단계 — Route 53에서 bridge-api.dccnft.com을 ALIAS → A 115.68.199.177로 교체
5. cert-manager retry 다음 차례에서 HTTP-01 성공 → cert 발급
6. 이후 HTTPS 정상
```

## Impact

**현재 사용자 영향 0**:
- `bridge-api.dccnft.com` 호출자 없음 (CloudWatch metric 0, dcc-frontend 배포된 코드에 호출 흔적 없음)
- DNS 변경 시점까지 외부 트래픽은 그대로 AWS API Gateway 사용

## Test plan

- [x] helm/lint 영향 없음 (단순 dnsNames 값 변경)
- [ ] 머지 + ArgoCD sync
- [ ] Route 53 변경 (별도 작업)
- [ ] `kubectl get cert -n traefik` Ready=True
- [ ] `curl -i https://bridge-api.dccnft.com/v1/transfers/0xtest` 정상 응답 + cert chain 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)