### PR TITLE
chore(ragnarok-breaker): bump staging + production image to git-93b1998

### DIFF
--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -5,31 +5,31 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 v8Gateway:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 logStream:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 # web2: ygg / bigquery workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 bqIngestGateway:
   enabled: false
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 v8Gateway:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 logStream:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 yggRedeem:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
   httpRoute:
     enabled: true
     hostnames:
@@ -25,15 +25,15 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 bqAnalyticsWorker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 bqIngestGateway:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
   httpRoute:
     enabled: true
     hostnames:

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 v8Gateway:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 yggRedeem:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
   httpRoute:
     enabled: true
     hostnames:
@@ -21,19 +21,19 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 yggQuestWorker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 bqAnalyticsWorker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 # bqIngestGateway is web3-tier-only; legacy single-ns stays off (tag pinned
 # for bulk-bump uniformity).
 bqIngestGateway:
   enabled: false
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b

--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,31 +5,31 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 v8Gateway:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 logStream:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 # web2: ygg / bigquery workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 bqIngestGateway:
   enabled: false
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 v8Gateway:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 logStream:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 yggRedeem:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
   deployment:
     replicas: 2
   httpRoute:
@@ -27,16 +27,16 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
   replicas: 2
 
 bqAnalyticsWorker:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 bqIngestGateway:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
   httpRoute:
     enabled: true
     hostnames:

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 v8Gateway:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 yggRedeem:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
   deployment:
     replicas: 2
   httpRoute:
@@ -23,20 +23,20 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 yggQuestWorker:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
   replicas: 2
 
 bqAnalyticsWorker:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b
 
 # bqIngestGateway is web3-tier-only; legacy single-ns stays off (tag pinned
 # for bulk-bump uniformity).
 bqIngestGateway:
   enabled: false
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-93b19988cd50aafeb03c4a419fe051de33c3063b


### PR DESCRIPTION
Pin all ragnarok-breaker images to `git-93b19988cd50aafeb03c4a419fe051de33c3063b` for staging + production.

## Test plan
- [ ] After sync, pods pull the pinned image successfully