### PR TITLE
feat(ragnarok-breaker): collapse bq-ingest-gateway to single prod-web3 instance

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -43,7 +43,3 @@ bqAnalyticsWorker:
   enabled: false
   image:
     tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
-bqIngestGateway:
-  enabled: false
-  image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -41,11 +41,3 @@ yggQuestWorker:
 bqAnalyticsWorker:
   image:
     tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
-
-bqIngestGateway:
-  image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
-  httpRoute:
-    enabled: true
-    hostnames:
-      - bq-ingest-dev.9c.gg

--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -29,7 +29,3 @@ bqAnalyticsWorker:
   enabled: false
   image:
     tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
-bqIngestGateway:
-  enabled: false
-  image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -30,11 +30,3 @@ yggQuestWorker:
 bqAnalyticsWorker:
   image:
     tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
-
-bqIngestGateway:
-  image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
-  httpRoute:
-    enabled: true
-    hostnames:
-      - bq-ingest-staging.9c.gg

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -30,10 +30,3 @@ yggQuestWorker:
 bqAnalyticsWorker:
   image:
     tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
-
-# bqIngestGateway is web3-tier-only; legacy single-ns stays off (tag pinned
-# for bulk-bump uniformity).
-bqIngestGateway:
-  enabled: false
-  image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229

--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -29,7 +29,3 @@ bqAnalyticsWorker:
   enabled: false
   image:
     tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
-bqIngestGateway:
-  enabled: false
-  image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -34,7 +34,11 @@ bqAnalyticsWorker:
   image:
     tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
 
+# Single shared ingest gateway for all payment envs (no app_env split) —
+# the only namespace that hosts it. Image tag is bumped on its own via
+# `bump-image rb bq-ingest-gateway <hash>` (excluded from the bulk all-bump).
 bqIngestGateway:
+  enabled: true
   image:
     tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
   httpRoute:

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -33,10 +33,3 @@ yggQuestWorker:
 bqAnalyticsWorker:
   image:
     tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
-
-# bqIngestGateway is web3-tier-only; legacy single-ns stays off (tag pinned
-# for bulk-bump uniformity).
-bqIngestGateway:
-  enabled: false
-  image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5

--- a/charts/ragnarok-breaker/values.yaml
+++ b/charts/ragnarok-breaker/values.yaml
@@ -201,11 +201,12 @@ bqAnalyticsWorker:
 # envelope and enqueues a bq_event job onto the bq-analytics-events BullMQ
 # queue consumed by bqAnalyticsWorker. Stateless; exposed externally via
 # Gateway API HTTPRoute so the V8 payment backend can push events.
-# web3-only (VX top-ups happen on web3) — disabled in web2 / legacy namespaces.
+# Single shared instance: every payment env hits one endpoint (no app_env
+# split), so it is deployed ONLY in prod-web3 (default off, enabled there).
 # Required env (from the ragnarok-breaker-env ExternalSecret): INGEST_ADMIN_TOKEN,
 # BQ_ANALYTICS_REDIS_URL.
 bqIngestGateway:
-  enabled: true
+  enabled: false
   image:
     repository: planetariumhq/ragnarok-breaker-bq-ingest-gateway
     tag: develop

--- a/scripts/bump-modules/rb.sh
+++ b/scripts/bump-modules/rb.sh
@@ -1,7 +1,11 @@
 # ragnarok-breaker chart — 7 independent images, one per workload.
 # Usage:
 #   bump-image.sh rb <worker|v8-gateway|ygg-redeem|log-stream|ygg-quest-worker|bq-analytics-worker|bq-ingest-gateway> <hash>
-#   bump-image.sh rb <hash>   # bump every workload at once
+#   bump-image.sh rb <hash>   # bump every workload at once (except bq-ingest-gateway)
+#
+# bq-ingest-gateway is a single shared instance living only in prod-web3, so it
+# is NOT part of the bulk all-bump and its per-service bump targets prod-web3
+# only. Bump it explicitly: bump-image.sh rb bq-ingest-gateway <hash>
 #
 # Environments after the env×tier split (dev/staging/prod × web2/web3):
 # each env keyword resolves to multiple values files (legacy single-ns values
@@ -66,6 +70,15 @@ resolve_sub_service() {
       TAG_KEYS=(".bqIngestGateway.image.tag")
       SERVICE_LABEL="ragnarok-breaker-bq-ingest-gateway"
       BRANCH_PREFIX="ragnarok-breaker-bq-ingest-gateway"
+      # Single shared instance, prod-web3 only — scope every env keyword to that
+      # one file so any --env (including the default `both`) only touches
+      # prod-web3 and never errors on files that lack the key.
+      DEV_FILES=(9c-main/ragnarok-breaker-prod-web3/values.yaml)
+      STAGING_FILES=(9c-main/ragnarok-breaker-prod-web3/values.yaml)
+      PRODUCTION_FILES=(9c-main/ragnarok-breaker-prod-web3/values.yaml)
+      DEV_FILE="${DEV_FILES[0]}"
+      STAGING_FILE="${STAGING_FILES[0]}"
+      PRODUCTION_FILE="${PRODUCTION_FILES[0]}"
       ;;
     *)
       echo "error: unknown rb sub-service '$1' (available: ${SUB_SERVICES[*]})" >&2
@@ -82,8 +95,9 @@ resolve_all_sub_services() {
     ".logStream.image.tag"
     ".yggQuestWorker.image.tag"
     ".bqAnalyticsWorker.image.tag"
-    ".bqIngestGateway.image.tag"
   )
+  # bqIngestGateway is intentionally excluded — it lives only in prod-web3 and
+  # the bulk bump spans every env file, most of which lack the key.
   SERVICE_LABEL="all ragnarok-breaker images"
   BRANCH_PREFIX="ragnarok-breaker-all"
 }


### PR DESCRIPTION
## What

Follow-up to #3425. The upstream design dropped the per-env `app_env` split — all payment environments now hit **one shared ingest endpoint** — so the gateway no longer needs per-verse isolation.

Collapses `bq-ingest-gateway` from **3 web3 instances → 1 instance in prod-web3**.

```
(all payment envs, no app_env) → bq-ingest.9c.gg → prod-web3 Redis/BullMQ → prod-web3 bq-analytics-worker → BigQuery
```

## Changes

- `charts/ragnarok-breaker/values.yaml` — `bqIngestGateway` default `enabled: false`.
- `prod-web3` — keep `enabled: true` + HTTPRoute `bq-ingest.9c.gg`; drop the `dev-web3` / `staging-web3` gateway blocks and their hostnames.
- Remove the disabled+pinned `bqIngestGateway` blocks from the web2 + legacy envs (no longer needed — single-namespace service).
- `scripts/bump-modules/rb.sh` — scope `bq-ingest-gateway` bump to **prod-web3 only** (every `--env` resolves to that one file) and **exclude it from the bulk all-bump** (it lives in a single namespace, so the all-env bump would otherwise error on files lacking the key). Bump explicitly with `bump-image rb bq-ingest-gateway <hash>`.

`bq-analytics-worker` is **unchanged** — it stays per-verse for the log-stream events (currency_changes / game_sessions); only the vx_topup producer collapses.

## Verification

`helm template` renders cleanly for all 8 env value files; the gateway (Service + Deployment + HTTPRoute `bq-ingest.9c.gg`) renders **only** in `prod-web3` and is absent everywhere else. `bash -n` + a sourced check confirm the bump module resolves `bq-ingest-gateway` to the single prod-web3 file and the bulk all-bump no longer includes its key.

## Deploy prerequisites

- [ ] `INGEST_ADMIN_TOKEN` in AWS Secrets Manager `ragnarok-breaker/prod-web3` (only — dev/staging-web3 no longer needed). `BQ_ANALYTICS_REDIS_URL` already present (shared with the worker).
- [ ] Bump to an image hash that contains the `bq-ingest-gateway` build: `bump-image rb bq-ingest-gateway <hash>`.
- [ ] DNS/TLS for `bq-ingest.9c.gg` via the traefik gateway.
- [ ] Share the prod `INGEST_ADMIN_TOKEN` with the V8 payment backend team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)