### PR TITLE
chore(ragnarok-breaker): pin staging log-stream image to git-3cd2e40

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -21,7 +21,7 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-3cd2e40faa196452421fa0ea56d8b525086f7933
 
 yggQuestWorker:
   image:


### PR DESCRIPTION
Pin ragnarok-breaker-log-stream to `git-3cd2e40faa196452421fa0ea56d8b525086f7933` for staging.

## Test plan
- [ ] After sync, pods pull the pinned image successfully