### PR TITLE
feat(9c-internal): bump headless + enable HTTP/2 keepalive on heimdall (Phase 1)

### DIFF
--- a/9c-internal/network/general.yaml
+++ b/9c-internal/network/general.yaml
@@ -4,7 +4,7 @@ provider: RKE2
 global:
   image:
     repository: planetariumhq/ninechronicles-headless
-    tag: "git-99a8cbb71c6a2dabc0c522b471cba552bad3a2d2"
+    tag: "git-436932c92da4c179a8fbbf3a8a3f327a540c6be2"
 
 seed:
   image:

--- a/9c-internal/network/heimdall.yaml
+++ b/9c-internal/network/heimdall.yaml
@@ -130,6 +130,10 @@ remoteHeadless:
     repository: planetariumhq/ninechronicles-headless
     pullPolicy: Always
 
+  env:
+    - name: RPC_KEEPALIVE_PING_DELAY_SECONDS
+      value: "30"
+
   hosts:
   - >-
     heimdall-internal-node-1.nine-chronicles.com


### PR DESCRIPTION
## Summary

Bumps the **9c-internal** headless image to include the two upstream fixes from yesterday and enables HTTP/2 keepalive PING on internal heimdall `remote-headless-1` as Phase 1 of a staged rollout.

- 9c-internal/network/general.yaml: image tag → `git-436932c92da4c179a8fbbf3a8a3f327a540c6be2`
- 9c-internal/network/heimdall.yaml: `remoteHeadless.env: RPC_KEEPALIVE_PING_DELAY_SECONDS=30`

> **Draft** — the headless image for `436932c9` is currently being built by CI. Mark Ready once Docker Hub has `planetariumhq/ninechronicles-headless:git-436932c92da4c179a8fbbf3a8a3f327a540c6be2`.

## Why

Recent investigation into client gRPC "timeout" reports showed the proxy and headless layers are mostly healthy, but neither side actively probes idle gRPC connections:

- Server-side: Kestrel's default `Http2.KeepAlivePingDelay` is `TimeSpan.MaxValue` (no PING).
- Client-side: Unity has no `grpc.keepalive_*` `ChannelOption`s set (planetarium/NineChronicles#7264 tracks the client fix; out of scope for this PR — needs an app release).

Result: dead/zombie connections sit in `ActionEvaluationPublisher._clients` until a TCP RST arrives, which may take minutes (NAT/proxy idle drop) or effectively never (network partition). Broadcasts still pay the serialization/compression cost for them. The recently-fixed `LeaveAsync` exception path (#2760) is the safety net but only triggers after the server *knows* the client is gone — keepalive is what shortens that detection window.

## What changes operationally

- `RPC_KEEPALIVE_PING_DELAY_SECONDS=30` → Kestrel sends a PING every 30 s on idle gRPC streams.
- `KeepAlivePingTimeout` stays at Kestrel default (20 s), so total dead-detection budget is ~50 s.
- Default is off in the headless code (planetarium/NineChronicles.Headless#2762), so any pod *without* this env keeps current behavior. **This PR is the explicit opt-in for internal heimdall only.**

## Risk

| Item | Assessment |
|---|---|
| Image change scope | All 9c-internal pods using `global.image` will get the new image on next ArgoCD sync — incurs rolling restart. New image is default-off for keepalive, default-on for the `LeaveAsync` cleanup guard. |
| Keepalive false positives | Unity client must ACK PING within ~50 s. Normal Unity GC pauses are well under that. Mobile background pods get cleaned up by the OS in a similar window anyway. |
| Rollback | Remove the `env:` block → next ArgoCD sync drops keepalive; restart pod if you want immediate effect. Or pin the image tag back. Both are one-line revert. |
| Mainnet impact | None in this PR — only `9c-internal/network/heimdall.yaml` is touched. |

## Validation plan (after merge & sync)

Compare before/after over 24–48 h on internal heimdall `remote-headless-1`:

- `ActionEvaluationPublisher._clients` size over time (should drop or stabilize lower)
- Frequency of `RemoveClient` / `LeaveAsync failed (hub likely already disposed)` log lines (transient spike acceptable; steady-state should be flat)
- broadcast iteration latency
- No spurious disconnect spike from QA/internal sessions
- nginx (115.68.221.180) edge log distribution unchanged for internal hosts

If signals are good, follow-up PR will:

1. Add keepalive env to **odin mainnet `remote-headless-3`** only (single pod via chart `envByIndex` or per-pod patching). odin shows the highest NetMQ 1 s timeout volume so the effect should be most measurable there.
2. Then heimdall mainnet and remaining odin pods.

## Test plan

- [ ] Wait for headless CI to publish `git-436932c9...` to Docker Hub
- [ ] Mark PR Ready for review
- [ ] Merge → ArgoCD auto-sync (or manual `kubectl patch applications.argoproj.io heimdall ... sync`)
- [ ] Confirm `remote-headless-1-0` pod restarts on new image
- [ ] Confirm `RPC_KEEPALIVE_PING_DELAY_SECONDS=30` is in the pod env (`kubectl describe pod -n heimdall remote-headless-1-0`)
- [ ] Observe 24–48 h, then propose mainnet rollout PR

## Related

- planetarium/NineChronicles.Headless#2762 — keepalive opt-in (env-driven)
- planetarium/NineChronicles.Headless#2760 — `LeaveAsync` cleanup guard
- planetarium/NineChronicles#7264 — companion client-side issue (deadlines + ChannelOptions; needs app release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)