### PR TITLE
fix(remote-headless): grant list/watch verbs to restart cron RBAC

### DIFF
--- a/charts/all-in-one/templates/remote-headless-restart-cron.yaml
+++ b/charts/all-in-one/templates/remote-headless-restart-cron.yaml
@@ -14,7 +14,7 @@ metadata:
 rules:
 - apiGroups: ["apps"]
   resources: ["statefulsets"]
-  verbs: ["get", "patch"]
+  verbs: ["get", "list", "watch", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Summary

`remote-headless-restarter` Role currently only has `get` and `patch` verbs on `statefulsets`, which is enough to trigger `kubectl rollout restart` (a patch under the hood) but **not** enough for `kubectl rollout status` — which internally `list`s and `watch`es the StatefulSet to track rollout completion.

This causes the restart cron job to repeatedly log:

\`\`\`
statefulsets.apps "remote-headless-1" is forbidden: User
"system:serviceaccount:heimdall:remote-headless-restarter"
cannot list resource "statefulsets" in API group "apps" in the
namespace "heimdall"
\`\`\`

…and ultimately end in \`Error\` state (e.g. \`remote-headless-restart-29640840-rlspw\` on the heimdall cluster today) even though the actual rollout patch succeeded.

## Change

Add \`list\` and \`watch\` verbs to the Role so \`kubectl rollout status\` can complete.

## Test plan

- [ ] Confirm next scheduled run of the cron job ends with \`Completed\` status instead of \`Error\`
- [ ] Verify rollout is still triggered correctly across all \`remote-headless-{N}\` StatefulSets

🤖 Generated with [Claude Code](https://claude.com/claude-code)