### PR TITLE
chore(9c-main): drop stale rh-3/odin-4 entries from odin remoteHeadless arrays

### DIFF
--- a/9c-main/network/odin.yaml
+++ b/9c-main/network/odin.yaml
@@ -204,20 +204,16 @@ remoteHeadless:
   hosts:
   - "odin-node-1.nine-chronicles.com"
   - "odin-node-2.nine-chronicles.com"
-  - "odin-node-3.nine-chronicles.com"
 
   loadBalancerIPs:
   - 115.68.194.60
   - 115.68.194.98
-  - 115.68.194.103
 
   nodeSelector:
   - node.kubernetes.io/network: odin
     node.kubernetes.io/node-index: '1'
   - node.kubernetes.io/network: odin
     node.kubernetes.io/node-index: '2'
-  - node.kubernetes.io/network: odin
-    node.kubernetes.io/node-index: '4'
 
   env:
   - name: Headless__AccessControlService__AccessControlServiceType
@@ -250,7 +246,6 @@ remoteHeadless:
     volumeNames:
     - remote-headless-data-4-remote-headless-4-0
     - remote-headless-data-2-remote-headless-2-0
-    - remote-headless-data-3-remote-headless-3-0
 
   tolerations:
   - effect: NoSchedule


### PR DESCRIPTION
## Summary

After decommissioning `odin/rh-3` (#3413) and the underlying `9c-main-odin-4` node, four arrays in `9c-main/network/odin.yaml` still carry their pre-shrink third entries. With `count: 2` they are harmless (helm only iterates the first two), but they point at resources that no longer exist:

| Array | Stale 3rd entry | Why stale |
|---|---|---|
| `hosts` | `odin-node-3.nine-chronicles.com` | rh-3 hostname, already removed from planet registry |
| `loadBalancerIPs` | `115.68.194.103` | was odin-4 node IP, node deleted today |
| `nodeSelector` | `node-index: '4'` | was odin-4 node, node deleted today |
| `storage.volumeNames` | `remote-headless-data-3-remote-headless-3-0` | PVC pruned in #3414 |

## Risk

- Behavioral change: **none** with `count: 2` (helm ignores the third entries already)
- Future safety: ✅ prevents accidental zombie activation if someone bumps count back to 3 without re-checking IPs/PVCs
- Reverting: this PR can be reverted; the entries can be re-added if rh-3 is genuinely brought back, but they should be re-evaluated (IP, node-index, etc.) at that point rather than relying on stale config

## Diff

```yaml
   hosts:
   - "odin-node-1.nine-chronicles.com"
   - "odin-node-2.nine-chronicles.com"
-  - "odin-node-3.nine-chronicles.com"

   loadBalancerIPs:
   - 115.68.194.60
   - 115.68.194.98
-  - 115.68.194.103

   nodeSelector:
   - node.kubernetes.io/network: odin
     node.kubernetes.io/node-index: '1'
   - node.kubernetes.io/network: odin
     node.kubernetes.io/node-index: '2'
-  - node.kubernetes.io/network: odin
-    node.kubernetes.io/node-index: '4'

   storage:
     volumeNames:
     - remote-headless-data-4-remote-headless-4-0
     - remote-headless-data-2-remote-headless-2-0
-    - remote-headless-data-3-remote-headless-3-0
```

## Related

- #3413 odin rh-3 deactivation (count 3→2)
- #3414/#3415/#3416 PVC cleanup (rh-3 / rh-5 / data-provider-data)
- odin-4 node deleted today (validator-5 replica migrated to odin-1)

## Test plan

- [ ] Merge
- [ ] `helm template charts/all-in-one -f 9c-main/network/general.yaml -f 9c-main/network/odin.yaml | grep remote-headless-3` ⇒ no matches (confirms nothing breaks)
- [ ] ArgoCD sync on odin (no resources should change — these were no-op entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)