### PR TITLE
chore(9c-main): drop remote-headless-data-5 orphan PVC from odin storage

### DIFF
--- a/9c-main/network/odin.yaml
+++ b/9c-main/network/odin.yaml
@@ -27,8 +27,6 @@ global:
     data: 650Gi
   - name: remote-headless-data-4-remote-headless-4-0
     data: 650Gi
-  - name: remote-headless-data-5-remote-headless-5-0
-    data: 650Gi
   - name: data-provider-data
     data: 650Gi
 


### PR DESCRIPTION
## Summary

Removes `remote-headless-data-5-remote-headless-5-0` from `global.storage` in `9c-main/network/odin.yaml`. Companion follow-up to #3414.

## Why

After #3414 freed up `odin-1`'s 650GB slot (rh-3 PVC pruned), Longhorn's scheduler **immediately** placed the rh-5 PVC's replica on `odin-1`, re-consuming the headroom we needed for the validator-5 migration.

Pre-flight check on rh-5 confirms it's an orphan:

| Property | Value |
|---|---|
| Mounted by pod | (none) |
| StatefulSet `remote-headless-5` | doesn't exist (count=2) |
| Longhorn volume state | `detached` |
| `actualSize` | **0 bytes** |
| Age | ~9 days idle |

So it's safe to delete — there is literally no data in it.

## What this PR does

`9c-main/network/odin.yaml`: drop the `data-5` entry from `global.storage`.

```yaml
# Before
global:
  storage:
  - name: remote-headless-data-1-remote-headless-1-0
  - name: remote-headless-data-2-remote-headless-2-0
  - name: remote-headless-data-4-remote-headless-4-0
  - name: remote-headless-data-5-remote-headless-5-0   # ← removed (orphan)
  - name: data-provider-data
```

## Manual follow-up after merge & sync prunes PVC

```bash
PV=pvc-b2668a23-65f3-409f-bf6b-19032e72c7d6
kubectl --context default delete pv $PV
kubectl --context default -n longhorn-system delete volumes.longhorn.io $PV
```

Verify:
```bash
kubectl --context default -n longhorn-system get nodes.longhorn.io 9c-main-odin-1 \
  -o json | jq '.status.diskStatus["odin-1"] | {storageScheduled, storageAvailable}'
# scheduled should drop to ~0GB after both rh-3 and rh-5 are gone
```

## Then

Proceed with validator-5 replica migration: temp replica=2 expansion (new replica on odin-1) → rebuild ~650GB → evict odin-4 replica → odin-4 ready for decommission.

## Risk

- Data loss: ⚠️ none (volume actualSize=0, no real data exists)
- Other PVCs: ✅ unaffected
- ArgoCD: PVC will appear OutOfSync → sync with `Prune=true` deletes it

## Test plan

- [ ] Merge
- [ ] ArgoCD selective sync (`Prune=true`) on `PersistentVolumeClaim/remote-headless-data-5-remote-headless-5-0`
- [ ] Manual delete PV + Longhorn volume
- [ ] Verify odin-1 scheduled drops to ~0GB
- [ ] Begin validator-5 replica migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)