### PR TITLE
feat(9c-main): bump headless + enable HTTP/2 keepalive on heimdall/odin

### DIFF
--- a/9c-internal/network/heimdall.yaml
+++ b/9c-internal/network/heimdall.yaml
@@ -126,9 +126,6 @@ seed:
 
 remoteHeadless:
   count: 1
-  image:
-    repository: planetariumhq/ninechronicles-headless
-    pullPolicy: Always
 
   env:
     - name: RPC_KEEPALIVE_PING_DELAY_SECONDS

--- a/9c-main/network/general.yaml
+++ b/9c-main/network/general.yaml
@@ -4,7 +4,7 @@ provider: RKE2
 global:
   image:
     repository: planetariumhq/ninechronicles-headless
-    tag: "392"
+    tag: "git-436932c92da4c179a8fbbf3a8a3f327a540c6be2"
 
 seed:
   image:

--- a/9c-main/network/heimdall.yaml
+++ b/9c-main/network/heimdall.yaml
@@ -175,6 +175,10 @@ remoteHeadless:
   count: 2
   replicas: 1
 
+  env:
+    - name: RPC_KEEPALIVE_PING_DELAY_SECONDS
+      value: "30"
+
   scheduledRestart:
     enabled: true
     schedule: "0 22 * * *"

--- a/9c-main/network/odin.yaml
+++ b/9c-main/network/odin.yaml
@@ -201,6 +201,10 @@ remoteHeadless:
   count: 3
   replicas: 1
 
+  env:
+    - name: RPC_KEEPALIVE_PING_DELAY_SECONDS
+      value: "30"
+
   scheduledRestart:
     enabled: true
     schedule: "0 22 * * *"


### PR DESCRIPTION
## Summary

Follow-up to #3410 (which handled 9c-internal). Rolls the same image and keepalive enablement out to mainnet, and cleans up a dead override that was discovered while reviewing #3410.

- `9c-main/network/general.yaml` — headless image tag `392` → `git-436932c92da4c179a8fbbf3a8a3f327a540c6be2`
- `9c-main/network/heimdall.yaml` — `RPC_KEEPALIVE_PING_DELAY_SECONDS=30` (covers 2 pods)
- `9c-main/network/odin.yaml` — `RPC_KEEPALIVE_PING_DELAY_SECONDS=30` (covers 3 pods)
- `9c-internal/network/heimdall.yaml` — drop dead `remoteHeadless.image` block (repository was set but `tag` was not, so the chart's `if and repository tag` check always fell back to `global.image` — the override was a no-op)

> **Note**: mainnet image is now pinned to a git-SHA instead of the release-number convention. This is a temporary deviation to pick up planetarium/NineChronicles.Headless#2760 + #2762 ahead of the next release. Reset to a release number tag (`393` or whatever is cut next) once those PRs are bundled.

## What's included in the image bump

Since `release/392` cut, two PRs landed on `development` HEAD `git-436932c9...`:

- planetarium/NineChronicles.Headless#2762 — opt-in `RPC_KEEPALIVE_PING_DELAY_SECONDS` env (default off; this PR is the explicit opt-in)
- planetarium/NineChronicles.Headless#2760 — `ActionEvaluationPublisher.RemoveClient` always disposes even if `LeaveAsync` throws

## Expected impact

- **All 5 mainnet `remote-headless` pods** (heimdall ×2, odin ×3) rolling restart on next ArgoCD sync — same restart cadence the daily 22:00 UTC cron already performs.
- Kestrel begins sending HTTP/2 PINGs every 30 s on idle gRPC streams; ~50 s dead-detection budget (delay + default 20 s timeout). Within the safe window for Unity GC pauses.
- `_clients` zombie cleanup happens via the actual disconnect path much sooner instead of waiting for TCP RST. Odin should see the biggest visible improvement because of its NetMQ 1 s timeout volume (Hetzner peers).
- No new user-facing UI / popup — existing `DimmedLoadingScreen` + `IconAndButtonSystem` reconnect flow in the client already covers it (planetarium/NineChronicles#7264 will eventually surface this on the client side too).

## Risk

| Item | Assessment |
|---|---|
| Code path change | None on the server; only an opt-in `if` branch. Defaults preserved unless env is set (and it now is). |
| Rolling restart | Same kind as daily cron. ArgoCD sync triggers it once. |
| Image format deviation | git-SHA on mainnet — recoverable, planned reset to release number. |
| Rollback | Drop the `env:` block (keepalive off) or re-pin tag to `392` (full revert). Both are one-line edits. |

## Rollout / validation

1. Merge
2. ArgoCD sync `heimdall` and `odin` (default ctx) — manual unless auto-sync is on
3. Confirm pod env (`kubectl describe pod -n heimdall remote-headless-1-0 | grep RPC_KEEPALIVE`)
4. 24-48 h observation: client connection count, `LeaveAsync failed (...)` log frequency, nginx 502/499 distribution, Player.log reports

## Related

- #3410 — 9c-internal counterpart (merged)
- planetarium/NineChronicles.Headless#2762, #2760 (merged)
- planetarium/NineChronicles#7264 — client-side companion (needs app release)

## Test plan

- [x] Image `git-436932c92da4c179a8fbbf3a8a3f327a540c6be2` published to Docker Hub
- [ ] Merge → ArgoCD sync heimdall (default ctx) → 2 pods restart → env present
- [ ] ArgoCD sync odin (default ctx) → 3 pods restart → env present
- [ ] Observation window 24-48 h

🤖 Generated with [Claude Code](https://claude.com/claude-code)