### PR TITLE
Unlist heimdall community node

### DIFF
--- a/planets/mainnet.json
+++ b/planets/mainnet.json
@@ -67,13 +67,11 @@
       ],
       "headless.gql": [
         "https://heimdall-rpc-1.nine-chronicles.com/graphql",
-        "https://heimdall-rpc-2.nine-chronicles.com/graphql",
-        "https://heimdall6.9capi.com/graphql"
+        "https://heimdall-rpc-2.nine-chronicles.com/graphql"
       ],
       "headless.grpc": [
         "http://heimdall-rpc-1.nine-chronicles.com:31238",
-        "http://heimdall-rpc-2.nine-chronicles.com:31238",
-        "http://heimdall6.9capi.com:31238"
+        "http://heimdall-rpc-2.nine-chronicles.com:31238"
       ],
       "market.rest": [
         "https://b.9capi.com/marketProviderHeimdall"


### PR DESCRIPTION
Removed duplicate entries for headless.gql and headless.grpc.