### PR TITLE
feat(ragnarok-breaker): split into 6 env×tier namespaces

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/application.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ragnarok-breaker-dev-web2
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/planetarium/9c-infra.git
+    targetRevision: main
+    path: charts/ragnarok-breaker
+    helm:
+      valueFiles:
+        - /9c-internal/ragnarok-breaker-dev-web2/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ragnarok-breaker-dev-web2
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -1,0 +1,45 @@
+externalSecretKey: ragnarok-breaker/dev-web2
+
+imagePullSecret:
+  secretKey: ragnarok-breaker/dockerhub
+
+# dev: only leagueSnapshot runs; scheduler + 3 validation workers OFF
+# (scheduler is the producer for game/gameplay/summon validation queues —
+# leaving it on with the consumers off would pile up jobs in Redis.)
+workers:
+  scheduler:
+    enabled: false
+  gameValidator:
+    enabled: false
+  gameplayValidator:
+    enabled: false
+  summonValidator:
+    enabled: false
+
+worker:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+v8Gateway:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+logStream:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+# web2: ygg / bigquery workloads are disabled, but their image.tag is still
+# pinned so `bump-image rb <hash>` (bulk) stays uniform across env×tier and
+# a future promotion to web3 doesn't need a separate tag-fill step.
+yggRedeem:
+  enabled: false
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+yggQuestWorker:
+  enabled: false
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+bqAnalyticsWorker:
+  enabled: false
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229

--- a/9c-internal/ragnarok-breaker-dev-web3/application.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ragnarok-breaker-dev-web3
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/planetarium/9c-infra.git
+    targetRevision: main
+    path: charts/ragnarok-breaker
+    helm:
+      valueFiles:
+        - /9c-internal/ragnarok-breaker-dev-web3/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ragnarok-breaker-dev-web3
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -1,0 +1,43 @@
+externalSecretKey: ragnarok-breaker/dev-web3
+
+imagePullSecret:
+  secretKey: ragnarok-breaker/dockerhub
+
+# dev: only leagueSnapshot runs; scheduler + 3 validation workers OFF
+workers:
+  scheduler:
+    enabled: false
+  gameValidator:
+    enabled: false
+  gameplayValidator:
+    enabled: false
+  summonValidator:
+    enabled: false
+
+worker:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+v8Gateway:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+logStream:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+yggRedeem:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+  httpRoute:
+    enabled: true
+    hostnames:
+      - ygg-redeem-dev.9c.gg
+
+yggQuestWorker:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+bqAnalyticsWorker:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229

--- a/9c-internal/ragnarok-breaker-staging-web2/application.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ragnarok-breaker-staging-web2
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/planetarium/9c-infra.git
+    targetRevision: main
+    path: charts/ragnarok-breaker
+    helm:
+      valueFiles:
+        - /9c-internal/ragnarok-breaker-staging-web2/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ragnarok-breaker-staging-web2
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -1,0 +1,31 @@
+externalSecretKey: ragnarok-breaker/staging-web2
+
+imagePullSecret:
+  secretKey: ragnarok-breaker/dockerhub
+
+worker:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+v8Gateway:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+logStream:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+# web2: ygg / bigquery workloads are disabled, but image.tag is pinned
+# so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
+yggRedeem:
+  enabled: false
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+yggQuestWorker:
+  enabled: false
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+bqAnalyticsWorker:
+  enabled: false
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229

--- a/9c-internal/ragnarok-breaker-staging-web3/application.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ragnarok-breaker-staging-web3
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/planetarium/9c-infra.git
+    targetRevision: main
+    path: charts/ragnarok-breaker
+    helm:
+      valueFiles:
+        - /9c-internal/ragnarok-breaker-staging-web3/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ragnarok-breaker-staging-web3
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -1,0 +1,32 @@
+externalSecretKey: ragnarok-breaker/staging-web3
+
+imagePullSecret:
+  secretKey: ragnarok-breaker/dockerhub
+
+worker:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+v8Gateway:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+logStream:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+yggRedeem:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+  httpRoute:
+    enabled: true
+    hostnames:
+      - ygg-redeem-staging.9c.gg
+
+yggQuestWorker:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+bqAnalyticsWorker:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229

--- a/9c-main/ragnarok-breaker-prod-web2/application.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ragnarok-breaker-prod-web2
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/planetarium/9c-infra.git
+    targetRevision: main
+    path: charts/ragnarok-breaker
+    helm:
+      valueFiles:
+        - /9c-main/ragnarok-breaker-prod-web2/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ragnarok-breaker-prod-web2
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -1,0 +1,31 @@
+externalSecretKey: ragnarok-breaker/prod-web2
+
+imagePullSecret:
+  secretKey: ragnarok-breaker/dockerhub
+
+worker:
+  image:
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+
+v8Gateway:
+  image:
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+
+logStream:
+  image:
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+
+# web2: ygg / bigquery workloads are disabled, but image.tag is pinned
+# so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
+yggRedeem:
+  enabled: false
+  image:
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+yggQuestWorker:
+  enabled: false
+  image:
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+bqAnalyticsWorker:
+  enabled: false
+  image:
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5

--- a/9c-main/ragnarok-breaker-prod-web3/application.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/application.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ragnarok-breaker-prod-web3
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/planetarium/9c-infra.git
+    targetRevision: main
+    path: charts/ragnarok-breaker
+    helm:
+      valueFiles:
+        - /9c-main/ragnarok-breaker-prod-web3/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ragnarok-breaker-prod-web3
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -1,0 +1,35 @@
+externalSecretKey: ragnarok-breaker/prod-web3
+
+imagePullSecret:
+  secretKey: ragnarok-breaker/dockerhub
+
+worker:
+  image:
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+
+v8Gateway:
+  image:
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+
+logStream:
+  image:
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+
+yggRedeem:
+  image:
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+  deployment:
+    replicas: 2
+  httpRoute:
+    enabled: true
+    hostnames:
+      - ygg-redeem.9c.gg
+
+yggQuestWorker:
+  image:
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+  replicas: 2
+
+bqAnalyticsWorker:
+  image:
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5

--- a/common/bootstrap-v2/templates/fluent-bit/configmap-fluent-bit.yaml
+++ b/common/bootstrap-v2/templates/fluent-bit/configmap-fluent-bit.yaml
@@ -57,7 +57,7 @@ data:
     [FILTER]
         Name                         rewrite_tag
         Match                        application.*
-        Rule                         $kubernetes['namespace_name'] ^ragnarok-breaker(-staging)?$ loki_rb.$kubernetes['namespace_name'].$kubernetes['container_name'].$TAG true
+        Rule                         $kubernetes['namespace_name'] ^(ragnarok-breaker|ragnarok-breaker-staging|ragnarok-breaker-(dev|staging|prod)-web[23])$ loki_rb.$kubernetes['namespace_name'].$kubernetes['container_name'].$TAG true
         Emitter_Name                 for_loki_rb
     [OUTPUT]
         Name                         loki

--- a/scripts/bump-image.sh
+++ b/scripts/bump-image.sh
@@ -13,7 +13,9 @@ set -euo pipefail
 #                  sub-service at once (requires the module to define
 #                  resolve_all_sub_services).
 #   <hash>         Image tag. Bare hash (e.g. abc123...) or git-<hash>; auto normalized.
-#   --env          default: both. Pick staging/production/both.
+#   --env          default: both. Pick dev/staging/production/both/all.
+#                  `both` = staging + production (legacy alias).
+#                  `all`  = dev + staging + production.
 #   --separate     when --env both, open two PRs instead of one combined PR.
 #
 # Requires: git, gh (authenticated), yq (v4+).
@@ -236,16 +238,46 @@ fi
 git fetch "$REMOTE" main --quiet
 
 file_for_env() {
+  # Modules may define *_FILES (bash array) when one env covers multiple
+  # values files — e.g. legacy single-ns values plus per-tier overlays during
+  # a cutover. Falls back to the single *_FILE variable for modules that only
+  # touch one path per env.
   case "$1" in
-    staging)    echo "$STAGING_FILE" ;;
-    production) echo "$PRODUCTION_FILE" ;;
-    *)          echo "error: invalid env: $1" >&2; return 1 ;;
+    dev)
+      if [[ "${#DEV_FILES[@]:-0}" -gt 0 ]]; then
+        printf '%s\n' "${DEV_FILES[@]}"
+      elif [[ -n "${DEV_FILE:-}" ]]; then
+        echo "$DEV_FILE"
+      else
+        echo "error: module did not define DEV_FILES or DEV_FILE for --env dev" >&2
+        return 1
+      fi
+      ;;
+    staging)
+      if [[ "${#STAGING_FILES[@]:-0}" -gt 0 ]]; then
+        printf '%s\n' "${STAGING_FILES[@]}"
+      else
+        echo "$STAGING_FILE"
+      fi
+      ;;
+    production)
+      if [[ "${#PRODUCTION_FILES[@]:-0}" -gt 0 ]]; then
+        printf '%s\n' "${PRODUCTION_FILES[@]}"
+      else
+        echo "$PRODUCTION_FILE"
+      fi
+      ;;
+    *)
+      echo "error: invalid env: $1" >&2
+      return 1
+      ;;
   esac
 }
 
 branch_for() {
-  # $1: staging | production | combined
+  # $1: dev | staging | production | combined
   case "$1" in
+    dev)        echo "${BRANCH_PREFIX}-dev-image-$SHORT8" ;;
     staging)    echo "${BRANCH_PREFIX}-staging-image-$SHORT8" ;;
     production) echo "${BRANCH_PREFIX}-main-image-$SHORT8" ;;
     combined)   echo "${BRANCH_PREFIX}-image-$SHORT8" ;;
@@ -299,8 +331,11 @@ bump_and_pr() {
     body_envs="${envs[0]}"
   else
     branch="$(branch_for combined)"
-    title="chore(${COMMIT_SCOPE}): bump staging + production${workload_part} image to git-$SHORT7"
-    body_envs="staging + production"
+    local envs_join
+    printf -v envs_join '%s + ' "${envs[@]}"
+    envs_join="${envs_join% + }"
+    title="chore(${COMMIT_SCOPE}): bump ${envs_join}${workload_part} image to git-$SHORT7"
+    body_envs="$envs_join"
   fi
 
   if git show-ref --verify --quiet "refs/heads/$branch"; then
@@ -310,9 +345,11 @@ bump_and_pr() {
 
   git checkout -b "$branch" "$REMOTE/main" --quiet
   for e in "${envs[@]}"; do
-    file="$(file_for_env "$e")"
-    update_file_tags "$file"
-    git add "$file"
+    while IFS= read -r file; do
+      [[ -z "$file" ]] && continue
+      update_file_tags "$file"
+      git add "$file"
+    done < <(file_for_env "$e")
   done
 
   if git diff --cached --quiet; then
@@ -344,10 +381,12 @@ EOF
 }
 
 case "$ENV" in
-  staging|production)
+  dev|staging|production)
     bump_and_pr "$ENV"
     ;;
   both)
+    # Legacy alias for staging + production (predates the dev env). Kept so
+    # existing automation keeps working; prefer `all` for full coverage.
     if [[ $SEPARATE -eq 1 ]]; then
       bump_and_pr staging
       git checkout "$ORIGINAL_BRANCH" --quiet
@@ -356,8 +395,19 @@ case "$ENV" in
       bump_and_pr staging production
     fi
     ;;
+  all)
+    if [[ $SEPARATE -eq 1 ]]; then
+      bump_and_pr dev
+      git checkout "$ORIGINAL_BRANCH" --quiet
+      bump_and_pr staging
+      git checkout "$ORIGINAL_BRANCH" --quiet
+      bump_and_pr production
+    else
+      bump_and_pr dev staging production
+    fi
+    ;;
   *)
-    echo "error: invalid --env: $ENV (expected staging|production|both)" >&2
+    echo "error: invalid --env: $ENV (expected dev|staging|production|both|all)" >&2
     exit 1
     ;;
 esac

--- a/scripts/bump-modules/rb.sh
+++ b/scripts/bump-modules/rb.sh
@@ -2,10 +2,32 @@
 # Usage:
 #   bump-image.sh rb <worker|v8-gateway|ygg-redeem|log-stream|ygg-quest-worker|bq-analytics-worker> <hash>
 #   bump-image.sh rb <hash>   # bump every workload at once
+#
+# Environments after the env×tier split (dev/staging/prod × web2/web3):
+# each env keyword resolves to multiple values files (legacy single-ns values
+# + the two new tier overlays) so a single bump keeps the cutover-period
+# namespaces in sync. The legacy entries should be dropped from this list
+# once those Applications are deleted.
 
 COMMIT_SCOPE="ragnarok-breaker"
-STAGING_FILE="9c-internal/ragnarok-breaker-staging/values.yaml"
-PRODUCTION_FILE="9c-main/ragnarok-breaker-production/values.yaml"
+DEV_FILES=(
+  9c-internal/ragnarok-breaker-dev-web2/values.yaml
+  9c-internal/ragnarok-breaker-dev-web3/values.yaml
+)
+STAGING_FILES=(
+  9c-internal/ragnarok-breaker-staging/values.yaml
+  9c-internal/ragnarok-breaker-staging-web2/values.yaml
+  9c-internal/ragnarok-breaker-staging-web3/values.yaml
+)
+PRODUCTION_FILES=(
+  9c-main/ragnarok-breaker-production/values.yaml
+  9c-main/ragnarok-breaker-prod-web2/values.yaml
+  9c-main/ragnarok-breaker-prod-web3/values.yaml
+)
+# Single-path fallbacks expected by bump-image.sh's mandatory-vars check.
+DEV_FILE="${DEV_FILES[0]}"
+STAGING_FILE="${STAGING_FILES[0]}"
+PRODUCTION_FILE="${PRODUCTION_FILES[0]}"
 SUB_SERVICES=(worker v8-gateway ygg-redeem log-stream ygg-quest-worker bq-analytics-worker)
 
 resolve_sub_service() {


### PR DESCRIPTION
## Summary

Stand up the dev / staging / prod × web2 / web3 namespace matrix for ragnarok-breaker, with ygg / bigquery workloads only enabled on web3 and dev running just the league-snapshot worker. Legacy `ragnarok-breaker-staging` (9c-internal) and `ragnarok-breaker` (9c-main) Applications stay live through cutover — they're removed in a follow-up.

### Namespace layout

| | web2 | web3 |
|---|---|---|
| **dev** (9c-internal) | ragnarok-breaker-dev-web2 | ragnarok-breaker-dev-web3 |
| **staging** (9c-internal) | ragnarok-breaker-staging-web2 | ragnarok-breaker-staging-web3 |
| **prod** (9c-main) | ragnarok-breaker-prod-web2 | ragnarok-breaker-prod-web3 |

### Workload matrix

| Workload | dev-web2 | dev-web3 | staging-web2 | staging-web3 | prod-web2 | prod-web3 |
|---|---|---|---|---|---|---|
| log-stream / v8-gateway | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| worker · leagueSnapshot | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| worker · scheduler + 3 validators | — | — | ✓ | ✓ | ✓ | ✓ |
| ygg-redeem / ygg-quest-worker / bq-analytics-worker | — | ✓ | — | ✓ | — | ✓ |

dev disables scheduler + 3 validators because scheduler is the producer for those queues; leaving it on with the consumers off would pile jobs in Redis. web2 disables ygg/bq but keeps `image.tag` pinned so `bump-image rb <hash>` (bulk) stays uniform across the matrix and a future web2→web3 promotion needs no separate tag-fill.

### What's in this PR

- **12 new files** under `9c-internal/ragnarok-breaker-{dev,staging}-web{2,3}/` and `9c-main/ragnarok-breaker-prod-web{2,3}/` — each folder owns its `application.yaml` + `values.yaml`. Initial image hashes match the cluster's current pin (`git-c30a3ca5` for dev/staging, `git-088af99` for prod).
- **`scripts/bump-image.sh`**: new `--env dev` and `--env all` (= dev+staging+production); `--env both` retained as legacy alias. `file_for_env()` now accepts an optional `*_FILES` bash array from modules (multi-file env), falling back to the single `*_FILE` var. Combined-env titles join env names dynamically.
- **`scripts/bump-modules/rb.sh`**: `DEV_FILES`, `STAGING_FILES`, `PRODUCTION_FILES` arrays — staging/prod include both the legacy single-ns `values.yaml` and the two new tier overlays, so cutover-period bumps stay in sync. Drop the legacy paths from these arrays when the legacy Applications are deleted.
- **`common/bootstrap-v2/templates/fluent-bit/configmap-fluent-bit.yaml`**: widens the `loki_rb` `rewrite_tag` regex to match the 6 new namespaces in addition to the 2 legacy ones (matched against a stub list with `bash =~` — all 8 expected ns match, unrelated names don't).

### Out-of-PR prerequisites (operator)

- Create 6 entries in AWS Secrets Manager: `ragnarok-breaker/{dev,staging,prod}-{web2,web3}`. web3 entries need `BQ_*`, `BQ_SERVICE_ACCOUNT_JSON_BASE64`, `BQ_ANALYTICS_REDIS_URL`, ygg-related keys; web2 only needs the worker / v8-gateway / log-stream keys.
- DNS records for `ygg-redeem-dev.9c.gg`, `ygg-redeem-staging.9c.gg` (prod already exists).
- BigQuery datasets/tables for the new web3 environments if separate from existing.

### Test plan

- [ ] ArgoCD picks up the 6 new Applications; each creates its namespace cleanly
- [ ] In each web2 ns: `kubectl get deploy` shows only worker (5 entries) + v8-gateway + log-stream (dev-web2: only league-snapshot + v8-gateway + log-stream)
- [ ] In each web3 ns: above + ygg-redeem + ygg-quest-worker + bq-analytics-worker
- [ ] `bump-image rb worker <hash> --env staging` updates 3 files (legacy + staging-web2 + staging-web3) in one PR
- [ ] `bump-image rb <hash> --env all` updates every rb workload tag in dev + staging + prod (9 files) in one PR
- [ ] In Grafana, `{job="ragnarok-breaker", namespace=~"ragnarok-breaker-.*"}` returns lines from each new namespace once log-stream rolls

### Follow-ups

- Cutover external clients (SDK URLs, Gateway hostnames) from legacy `ragnarok-breaker` / `ragnarok-breaker-staging` to the new web2/web3 namespaces.
- Separate PR: delete the legacy `9c-internal/ragnarok-breaker-staging/` and `9c-main/ragnarok-breaker-production/` folders + remove their entries from `rb.sh` arrays.