### PR TITLE
chore(petpop): update main image tags to ab0a21c

### DIFF
--- a/9c-main/petpop/values.yaml
+++ b/9c-main/petpop/values.yaml
@@ -4,7 +4,7 @@ server:
   enabled: true
   image:
     repository: planetariumhq/petpop
-    tag: server-8e9bd3994a502352efa27e475e0e853a21d6485f
+    tag: server-ab0a21caafe710a7b3f2fa320b0f2c3767e1d988
   hostnames:
     - petpop.fun
     - www.petpop.fun
@@ -20,7 +20,7 @@ backoffice:
   enabled: true
   image:
     repository: planetariumhq/petpop
-    tag: server-8e9bd3994a502352efa27e475e0e853a21d6485f
+    tag: server-ab0a21caafe710a7b3f2fa320b0f2c3767e1d988
   hostname: petpop-backoffice.9c.gg
   nodeSelector:
     node.kubernetes.io/type: general
@@ -28,7 +28,7 @@ backoffice:
 workers:
   image:
     repository: planetariumhq/petpop
-    tag: worker-8e9bd3994a502352efa27e475e0e853a21d6485f
+    tag: worker-ab0a21caafe710a7b3f2fa320b0f2c3767e1d988
   nodeSelector:
     node.kubernetes.io/type: general
   rankingWorker:


### PR DESCRIPTION
## Summary
- petpop main 이미지 태그를 \`8e9bd39\` → \`ab0a21c\` 로 업데이트합니다.
- petpop PR https://github.com/planetarium/petpop/pull/916 머지 반영.

## Included changes (petpop main)
- [#915](https://github.com/planetarium/petpop/pull/915) Fix /quest/claim Prisma interactive transaction timeout
- [#918](https://github.com/planetarium/petpop/pull/918) Stop logging expected P2025 on /api/user/pop-pass
- [#917](https://github.com/planetarium/petpop/pull/917) Loosen flaky auth test name regex
- Dockerfile pnpm pin (10.28.0)

## Test plan
- [ ] argo sync 후 server / backoffice / worker pod 가 새 태그로 롤아웃되는지 확인
- [ ] /api/quest/claim 응답시간이 5초 timeout 에러 없이 정상 종료되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)