### PR TITLE
fix(ragnarok-breaker): prefix worker entries with services/ + bulk bump

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-711d51162b59f6dc7c732a829664697065bbb1c3
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
 
 v8Gateway:
   image:
-    tag: git-711d51162b59f6dc7c732a829664697065bbb1c3
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
 
 yggRedeem:
   image:
-    tag: git-711d51162b59f6dc7c732a829664697065bbb1c3
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
   httpRoute:
     enabled: true
     hostnames:
@@ -21,8 +21,8 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-711d51162b59f6dc7c732a829664697065bbb1c3
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
 
 yggQuestWorker:
   image:
-    tag: git-711d51162b59f6dc7c732a829664697065bbb1c3
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-7a923800ef25c942171a2e251a9814cb6d30d841
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
 
 v8Gateway:
   image:
-    tag: git-7a923800ef25c942171a2e251a9814cb6d30d841
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
 
 yggRedeem:
   image:
-    tag: git-7a923800ef25c942171a2e251a9814cb6d30d841
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
   deployment:
     replicas: 2
   httpRoute:
@@ -23,9 +23,9 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-7a923800ef25c942171a2e251a9814cb6d30d841
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
 
 yggQuestWorker:
   image:
-    tag: git-7a923800ef25c942171a2e251a9814cb6d30d841
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
   replicas: 2

--- a/charts/ragnarok-breaker/values.yaml
+++ b/charts/ragnarok-breaker/values.yaml
@@ -15,7 +15,7 @@ workers:
   scheduler:
     enabled: true
     replicas: 1
-    command: ["bun", "run", "worker/src/entry/scheduler.entry.ts"]
+    command: ["bun", "run", "services/worker/src/entry/scheduler.entry.ts"]
     resources:
       requests:
         cpu: 100m
@@ -26,7 +26,7 @@ workers:
   gameValidator:
     enabled: true
     replicas: 1
-    command: ["bun", "run", "worker/src/entry/game-worker.entry.ts"]
+    command: ["bun", "run", "services/worker/src/entry/game-worker.entry.ts"]
     resources:
       requests:
         cpu: 200m
@@ -37,7 +37,7 @@ workers:
   gameplayValidator:
     enabled: true
     replicas: 1
-    command: ["bun", "run", "worker/src/entry/gameplay-worker.entry.ts"]
+    command: ["bun", "run", "services/worker/src/entry/gameplay-worker.entry.ts"]
     resources:
       requests:
         cpu: 200m
@@ -48,7 +48,7 @@ workers:
   summonValidator:
     enabled: true
     replicas: 1
-    command: ["bun", "run", "worker/src/entry/summon-worker.entry.ts"]
+    command: ["bun", "run", "services/worker/src/entry/summon-worker.entry.ts"]
     resources:
       requests:
         cpu: 200m
@@ -59,7 +59,7 @@ workers:
   leagueSnapshot:
     enabled: true
     replicas: 1
-    command: ["bun", "run", "worker/src/entry/league-worker.entry.ts"]
+    command: ["bun", "run", "services/worker/src/entry/league-worker.entry.ts"]
     resources:
       requests:
         cpu: 200m

--- a/scripts/bump-image.sh
+++ b/scripts/bump-image.sh
@@ -9,7 +9,9 @@ set -euo pipefail
 #   <service>      Service id. Discovered from scripts/bump-modules/<service>.sh.
 #                  Use --help to list available services.
 #   <sub-service>  Required only when the module declares SUB_SERVICES (e.g. `rb`).
-#                  Picks which workload's image.tag to bump.
+#                  Picks which workload's image.tag to bump. Omit to bump every
+#                  sub-service at once (requires the module to define
+#                  resolve_all_sub_services).
 #   <hash>         Image tag. Bare hash (e.g. abc123...) or git-<hash>; auto normalized.
 #   --env          default: both. Pick staging/production/both.
 #   --separate     when --env both, open two PRs instead of one combined PR.
@@ -23,7 +25,9 @@ set -euo pipefail
 # Adding a service with multiple workloads: also set
 #   SUB_SERVICES=(name1 name2 ...) and define `resolve_sub_service()` to set
 #   TAG_KEYS / SERVICE_LABEL / BRANCH_PREFIX for the chosen sub-service.
-#   When SUB_SERVICES is non-empty, CLI requires the sub-service positional.
+#   Optionally define `resolve_all_sub_services()` to enable the
+#   `bump-image.sh <service> <hash>` shortcut (no sub-service), which bumps
+#   every workload in one PR.
 
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 resolve_self() {
@@ -60,14 +64,24 @@ sub_services_for() {
   )
 }
 
+supports_all() {
+  (
+    # shellcheck disable=SC1090
+    source "$MODULE_DIR/$1.sh" >/dev/null 2>&1 || exit 1
+    declare -F resolve_all_sub_services >/dev/null
+  )
+}
+
 usage() {
-  sed -n '4,26p' "$SCRIPT_PATH" | sed 's/^# \{0,1\}//'
+  sed -n '4,30p' "$SCRIPT_PATH" | sed 's/^# \{0,1\}//'
   echo "Available services:"
-  local s subs
+  local s subs suffix
   for s in $(list_services); do
     subs="$(sub_services_for "$s" | paste -sd ' ' -)"
     if [[ -n "$subs" ]]; then
-      echo "  - $s (sub: $subs)"
+      suffix=""
+      supports_all "$s" && suffix=", or omit for all"
+      echo "  - $s (sub: $subs$suffix)"
     else
       echo "  - $s"
     fi
@@ -132,23 +146,45 @@ source "$MODULE_FILE"
 
 SUB=""
 HASH=""
+# A "hash-like" token: bare 7–40 hex chars or a git-<hash> form. Used to detect
+# whether the user typed `bump-image.sh rb <hash>` (bulk) vs
+# `bump-image.sh rb <sub> <hash>`.
+is_hashlike() {
+  [[ "$1" =~ ^(git-)?[0-9a-f]{7,40}$ ]]
+}
 if [[ "${#SUB_SERVICES[@]}" -gt 0 ]]; then
   SUB="${POSITIONALS[1]:-}"
   HASH="${POSITIONALS[2]:-}"
-  if [[ -z "$SUB" || -z "$HASH" ]]; then
-    echo "error: service '$SERVICE' requires <sub-service> and <hash>" >&2
-    echo "available sub-services: ${SUB_SERVICES[*]}" >&2
-    exit 1
+  # Bulk shortcut: only one trailing positional and it looks like a hash.
+  # Treat as "all sub-services" if the module supports it.
+  if [[ -z "$HASH" && -n "$SUB" ]] && is_hashlike "$SUB"; then
+    if ! declare -F resolve_all_sub_services >/dev/null; then
+      echo "error: service '$SERVICE' requires <sub-service> and <hash>" >&2
+      echo "available sub-services: ${SUB_SERVICES[*]}" >&2
+      exit 1
+    fi
+    HASH="$SUB"
+    SUB=""
+    resolve_all_sub_services || exit 1
+  else
+    if [[ -z "$SUB" || -z "$HASH" ]]; then
+      echo "error: service '$SERVICE' requires <sub-service> and <hash>" >&2
+      echo "available sub-services: ${SUB_SERVICES[*]}" >&2
+      if declare -F resolve_all_sub_services >/dev/null; then
+        echo "(omit <sub-service> to bump every sub-service at once)" >&2
+      fi
+      exit 1
+    fi
+    if [[ "${#POSITIONALS[@]}" -gt 3 ]]; then
+      echo "error: unexpected positional arg: ${POSITIONALS[3]}" >&2
+      exit 1
+    fi
+    if ! declare -F resolve_sub_service >/dev/null; then
+      echo "error: module $MODULE_FILE declared SUB_SERVICES but no resolve_sub_service()" >&2
+      exit 1
+    fi
+    resolve_sub_service "$SUB" || exit 1
   fi
-  if [[ "${#POSITIONALS[@]}" -gt 3 ]]; then
-    echo "error: unexpected positional arg: ${POSITIONALS[3]}" >&2
-    exit 1
-  fi
-  if ! declare -F resolve_sub_service >/dev/null; then
-    echo "error: module $MODULE_FILE declared SUB_SERVICES but no resolve_sub_service()" >&2
-    exit 1
-  fi
-  resolve_sub_service "$SUB" || exit 1
 else
   HASH="${POSITIONALS[1]:-}"
   if [[ -z "$HASH" ]]; then
@@ -292,7 +328,7 @@ bump_and_pr() {
   git push --quiet -u origin "$branch"
 
   body=$(cat <<EOF
-Pin ${SERVICE_LABEL} image to \`$TAG\` for $body_envs.
+Pin ${SERVICE_LABEL} to \`$TAG\` for $body_envs.
 
 ## Test plan
 - [ ] After sync, pods pull the pinned image successfully

--- a/scripts/bump-modules/rb.sh
+++ b/scripts/bump-modules/rb.sh
@@ -1,5 +1,7 @@
 # ragnarok-breaker chart — 5 independent images, one per workload.
-# Usage: bump-image.sh rb <worker|v8-gateway|ygg-redeem|log-stream|ygg-quest-worker> <hash>
+# Usage:
+#   bump-image.sh rb <worker|v8-gateway|ygg-redeem|log-stream|ygg-quest-worker> <hash>
+#   bump-image.sh rb <hash>   # bump every workload at once
 
 COMMIT_SCOPE="ragnarok-breaker"
 STAGING_FILE="9c-internal/ragnarok-breaker-staging/values.yaml"
@@ -38,4 +40,16 @@ resolve_sub_service() {
       return 1
       ;;
   esac
+}
+
+resolve_all_sub_services() {
+  TAG_KEYS=(
+    ".worker.image.tag"
+    ".v8Gateway.image.tag"
+    ".yggRedeem.image.tag"
+    ".logStream.image.tag"
+    ".yggQuestWorker.image.tag"
+  )
+  SERVICE_LABEL="all ragnarok-breaker images"
+  BRANCH_PREFIX="ragnarok-breaker-all"
 }


### PR DESCRIPTION
## Summary

- **fix(chart)**: `charts/ragnarok-breaker/values.yaml` — prefix all 5 worker `command:` entries with `services/`. JiwonRB moved worker sources under `services/worker/` in its monorepo restructure, but this chart still ran `bun run worker/src/entry/<x>.entry.ts`, so every new image rolled out with "file not found" on the configured entry.
- **feat(bump-image)**: `bump-image.sh rb <hash>` (no sub-service) now bumps all 5 rb workloads — `worker`, `v8-gateway`, `ygg-redeem`, `log-stream`, `ygg-quest-worker` — in a single PR. The existing single-workload form (`rb <sub> <hash>`) is unchanged. Modules opt in by defining `resolve_all_sub_services()`.
- **chore(bump)**: pin every rb image in staging and production to `git-088af99e6359ab9062796dd43fca5a43b92335f5` — first rollout that picks up the entry-path fix above.

Verified locally:
- `helm template` renders all 5 worker commands with `services/worker/src/entry/<x>.entry.ts`.
- `yq` resolves every `TAG_KEYS` entry to the new hash in both overlays.
- `bump-image.sh rb <hash>` (bulk) and `bump-image.sh rb <sub> <hash>` (single) parse correctly; the unknown-sub case still errors with a sensible message.

## Test plan

- [ ] After sync, staging pods pull `git-088af99…` and the 5 worker Deployments stay Ready (no `bun: file not found` exits)
- [ ] After sync, production pods pull `git-088af99…` and the 5 worker Deployments stay Ready
- [ ] Sanity-run `scripts/bump-image.sh rb <some-future-hash> --env staging` and confirm the resulting PR touches all 5 `.image.tag` lines