### PR TITLE
fix(remote-headless): swap restart-cron image to rancher/kubectl

### DIFF
--- a/charts/all-in-one/templates/remote-headless-restart-cron.yaml
+++ b/charts/all-in-one/templates/remote-headless-restart-cron.yaml
@@ -49,7 +49,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: kubectl
-            image: bitnami/kubectl:1.31
+            image: {{ $.Values.remoteHeadless.scheduledRestart.image | default "rancher/kubectl:v1.31.14" }}
             command:
             - sh
             - -c

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -242,6 +242,11 @@ remoteHeadless:
   scheduledRestart:
     enabled: false
     schedule: "0 22 * * *"
+    # kubectl image used by the rollout-restart CronJob. Default
+    # rancher/kubectl is multi-arch and tracks RKE2's kubectl version.
+    # Bitnami images were excluded because Bitnami restricted Docker Hub
+    # access in 2025-08, breaking earlier `bitnami/kubectl:1.31` pulls.
+    image: "rancher/kubectl:v1.31.14"
   image:
     # follow global image
     repository: ""


### PR DESCRIPTION
## Summary
The cron added in #3385 referenced `bitnami/kubectl:1.31`, which has been unavailable on Docker Hub since Bitnami's 2025-08 image policy change. Both the heimdall and odin scheduled-restart Jobs created on 2026-05-04 22:00 UTC are still in `ImagePullBackOff` after 2 days (586 retries) and `concurrencyPolicy: Forbid` blocked subsequent runs.

**Net effect: zero scheduled restarts since the feature was deployed**, and users continue to hit NetMQ broadcast timeouts on stale RH pods.

## Diagnosis
```
$ kubectl -n heimdall describe pod remote-headless-restart-29632200-s8mj5
Reason: ImagePullBackOff
Pulling image "bitnami/kubectl:1.31"   (x586 over 2d2h)
```

```
$ kubectl -n heimdall get jobs | grep restart
remote-headless-restart-29632200   Running   0/1   2d2h    # stuck
```

Same in odin.

## Fix
Switch to `rancher/kubectl:v1.31.14`:
- Multi-arch (amd64/arm64), maintained on Docker Hub by Rancher Labs.
- Matches our RKE2 v1.31.x kubectl version.
- Pinned via new values key `remoteHeadless.scheduledRestart.image` so future bumps don't require a template edit.

```yaml
remoteHeadless:
  scheduledRestart:
    image: "rancher/kubectl:v1.31.14"
```

## Verification
```
$ helm template charts/all-in-one -f 9c-main/network/general.yaml \
                                  -f 9c-main/network/odin.yaml | grep -A1 "name: kubectl"
- name: kubectl
  image: rancher/kubectl:v1.31.14
```

## Operational steps after merge
1. **ArgoCD sync** 9c-main `odin` and `heimdall` Applications to update the CronJob spec.
2. **Delete stuck Jobs** so next 22:00 UTC trigger can fire:
   ```
   kubectl --context default -n heimdall delete job remote-headless-restart-29632200
   kubectl --context default -n odin     delete job remote-headless-restart-29632200
   ```
3. **(Optional) Manually restart RH StatefulSets** if user-facing timeout symptoms persist before the next scheduled run:
   ```
   kubectl --context default -n heimdall rollout restart statefulset/remote-headless-1
   kubectl --context default -n heimdall rollout restart statefulset/remote-headless-2
   kubectl --context default -n odin rollout restart statefulset/remote-headless-1
   kubectl --context default -n odin rollout restart statefulset/remote-headless-2
   kubectl --context default -n odin rollout restart statefulset/remote-headless-3
   ```

## Backward compatibility
9c-internal and pt6 unaffected — `scheduledRestart.enabled` is still default `false` for them. Only 9c-main odin / heimdall render the CronJob today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)