### PR TITLE
feat(fluent-bit): route ragnarok-breaker logs to Loki

### DIFF
--- a/common/bootstrap-v2/templates/fluent-bit/configmap-fluent-bit.yaml
+++ b/common/bootstrap-v2/templates/fluent-bit/configmap-fluent-bit.yaml
@@ -54,6 +54,20 @@ data:
         Match                        application.*
         Rule                         $kubernetes['container_name'] ^.*$ s3.$kubernetes['namespace_name'].$kubernetes['container_name'].$TAG true
         Emitter_Name                 for_s3
+    [FILTER]
+        Name                         rewrite_tag
+        Match                        application.*
+        Rule                         $kubernetes['namespace_name'] ^ragnarok-breaker(-staging)?$ loki_rb.$kubernetes['namespace_name'].$kubernetes['container_name'].$TAG true
+        Emitter_Name                 for_loki_rb
+    [OUTPUT]
+        Name                         loki
+        Match                        loki_rb.*
+        host                         loki-gateway.monitoring.svc.cluster.local
+        port                         80
+        labels                       job=ragnarok-breaker, alias=$kubernetes['namespace_name'].$kubernetes['container_name'], pod=$kubernetes['pod_name'], host=$kubernetes['host'], container=$kubernetes['container_name'], namespace=$kubernetes['namespace_name']
+        auto_kubernetes_labels       on
+        line_format                  json
+        workers                      8
     {{- if eq .Values.provider "AWS" }}
     [OUTPUT]
         Name                         s3


### PR DESCRIPTION
## Summary

Tail-and-ship every `ragnarok-breaker` workload's stdout to Loki, so log-stream / worker / v8-gateway / ygg-redeem / ygg-quest-worker / bq-analytics-worker all become queryable from Grafana with retention beyond the kubelet's local rotation.

How: extends the existing `application.*` tail in [common/bootstrap-v2/templates/fluent-bit/configmap-fluent-bit.yaml](common/bootstrap-v2/templates/fluent-bit/configmap-fluent-bit.yaml) — same pattern as the `petpop` Loki rule a few blocks below — with:

- a second `rewrite_tag` filter that re-emits to `loki_rb.*` whenever `$kubernetes['namespace_name']` matches `^ragnarok-breaker(-staging)?$`. `keep=true`, so the S3 archive path is untouched.
- a Loki OUTPUT that ships `loki_rb.*` to `loki-gateway.monitoring.svc.cluster.local:80`, labelled `job=ragnarok-breaker, alias=$ns.$container, pod=$pod, host=$host, container=$container, namespace=$ns` (petpop-style).

Reuses the existing application.* tail rather than introducing a new INPUT, so we don't double-read container log files or duplicate fluent-bit state DBs. Provider-agnostic — Loki ships on both AWS and RKE2; only the S3 archive sidecar remains AWS-gated.

Bootstrap-v2 is referenced by both clusters' `bootstrap.yaml` (9c-main, 9c-internal), so this single change reaches production and staging in one merge.

## Rollout / verification

- [ ] ArgoCD `bootstrap` Application syncs cleanly in 9c-main and 9c-internal
- [ ] fluent-bit pods pick up the new `fluent-bit-config` ConfigMap. The chart's `existingConfigMap` setup does not auto-rollout on ConfigMap content change — verify pods reloaded the config (either restart the DaemonSet or wait for fluent-bit's own config watcher; check `/api/v1/uptime` against the merge time)
- [ ] In Grafana, `{job="ragnarok-breaker"}` returns lines from staging within ~minutes; `{job="ragnarok-breaker", container="log-stream"}` narrows to log-stream
- [ ] In Grafana, `{job="ragnarok-breaker", namespace="ragnarok-breaker"}` returns production lines
- [ ] No regression in petpop / 9c-headless Loki streams (unaffected blocks)

## Notes

- Loki retention is the cluster-wide setting in [common/bootstrap-v2/templates/loki.yaml](common/bootstrap-v2/templates/loki.yaml#L81) (currently `360h` = 15 days). Not touched here; bump it in a separate PR if a longer window is wanted for rb.
- If a future `ragnarok-breaker-canary` (or similar) namespace appears, the regex `^ragnarok-breaker(-staging)?$` will need widening to `^ragnarok-breaker(-[a-z0-9-]+)?$` or an explicit alternation.