### PR TITLE
feat(ragnarok-breaker): add bq-analytics-worker workload + enable in both envs

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -26,3 +26,7 @@ logStream:
 yggQuestWorker:
   image:
     tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+bqAnalyticsWorker:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -29,3 +29,7 @@ yggQuestWorker:
   image:
     tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
   replicas: 2
+
+bqAnalyticsWorker:
+  image:
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5

--- a/charts/ragnarok-breaker/templates/bq-analytics-worker-deployment.yaml
+++ b/charts/ragnarok-breaker/templates/bq-analytics-worker-deployment.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.bqAnalyticsWorker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bq-analytics-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: bq-analytics-worker
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: bq-analytics-worker
+spec:
+  replicas: {{ .Values.bqAnalyticsWorker.replicas }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: bq-analytics-worker
+  template:
+    metadata:
+      labels:
+        app: bq-analytics-worker
+    spec:
+      {{- if .Values.imagePullSecret.secretKey }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret.name }}
+      {{- end }}
+      containers:
+        - name: bq-analytics-worker
+          image: "{{ .Values.bqAnalyticsWorker.image.repository }}:{{ .Values.bqAnalyticsWorker.image.tag }}"
+          imagePullPolicy: {{ .Values.bqAnalyticsWorker.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: ragnarok-breaker-env
+          resources:
+            {{- toYaml .Values.bqAnalyticsWorker.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always
+{{- end }}

--- a/charts/ragnarok-breaker/values.yaml
+++ b/charts/ragnarok-breaker/values.yaml
@@ -177,4 +177,23 @@ yggQuestWorker:
       cpu: 500m
       memory: 512Mi
 
+# === BullMQ consumer for bq-analytics-events queue → BigQuery insertAll ===
+# Consumes bq_event jobs enqueued by log-stream and writes rows to BigQuery.
+# Independent of V8 gateway. GCP auth via BQ_SERVICE_ACCOUNT_JSON_BASE64
+# (set in the ragnarok-breaker-env ExternalSecret).
+bqAnalyticsWorker:
+  enabled: true
+  image:
+    repository: planetariumhq/ragnarok-breaker-bq-analytics-worker
+    tag: develop
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
 nodeSelector: {}

--- a/scripts/bump-modules/rb.sh
+++ b/scripts/bump-modules/rb.sh
@@ -1,12 +1,12 @@
-# ragnarok-breaker chart — 5 independent images, one per workload.
+# ragnarok-breaker chart — 6 independent images, one per workload.
 # Usage:
-#   bump-image.sh rb <worker|v8-gateway|ygg-redeem|log-stream|ygg-quest-worker> <hash>
+#   bump-image.sh rb <worker|v8-gateway|ygg-redeem|log-stream|ygg-quest-worker|bq-analytics-worker> <hash>
 #   bump-image.sh rb <hash>   # bump every workload at once
 
 COMMIT_SCOPE="ragnarok-breaker"
 STAGING_FILE="9c-internal/ragnarok-breaker-staging/values.yaml"
 PRODUCTION_FILE="9c-main/ragnarok-breaker-production/values.yaml"
-SUB_SERVICES=(worker v8-gateway ygg-redeem log-stream ygg-quest-worker)
+SUB_SERVICES=(worker v8-gateway ygg-redeem log-stream ygg-quest-worker bq-analytics-worker)
 
 resolve_sub_service() {
   case "$1" in
@@ -35,6 +35,11 @@ resolve_sub_service() {
       SERVICE_LABEL="ragnarok-breaker-ygg-quest-worker"
       BRANCH_PREFIX="ragnarok-breaker-ygg-quest-worker"
       ;;
+    bq-analytics-worker)
+      TAG_KEYS=(".bqAnalyticsWorker.image.tag")
+      SERVICE_LABEL="ragnarok-breaker-bq-analytics-worker"
+      BRANCH_PREFIX="ragnarok-breaker-bq-analytics-worker"
+      ;;
     *)
       echo "error: unknown rb sub-service '$1' (available: ${SUB_SERVICES[*]})" >&2
       return 1
@@ -49,6 +54,7 @@ resolve_all_sub_services() {
     ".yggRedeem.image.tag"
     ".logStream.image.tag"
     ".yggQuestWorker.image.tag"
+    ".bqAnalyticsWorker.image.tag"
   )
   SERVICE_LABEL="all ragnarok-breaker images"
   BRANCH_PREFIX="ragnarok-breaker-all"


### PR DESCRIPTION
## Summary

JiwonRB shipped a new ragnarok-breaker service — `services/bq-analytics-worker/` — that consumes the `bq-analytics-events` BullMQ queue (filled by `log-stream` from V8 SSE `bq_event` topics) and writes rows into BigQuery via `insertAll`. This PR is the chart side of the rollout.

- **feat(chart)**: new `bqAnalyticsWorker` block in [charts/ragnarok-breaker/values.yaml](charts/ragnarok-breaker/values.yaml) and a new [charts/ragnarok-breaker/templates/bq-analytics-worker-deployment.yaml](charts/ragnarok-breaker/templates/bq-analytics-worker-deployment.yaml) template. Patterned after `log-stream` rather than `worker` because the new service is independent of V8 gateway (no init wait, no `V8_GATEWAY_URL` injection). Single-replica `Recreate` strategy, `envFrom: ragnarok-breaker-env` like every other workload.
- **feat(bump-image)**: `scripts/bump-modules/rb.sh` learns a 6th sub-service. Both single (`bump-image.sh rb bq-analytics-worker <hash>`) and bulk (`bump-image.sh rb <hash>`) forms now cover `.bqAnalyticsWorker.image.tag`.
- **chore(overlays)**: pin `bqAnalyticsWorker.image.tag` in both staging (`git-c30a3ca5`) and production (`git-088af99`). Chart default `enabled: true` rolls the workload on both environments at sync time.

Image: `planetariumhq/ragnarok-breaker-bq-analytics-worker` (built by JiwonRB CI, same registry as the other rb images).

## Out-of-PR prerequisites (operator)

The new worker reads these env vars from the existing `ragnarok-breaker-env` ExternalSecret — add them to the upstream secret store before merging or the pod will crash on boot:

- `BQ_ANALYTICS_REDIS_URL` (BullMQ Redis, typically same as the other rb workers)
- `BQ_PROJECT_ID`, `BQ_DATASET`
- `BQ_SERVICE_ACCOUNT_JSON_BASE64` (base64-encoded GCP SA key with BigQuery Data Editor + Job User)
- BigQuery dataset + 3 tables pre-created: `currency_changes`, `game_sessions_started`, `game_sessions_ended` (per `services/bq-analytics-worker/README.md` §6)

## Test plan

- [ ] Operator confirms BQ_* keys + SA key are in both `ragnarok-breaker/staging` and `ragnarok-breaker/production` secret stores
- [ ] BigQuery dataset + 3 tables exist in the target GCP project for both environments
- [ ] After sync, `bq-analytics-worker` pod is Ready in staging (`kubectl logs` shows `[bq-analytics-worker] started concurrency=8`)
- [ ] After sync, `bq-analytics-worker` pod is Ready in production
- [ ] A `bq_event` flowing through `log-stream` lands as a BigQuery row in the expected table within ~seconds
- [ ] Sanity-run `scripts/bump-image.sh rb bq-analytics-worker <hash> --env staging` and confirm the resulting PR touches only `.bqAnalyticsWorker.image.tag`
- [ ] Sanity-run `scripts/bump-image.sh rb <hash> --env staging` and confirm the resulting PR touches all 6 tag keys