### PR TITLE
chore(9c-main): deactivate odin remote-headless-3 (count 3 → 2)

### DIFF
--- a/9c-main/network/odin.yaml
+++ b/9c-main/network/odin.yaml
@@ -198,7 +198,7 @@ validator:
       memory: 30Gi
 
 remoteHeadless:
-  count: 3
+  count: 2
   replicas: 1
 
   scheduledRestart:


### PR DESCRIPTION
## Summary

Reduces mainnet odin `remoteHeadless.count` from 3 → 2. ArgoCD sync will delete the `remote-headless-3` StatefulSet, terminating its pod. PVC + volume are retained (`volumeReclaimPolicy: Retain`), so reverting this change re-mounts the same data and brings the pod back.

> **Draft** — review-only. Merge when ready. nginx cleanup (separate) should land first or together so bot traffic against `odin-rpc-3.nine-chronicles.com` doesn't get 502.

## Why

Following the planet registry change that removed `odin-rpc-3.nine-chronicles.com` from `mainnet.json`, a 24h Prometheus trend shows:

| pod | RPC clients (peak / current) | HTTP req/s (peak / current) |
|---|---|---|
| odin/rh-1 | 27 / ~17 | 18.2 / ~14 |
| odin/rh-2 | 86 / 0 | 12.5 / 7 |
| odin/rh-3 | 73 / **1-2** | 6.0 / ~4 |

- After daily cron restart cycle, rh-3 user count dropped from 73 → 1-2 (cache expired, clients re-fetched registry, moved to odin-rpc-1 / odin5 / odin6).
- Remaining ~4 req/s on rh-3 is automated-bot traffic still hitting the hostname directly (e.g. `211.97.125.209` China Unicom doing `GetAvatarStatesByBlockHash`).
- rh-1 absorbed the rebalance without strain: CPU 9%, mem 44%, peak 24 clients, 18 req/s — comfortably within 5 cores / 25 GiB request.

## Risk

| Item | Assessment |
|---|---|
| Code change | YAML 1 line (`count: 3 → 2`) |
| Reverting | Single-line revert; PVC + storage definition retained; StatefulSet re-creates on next sync |
| SPOF | mainnet odin now has rh-1 + rh-2 (2 pods) + external odin5/odin6 — still 4 endpoints worth of capacity |
| HDD-bound state read | unchanged; rh-1 and rh-2 still serve heavy `GetAvatarStatesByBlockHash` traffic. Monitor p95/p99 GraphQL latency for regressions |
| nginx fallout (502) | ⚠️ `odin-rpc-3.nine-chronicles.com` upstream `odin_grpc_rpc3` points at rh-3. Bot traffic and any cached client will get 502 after this PR. Followup needed to remap to `odin_grpc_backend` (multi-backend fallback) or drop the DNS entry. |

## Rollout

1. **Optional pre-step (recommended)**: nginx config on `115.68.221.180` —
   - either remap `odin-rpc-3.nine-chronicles.com` to `odin_grpc_backend` fallback
   - or drop the hostname (DNS + nginx)
2. Merge this PR
3. ArgoCD sync `odin` (default ctx) — selective `apps/StatefulSet/remote-headless-3` (pruning) or full sync
4. Confirm `kubectl -n odin get pod | grep remote-headless` only shows rh-1 and rh-2
5. PVC `remote-headless-data-3-remote-headless-3-0` and PV remain (Retain). Disk reclaim is a separate operator decision.

## Verification (post-merge)

```bash
# pod 종료 확인
kubectl --context default -n odin get statefulset
# → remote-headless-1, remote-headless-2 만 남음

# PVC는 살아있음 (Retain)
kubectl --context default -n odin get pvc | grep remote-headless-data-3
# → Bound 상태 유지

# 메트릭에서 rh-3 인스턴스 사라짐 확인
# Grafana: ninechronicles_rpc_clients_count{instance=~"remote-headless-3.*"} → no data
```

## Revert

```yaml
# 9c-main/network/odin.yaml
remoteHeadless:
  count: 3  # ← 되돌리고 PR + sync
  replicas: 1
```

복구는 같은 PVC로 자동 mount되어 rh-3 데이터 그대로 사용. 데이터 sync 따라잡기 시간은 빠짐 시간에 비례 (보통 분~시간 단위).

🤖 Generated with [Claude Code](https://claude.com/claude-code)