### PR TITLE
feat(dcc-bridge): periodic CronJob to retry stranded burn transfers

### DIFF
--- a/9c-main/dcc-bridge/values.yaml
+++ b/9c-main/dcc-bridge/values.yaml
@@ -12,7 +12,7 @@ api:
     repository: planetariumhq/dcc-bridge
     # Bumped by hand following the petpop pattern when a new SHA is published
     # by docker.yml on dcc-bridge develop/main.
-    tag: api-dc8edccaa0013da82169daf6224ad61194d2030c
+    tag: api-66f4679ddb5c103de1cb853a998def1d414e741d
   replicas: 1
   hostnames:
     - bridge-api.dccnft.com
@@ -44,7 +44,7 @@ bridge:
   enabled: true
   image:
     repository: planetariumhq/dcc-bridge
-    tag: bridge-dc8edccaa0013da82169daf6224ad61194d2030c
+    tag: bridge-66f4679ddb5c103de1cb853a998def1d414e741d
   resources:
     requests:
       cpu: 100m

--- a/9c-main/dcc-bridge/values.yaml
+++ b/9c-main/dcc-bridge/values.yaml
@@ -54,3 +54,12 @@ bridge:
       memory: 1Gi
   nodeSelector:
     node.kubernetes.io/type: general
+
+  cronRetry:
+    # Periodically retries nc_transfer rows that EventObserver left behind
+    # with tx_status NULL (stranded burns), then sweeps fetch_log entries
+    # so the /status check returns STABLE without manual intervention.
+    # NOTE: takes effect only once `bridge.image.tag` is bumped to a SHA
+    # that includes the retry-stuck-transfers script (dcc-bridge#44).
+    enabled: true
+    schedule: "*/30 * * * *"

--- a/charts/dcc-bridge/templates/bridge-cron-retry.yaml
+++ b/charts/dcc-bridge/templates/bridge-cron-retry.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.bridge.enabled .Values.bridge.cronRetry.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: dcc-bridge-retry-stuck
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+spec:
+  schedule: {{ .Values.bridge.cronRetry.schedule | quote }}
+  # Forbid prevents two retry runs from racing on the same nc_transfer row;
+  # the script picks rows where tx_status is still NULL, so a concurrent run
+  # could double-stage if it raced after the first run finished transferAsset
+  # but before updateTransferAsStaging committed.
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          serviceAccountName: {{ $.Release.Name }}
+          restartPolicy: Never
+          containers:
+            - name: retry-stuck
+              image: "{{ .Values.bridge.image.repository }}:{{ .Values.bridge.image.tag }}"
+              command: ["node", "--trace-deprecation", "dist/src/scripts/retry-stuck-transfers.js"]
+              envFrom:
+                - secretRef:
+                    name: dcc-bridge-env
+              resources:
+                {{- toYaml .Values.bridge.resources | nindent 16 }}
+          {{- with .Values.bridge.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/dcc-bridge/templates/bridge-cron-retry.yaml
+++ b/charts/dcc-bridge/templates/bridge-cron-retry.yaml
@@ -18,6 +18,12 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
+      # Cap any single run at 5 minutes. KMS sign + NC stageTransaction
+      # normally completes in a few seconds; an excess here means the Job
+      # is hung against an upstream and risks blocking subsequent runs
+      # (concurrencyPolicy: Forbid). Killing it lets the next 30-min run
+      # try again from a clean slate.
+      activeDeadlineSeconds: 300
       template:
         spec:
           serviceAccountName: {{ $.Release.Name }}

--- a/charts/dcc-bridge/values.yaml
+++ b/charts/dcc-bridge/values.yaml
@@ -45,3 +45,12 @@ bridge:
       cpu: 500m
       memory: 1Gi
   nodeSelector: {}
+
+  cronRetry:
+    # Periodic retry of nc_transfer rows where EventObserver started but
+    # failed before staging the 9c TransferAsset (tx_status / tx_hash NULL).
+    # Re-runs the same KMS+stage path the worker uses, then sweeps fetch_log.
+    enabled: false
+    # 30 min cadence keeps incomplete_block_count from staying nonzero for
+    # long enough that the /status check flips to UNSTABLE.
+    schedule: "*/30 * * * *"


### PR DESCRIPTION
## Summary

Adds a Helm template + values for a CronJob that runs the new `retry-stuck-transfers` script (added in **planetarium/dcc-bridge#44**) against the dcc-bridge worker image. The CronJob is the deployment side of self-healing for the `[Incomplete block]` notification class that previously required manual recovery.

## Background

The dcc-bridge worker's `EventObserver` does not retry partially-processed Ethereum burn blocks. When `transferAsset` throws midway (KMS hiccup, NC GQL timeout, DB error, etc.), the row is left with `tx_status` and `tx_hash` both NULL and the `fetch_log` row stays `complete=false`. The `/status` cron then keeps reporting UNSTABLE until an operator manually recovers.

A row stuck since 2026-05-16 was manually recovered on 2026-05-21 using a one-off node script; this PR codifies that recovery procedure into a periodic job.

## Changes

- `charts/dcc-bridge/templates/bridge-cron-retry.yaml` — new CronJob template. Uses the bridge worker image, mounts `dcc-bridge-env` secret (so it inherits DATABASE_URL, KMS_PROVIDER_KEY_ID, GQL_ENDPOINTS, BRIDGE_ADDRESS, etc.), and runs the same KMS-signed transferAsset path the worker uses. `concurrencyPolicy: Forbid` prevents two runs from racing on the same NULL row.
- `charts/dcc-bridge/values.yaml` — new `bridge.cronRetry` section (default disabled, 30-min schedule).
- `9c-main/dcc-bridge/values.yaml` — enabled for the mainnet release.

## Test plan

- [ ] After merge + image tag bump: confirm `dcc-bridge-retry-stuck` Job ran with the bumped tag and Completed (no Errors).
- [ ] Synthetic test (optional): null out `tx_status` on a test row, wait for next run, confirm row gets staged.
- [ ] Confirm `/status` returns STABLE without manual intervention next time `[Incomplete block]` would have fired.

## Dependencies

Companion PR: planetarium/dcc-bridge#44. This PR is functional only once the bridge image tag in `9c-main/dcc-bridge/values.yaml` is bumped to a SHA that includes that script (separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)