### PR TITLE
chore(ragnarok-breaker): pin staging log-stream image to git-711d511

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -21,7 +21,7 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-7a923800ef25c942171a2e251a9814cb6d30d841
+    tag: git-711d51162b59f6dc7c732a829664697065bbb1c3
 
 yggQuestWorker:
   image:


### PR DESCRIPTION
Pin ragnarok-breaker-log-stream image to `git-711d51162b59f6dc7c732a829664697065bbb1c3` for staging.

## Test plan
- [ ] After sync, pods pull the pinned image successfully