### PR TITLE
fix(9c-main): merge RPC_KEEPALIVE into existing remoteHeadless.env (duplicate key bug)

### DIFF
--- a/9c-main/network/heimdall.yaml
+++ b/9c-main/network/heimdall.yaml
@@ -175,10 +175,6 @@ remoteHeadless:
   count: 2
   replicas: 1
 
-  env:
-    - name: RPC_KEEPALIVE_PING_DELAY_SECONDS
-      value: "30"
-
   scheduledRestart:
     enabled: true
     schedule: "0 22 * * *"
@@ -213,6 +209,8 @@ remoteHeadless:
       secretKeyRef:
         key: jwt
         name: private-keys
+  - name: RPC_KEEPALIVE_PING_DELAY_SECONDS
+    value: "30"
 
   extraArgs:
   - --tx-quota-per-signer=1

--- a/9c-main/network/odin.yaml
+++ b/9c-main/network/odin.yaml
@@ -201,10 +201,6 @@ remoteHeadless:
   count: 3
   replicas: 1
 
-  env:
-    - name: RPC_KEEPALIVE_PING_DELAY_SECONDS
-      value: "30"
-
   scheduledRestart:
     enabled: true
     schedule: "0 22 * * *"
@@ -243,6 +239,8 @@ remoteHeadless:
       secretKeyRef:
         key: jwt
         name: private-keys
+  - name: RPC_KEEPALIVE_PING_DELAY_SECONDS
+    value: "30"
 
   extraArgs:
   - --tx-quota-per-signer=1


### PR DESCRIPTION
## Summary

Follow-up to #3411. The keepalive env didn't actually reach mainnet pods because of a YAML duplicate-key issue.

Diff per file: removes the standalone `env:` block we added near the top of `remoteHeadless`, and appends `RPC_KEEPALIVE_PING_DELAY_SECONDS=30` to the existing `env:` block that lives lower in the same `remoteHeadless` section (next to `Headless__AccessControlService__*`, `PLUGIN_PATH`, `DOTNET_gcServer`, `JWT__Key`).

## Root cause

Both `9c-main/network/heimdall.yaml` and `9c-main/network/odin.yaml` already had a `remoteHeadless.env:` block (the AccessControlService env). #3411 added a second `env:` higher up in the same `remoteHeadless` block. Per YAML spec, when the same key appears twice at the same indent level the **second value wins**, so `helm template` received the AccessControl env list and silently dropped the keepalive entry. Verified by inserting debug ChannelOptions into the chart template and re-rendering — `kindOf` was `slice`, `len` matched the AccessControl list, and `keys` showed `env` was present but pointed at the wrong list.

`9c-internal/network/heimdall.yaml` does not have a second env block, so #3411 worked correctly there once the internal cluster ArgoCD was synced (rke2 ctx, separate from the default ctx that #3411 already covered).

## Verification

After this patch, local `helm template charts/all-in-one -f 9c-main/network/general.yaml -f 9c-main/network/heimdall.yaml | grep RPC_KEEPALIVE` returns the expected env entry. Same for odin.

## Risk

| Item | Assessment |
|---|---|
| Code change | YAML-only, two files, +4 / -8 lines. |
| Behavior change | Mainnet heimdall (2) + odin (3) remote-headless pods will roll restart once on next sync (still same image, just env added). After restart Kestrel begins HTTP/2 PING every 30 s — the actual goal of #3411. |
| Rollback | Drop the appended line from each env block, ArgoCD sync. |

## Rollout

1. Merge
2. ArgoCD sync `heimdall` and `odin` (default ctx) — selective on the two StatefulSets per app
3. Verify pod env contains `RPC_KEEPALIVE_PING_DELAY_SECONDS=30`
4. Observe zombie cleanup / `LeaveAsync` log frequency over 24-48 h

## Related

- #3410 — 9c-internal counterpart (merged, working after internal sync)
- #3411 — original mainnet PR (merged, image bump took effect, env was silently dropped due to this bug)
- planetarium/NineChronicles.Headless#2762 — server-side keepalive opt-in
- planetarium/NineChronicles.Headless#2760 — LeaveAsync cleanup guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)