### PR TITLE
chore(9c-main): drop remote-headless-data-3 PVC from odin storage

### DIFF
--- a/9c-main/network/odin.yaml
+++ b/9c-main/network/odin.yaml
@@ -25,8 +25,6 @@ global:
     data: 650Gi
   - name: remote-headless-data-2-remote-headless-2-0
     data: 650Gi
-  - name: remote-headless-data-3-remote-headless-3-0
-    data: 650Gi
   - name: remote-headless-data-4-remote-headless-4-0
     data: 650Gi
   - name: remote-headless-data-5-remote-headless-5-0


### PR DESCRIPTION
## Summary

Removes `remote-headless-data-3-remote-headless-3-0` from `global.storage` in `9c-main/network/odin.yaml`. ArgoCD sync with prune will delete the PVC; the PV + Longhorn volume need manual cleanup afterward.

This is the prerequisite to migrating `validator-5`'s Longhorn replica off `odin-4` so we can decommission that node for cost savings.

## Why

- `odin/rh-3` was deactivated in #3413 (StatefulSet `count: 3 → 2`); its PVC was retained for potential rollback.
- The rh-3 replica sits on `odin-1` consuming 650GB of the 687GB disk.
- Longhorn's `StorageOverProvisioningPercentage = 100` is strict — no over-provisioning allowed cluster-wide.
- Capacity audit (`scheduled / max`):
  - odin-1: 650 / 687 GB (37 GB headroom)  ← rh-3 sits here
  - odin-2: 70 / 687 GB (617 GB headroom)
  - odin-3: 1390 / 1672 GB (282 GB headroom)
- None can fit the validator-5 replica (~650GB scheduled, 350GB actual) without freeing space first.
- Deleting rh-3 frees the slot on odin-1, which is large enough.

## What this PR does (Step 1 of multi-step)

- `9c-main/network/odin.yaml`: drop the `data-3` entry from `global.storage`

```yaml
# Before
global:
  storage:
  - name: remote-headless-data-1-remote-headless-1-0
    data: 650Gi
  - name: remote-headless-data-2-remote-headless-2-0
    data: 650Gi
  - name: remote-headless-data-3-remote-headless-3-0   # ← removed
    data: 650Gi
  - name: remote-headless-data-4-remote-headless-4-0
    data: 650Gi
  - name: remote-headless-data-5-remote-headless-5-0
    data: 650Gi
  - name: data-provider-data
    data: 650Gi
```

## Manual follow-up (after merge & ArgoCD sync prunes the PVC)

```bash
# PV remains because of volumeReclaimPolicy: Retain
kubectl --context default delete pv pvc-a3147d31-08cb-4420-9790-56043137a27a

# Longhorn volume must be deleted explicitly per CLAUDE.md PVC deletion procedure
kubectl --context default -n longhorn-system delete volumes.longhorn.io \
    pvc-a3147d31-08cb-4420-9790-56043137a27a
```

Verify with:
```bash
kubectl --context default -n longhorn-system get nodes.longhorn.io 9c-main-odin-1 -o json | \
    jq '.status.diskStatus["odin-1"] | {storageScheduled, storageMaximum}'
# scheduled should drop from ~650GB to ~0GB
```

## Then (separate operator steps, not in this PR)

1. Expand validator-5 PVC's Longhorn replica count `1 → 2`, with new replica targeted to `odin-1`. Rebuild ~650GB will take a few hours; validator-5 pod stays Running throughout.
2. After odin-1 replica reaches `healthy`, evict the odin-4 replica.
3. `odin-4` becomes empty (prometheus-server was already moved to baremetal-1).
4. Drain & `kubectl delete node 9c-main-odin-4`.

## Risk

| Item | Assessment |
|---|---|
| Data loss | ⚠️ rh-3 RocksDB data deleted permanently — rollback to rh-3 active no longer possible without full resync from snapshot/peers |
| Other PVCs (data-1, 2, 4, 5) | ✅ unaffected |
| rh-1, rh-2 pods | ✅ unaffected (their PVCs are data-4 and data-2, kept) |
| validator-5 | ✅ unaffected by this PR alone (replica migration happens after, separately) |
| ArgoCD app | Will show PVC OutOfSync → sync with prune to remove |

## Test plan

- [ ] Merge
- [ ] ArgoCD sync with `Prune=true` on `PersistentVolumeClaim/remote-headless-data-3-remote-headless-3-0`
- [ ] Manual `kubectl delete pv ...` + `kubectl delete volumes.longhorn.io ...`
- [ ] Verify odin-1 scheduled capacity dropped by 650GB
- [ ] Proceed with validator-5 replica migration (separate ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)