### PR TITLE
fix(remote-headless): use alpine/k8s for restart cron (rancher/kubectl has no shell)

### DIFF
--- a/charts/all-in-one/templates/remote-headless-restart-cron.yaml
+++ b/charts/all-in-one/templates/remote-headless-restart-cron.yaml
@@ -49,7 +49,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: kubectl
-            image: {{ $.Values.remoteHeadless.scheduledRestart.image | default "rancher/kubectl:v1.31.14" }}
+            image: {{ $.Values.remoteHeadless.scheduledRestart.image | default "alpine/k8s:1.31.13" }}
             command:
             - sh
             - -c

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -242,11 +242,12 @@ remoteHeadless:
   scheduledRestart:
     enabled: false
     schedule: "0 22 * * *"
-    # kubectl image used by the rollout-restart CronJob. Default
-    # rancher/kubectl is multi-arch and tracks RKE2's kubectl version.
-    # Bitnami images were excluded because Bitnami restricted Docker Hub
-    # access in 2025-08, breaking earlier `bitnami/kubectl:1.31` pulls.
-    image: "rancher/kubectl:v1.31.14"
+    # kubectl image used by the rollout-restart CronJob. alpine/k8s ships
+    # kubectl + busybox sh, which the inline shell loop below requires.
+    # `rancher/kubectl` is distroless (no shell) and `bitnami/kubectl`
+    # became unavailable on Docker Hub after Bitnami's 2025-08 image
+    # policy change.
+    image: "alpine/k8s:1.31.13"
   image:
     # follow global image
     repository: ""


### PR DESCRIPTION
## Summary
#3393 swapped the cron image from the unavailable `bitnami/kubectl:1.31` to `rancher/kubectl:v1.31.14`, but `rancher/kubectl` is **distroless** — it ships only the kubectl binary, no shell. Our cron uses an inline `sh -c` script to iterate `kubectl rollout restart` per RH StatefulSet, which fails on container start:

```
StartError: OCI runtime create failed: ...
exec: "sh": executable file not found in $PATH
```

## Fix
Switch to `alpine/k8s:1.31.13`. Confirmed via Docker Hub docs to include kubectl + busybox sh (and bash). Image is ~200 MB vs rancher/kubectl's 17 MB, but only the restart cron pulls it, briefly, once per network per day.

```diff
-    image: "rancher/kubectl:v1.31.14"
+    image: "alpine/k8s:1.31.13"
```

Verified `helm template` renders the new image and the inline shell script runs unchanged.

## Operational steps after merge
1. ArgoCD sync `odin` and `heimdall`.
2. Delete the stuck `remote-headless-restart-29635080` Jobs in both namespaces (those started after #3393 sync but failed with `StartError`).
3. Monitor next 22:00 UTC trigger to confirm successful sequential rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)