### PR TITLE
chore(ragnarok-breaker): pin staging ygg-redeem image to git-711d511

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -13,7 +13,7 @@ v8Gateway:
 
 yggRedeem:
   image:
-    tag: git-1b36f5493f1c9fdd76c618c7ea381bcd91026c4e
+    tag: git-711d51162b59f6dc7c732a829664697065bbb1c3
   httpRoute:
     enabled: true
     hostnames:


### PR DESCRIPTION
Pin ragnarok-breaker-ygg-redeem image to `git-711d51162b59f6dc7c732a829664697065bbb1c3` for staging.

## Test plan
- [ ] After sync, pods pull the pinned image successfully