### PR TITLE
feat(ragnarok-breaker): add bq-ingest-gateway workload (web3) + HTTPRoute

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -43,3 +43,7 @@ bqAnalyticsWorker:
   enabled: false
   image:
     tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+bqIngestGateway:
+  enabled: false
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -41,3 +41,11 @@ yggQuestWorker:
 bqAnalyticsWorker:
   image:
     tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+bqIngestGateway:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+  httpRoute:
+    enabled: true
+    hostnames:
+      - bq-ingest-dev.9c.gg

--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -29,3 +29,7 @@ bqAnalyticsWorker:
   enabled: false
   image:
     tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+bqIngestGateway:
+  enabled: false
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -30,3 +30,11 @@ yggQuestWorker:
 bqAnalyticsWorker:
   image:
     tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+bqIngestGateway:
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+  httpRoute:
+    enabled: true
+    hostnames:
+      - bq-ingest-staging.9c.gg

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -30,3 +30,10 @@ yggQuestWorker:
 bqAnalyticsWorker:
   image:
     tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+
+# bqIngestGateway is web3-tier-only; legacy single-ns stays off (tag pinned
+# for bulk-bump uniformity).
+bqIngestGateway:
+  enabled: false
+  image:
+    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229

--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -29,3 +29,7 @@ bqAnalyticsWorker:
   enabled: false
   image:
     tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+bqIngestGateway:
+  enabled: false
+  image:
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -33,3 +33,11 @@ yggQuestWorker:
 bqAnalyticsWorker:
   image:
     tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+
+bqIngestGateway:
+  image:
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+  httpRoute:
+    enabled: true
+    hostnames:
+      - bq-ingest.9c.gg

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -33,3 +33,10 @@ yggQuestWorker:
 bqAnalyticsWorker:
   image:
     tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+
+# bqIngestGateway is web3-tier-only; legacy single-ns stays off (tag pinned
+# for bulk-bump uniformity).
+bqIngestGateway:
+  enabled: false
+  image:
+    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5

--- a/charts/ragnarok-breaker/templates/bq-ingest-gateway.yaml
+++ b/charts/ragnarok-breaker/templates/bq-ingest-gateway.yaml
@@ -1,0 +1,100 @@
+{{- if .Values.bqIngestGateway.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: bq-ingest-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: bq-ingest-gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: bq-ingest-gateway
+spec:
+  type: ClusterIP
+  selector:
+    app: bq-ingest-gateway
+  ports:
+    - name: http
+      port: {{ .Values.bqIngestGateway.service.port }}
+      targetPort: {{ .Values.bqIngestGateway.deployment.port }}
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bq-ingest-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: bq-ingest-gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: bq-ingest-gateway
+spec:
+  replicas: {{ .Values.bqIngestGateway.deployment.replicas }}
+  selector:
+    matchLabels:
+      app: bq-ingest-gateway
+  template:
+    metadata:
+      labels:
+        app: bq-ingest-gateway
+    spec:
+      {{- if .Values.imagePullSecret.secretKey }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret.name }}
+      {{- end }}
+      containers:
+        - name: bq-ingest-gateway
+          image: "{{ .Values.bqIngestGateway.image.repository }}:{{ .Values.bqIngestGateway.image.tag }}"
+          imagePullPolicy: {{ .Values.bqIngestGateway.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.bqIngestGateway.deployment.port }}
+          env:
+            - name: PORT
+              value: {{ .Values.bqIngestGateway.deployment.port | quote }}
+          envFrom:
+            - secretRef:
+                name: ragnarok-breaker-env
+          livenessProbe:
+            {{- toYaml .Values.bqIngestGateway.deployment.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.bqIngestGateway.deployment.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.bqIngestGateway.deployment.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always
+{{- if and .Values.bqIngestGateway.httpRoute.enabled .Values.bqIngestGateway.httpRoute.hostnames }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: bq-ingest-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: bq-ingest-gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: bq-ingest-gateway
+spec:
+  parentRefs:
+    - name: {{ .Values.bqIngestGateway.httpRoute.gatewayName }}
+      namespace: {{ .Values.bqIngestGateway.httpRoute.gatewayNamespace }}
+      sectionName: web
+    - name: {{ .Values.bqIngestGateway.httpRoute.gatewayName }}
+      namespace: {{ .Values.bqIngestGateway.httpRoute.gatewayNamespace }}
+      sectionName: websecure
+  hostnames:
+    {{- range .Values.bqIngestGateway.httpRoute.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: bq-ingest-gateway
+          port: {{ .Values.bqIngestGateway.service.port }}
+{{- end }}
+{{- end }}

--- a/charts/ragnarok-breaker/values.yaml
+++ b/charts/ragnarok-breaker/values.yaml
@@ -196,4 +196,50 @@ bqAnalyticsWorker:
       cpu: 500m
       memory: 512Mi
 
+# === External payment backend → BigQuery analytics ingest gateway ===
+# Thin HTTP gateway (Bun.serve): POST /v1/events (Bearer auth) validates the
+# envelope and enqueues a bq_event job onto the bq-analytics-events BullMQ
+# queue consumed by bqAnalyticsWorker. Stateless; exposed externally via
+# Gateway API HTTPRoute so the V8 payment backend can push events.
+# web3-only (VX top-ups happen on web3) — disabled in web2 / legacy namespaces.
+# Required env (from the ragnarok-breaker-env ExternalSecret): INGEST_ADMIN_TOKEN,
+# BQ_ANALYTICS_REDIS_URL.
+bqIngestGateway:
+  enabled: true
+  image:
+    repository: planetariumhq/ragnarok-breaker-bq-ingest-gateway
+    tag: develop
+    pullPolicy: IfNotPresent
+  service:
+    port: 8080
+  deployment:
+    replicas: 1
+    port: 8080
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      initialDelaySeconds: 30
+      periodSeconds: 15
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      failureThreshold: 3
+  httpRoute:
+    enabled: false
+    hostnames: []
+    gatewayName: traefik-gateway
+    gatewayNamespace: traefik
+
 nodeSelector: {}

--- a/scripts/bump-modules/rb.sh
+++ b/scripts/bump-modules/rb.sh
@@ -1,6 +1,6 @@
-# ragnarok-breaker chart — 6 independent images, one per workload.
+# ragnarok-breaker chart — 7 independent images, one per workload.
 # Usage:
-#   bump-image.sh rb <worker|v8-gateway|ygg-redeem|log-stream|ygg-quest-worker|bq-analytics-worker> <hash>
+#   bump-image.sh rb <worker|v8-gateway|ygg-redeem|log-stream|ygg-quest-worker|bq-analytics-worker|bq-ingest-gateway> <hash>
 #   bump-image.sh rb <hash>   # bump every workload at once
 #
 # Environments after the env×tier split (dev/staging/prod × web2/web3):
@@ -28,7 +28,7 @@ PRODUCTION_FILES=(
 DEV_FILE="${DEV_FILES[0]}"
 STAGING_FILE="${STAGING_FILES[0]}"
 PRODUCTION_FILE="${PRODUCTION_FILES[0]}"
-SUB_SERVICES=(worker v8-gateway ygg-redeem log-stream ygg-quest-worker bq-analytics-worker)
+SUB_SERVICES=(worker v8-gateway ygg-redeem log-stream ygg-quest-worker bq-analytics-worker bq-ingest-gateway)
 
 resolve_sub_service() {
   case "$1" in
@@ -62,6 +62,11 @@ resolve_sub_service() {
       SERVICE_LABEL="ragnarok-breaker-bq-analytics-worker"
       BRANCH_PREFIX="ragnarok-breaker-bq-analytics-worker"
       ;;
+    bq-ingest-gateway)
+      TAG_KEYS=(".bqIngestGateway.image.tag")
+      SERVICE_LABEL="ragnarok-breaker-bq-ingest-gateway"
+      BRANCH_PREFIX="ragnarok-breaker-bq-ingest-gateway"
+      ;;
     *)
       echo "error: unknown rb sub-service '$1' (available: ${SUB_SERVICES[*]})" >&2
       return 1
@@ -77,6 +82,7 @@ resolve_all_sub_services() {
     ".logStream.image.tag"
     ".yggQuestWorker.image.tag"
     ".bqAnalyticsWorker.image.tag"
+    ".bqIngestGateway.image.tag"
   )
   SERVICE_LABEL="all ragnarok-breaker images"
   BRANCH_PREFIX="ragnarok-breaker-all"


### PR DESCRIPTION
## What

Adds the `bq-ingest-gateway` workload to the ragnarok-breaker chart — a thin HTTP gateway the external V8 payment backend (GCP-hosted) calls to push VX top-up events into BigQuery analytics.

```
bq-ingest-gateway → (per-verse) Redis / BullMQ (bq-analytics-events) → bq-analytics-worker → BigQuery
```

The gateway validates the envelope (`POST /v1/events`, Bearer auth) and enqueues; it never touches BigQuery directly. It's the producer side of the existing per-verse Redis→worker pipeline, so it's deployed **one per web3 verse** to match the 3 existing `bq-analytics-worker` instances (env/token isolation + dev/staging test path).

## Changes

- **New** `charts/ragnarok-breaker/templates/bq-ingest-gateway.yaml` — Service (ClusterIP) + Deployment + HTTPRoute (gated on `httpRoute.enabled && hostnames`), mirroring the `ygg-redeem` external-HTTP pattern. Port 8080, `/healthz` liveness/readiness, `envFrom: ragnarok-breaker-env`.
- `charts/ragnarok-breaker/values.yaml` — `bqIngestGateway` defaults.
- **web3** (dev/staging/prod-web3): enabled + per-env HTTPRoute hostname:
  - dev → `bq-ingest-dev.9c.gg`
  - staging → `bq-ingest-staging.9c.gg`
  - prod → `bq-ingest.9c.gg`
- **web2 + legacy single-ns**: `enabled: false`, `image.tag` pinned for bulk-bump uniformity (web3-only — VX top-ups happen on web3).
- `scripts/bump-modules/rb.sh` — add `bq-ingest-gateway` sub-service.

## Verification

`helm template` renders cleanly for all 8 env value files; gateway resources render only in the 3 web3 namespaces (Service + Deployment + HTTPRoute) and are absent in web2/legacy.

## Deploy prerequisites (out of this repo)

- [ ] **AWS Secrets Manager**: add `INGEST_ADMIN_TOKEN` (per-env value, `openssl rand -hex 32`) to `ragnarok-breaker/{dev,staging,prod}-web3`. `BQ_ANALYTICS_REDIS_URL` already present (shared with the worker).
- [ ] **Image**: pinned to each env's current hash for bump uniformity; bump to a hash that actually contains the `bq-ingest-gateway` image (`bump-image rb bq-ingest-gateway <hash>`) once CI has built+pushed it, otherwise ImagePullBackOff.
- [ ] **DNS/TLS**: 3 hostnames go through the same `traefik-gateway` as ygg-redeem; confirm `*.9c.gg` coverage / DNS records.
- [ ] Share each env's `INGEST_ADMIN_TOKEN` with the V8 payment backend team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)