### PR TITLE
chore(9c-main): drop data-provider-data orphan PVC from odin storage

### DIFF
--- a/9c-main/network/odin.yaml
+++ b/9c-main/network/odin.yaml
@@ -27,8 +27,6 @@ global:
     data: 650Gi
   - name: remote-headless-data-4-remote-headless-4-0
     data: 650Gi
-  - name: data-provider-data
-    data: 650Gi
 
 RKE2:
   loadBalancerIPs:


### PR DESCRIPTION
## Summary

Third in the "free up odin-1 for validator-5 migration" series, after #3414 (rh-3) and #3415 (rh-5). Removes `data-provider-data` from `global.storage` in `9c-main/network/odin.yaml`.

## Why

After #3415 freed odin-1's slot, Longhorn's scheduler immediately placed the `data-provider-data` PVC's replica on odin-1 (the same auto-rebalance behavior we saw with rh-5). This is the third orphan in odin namespace:

| Property | Value |
|---|---|
| Mounted by pod | (none) — `dataProvider.enabled: false` in odin.yaml |
| Deployment / StatefulSet | doesn't exist |
| Longhorn volume state | `detached` |
| `actualSize` | **0 bytes** |

Same pattern as rh-5: chart declares a PVC that no workload consumes, Longhorn auto-rebalances detached replicas onto whatever node has free space.

odin namespace PVC audit confirms only 3 orphans (now reduced to 1 remaining):

| PVC | Used? | State | actualSize |
|---|---|---|---|
| ~~remote-headless-data-3~~ | ORPHAN | (deleted in #3414) | - |
| ~~remote-headless-data-5~~ | ORPHAN | (deleted in #3415) | - |
| **data-provider-data** | **ORPHAN** | **detached** | **0 GB** ← this PR |
| remote-headless-data-1 (validator-5) | YES | attached | 325 GB |
| remote-headless-data-2 (rh-2) | YES | attached | 332 GB |
| remote-headless-data-4 (rh-1) | YES | attached | 328 GB |
| snapshot-partition-data-baremetal | ORPHAN | detached | 644 GB (KEEP — actual data exists, baremetal-1 storage, doesn't affect odin-1) |

## What this PR does

`9c-main/network/odin.yaml`: drop `data-provider-data` from `global.storage`.

## Manual follow-up

```bash
PV=pvc-38070eb6-4052-4a5d-9ea0-ddd328ab02cd
kubectl --context default delete pv $PV
kubectl --context default -n longhorn-system delete volumes.longhorn.io $PV
```

Verify odin-1 truly has 0GB scheduled:
```bash
kubectl --context default -n longhorn-system get nodes.longhorn.io 9c-main-odin-1 \
  -o json | jq '.status.diskStatus["odin-1"] | {storageScheduled, storageAvailable}'
```

## Then

validator-5 volume already has `numberOfReplicas: 2` set (waiting in degraded state because of scheduling failure). Once odin-1 is truly free, Longhorn should auto-retry the scheduling and place the new replica on odin-1. If it doesn't auto-trigger, a no-op patch on the volume can re-kick the scheduler.

## Risk

- Data loss: ✅ none (actualSize = 0)
- ArgoCD: PVC will show OutOfSync → sync with `Prune=true`

## Test plan

- [ ] Merge
- [ ] ArgoCD selective sync (Prune=true) on the PVC
- [ ] Manual PV + Longhorn volume delete
- [ ] Verify odin-1 scheduled drops to ~0GB
- [ ] Verify validator-5 new replica auto-spawns on odin-1 (or kick via no-op patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)