### PR TITLE
chore(ragnarok-breaker): bump staging + production image to git-955b6e6

### DIFF
--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -5,27 +5,27 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 v8Gateway:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 logStream:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 # web2: ygg / bigquery workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 v8Gateway:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 logStream:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 yggRedeem:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
   httpRoute:
     enabled: true
     hostnames:
@@ -25,8 +25,8 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 bqAnalyticsWorker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 v8Gateway:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 yggRedeem:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
   httpRoute:
     enabled: true
     hostnames:
@@ -21,12 +21,12 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 yggQuestWorker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 bqAnalyticsWorker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5

--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,27 +5,27 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 v8Gateway:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 logStream:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 # web2: ygg / bigquery workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 v8Gateway:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 logStream:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 yggRedeem:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
   deployment:
     replicas: 2
   httpRoute:
@@ -27,12 +27,12 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
   replicas: 2
 
 bqAnalyticsWorker:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 # Single shared ingest gateway for all payment envs (no app_env split) —
 # the only namespace that hosts it. Image tag is bumped on its own via

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 v8Gateway:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 yggRedeem:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
   deployment:
     replicas: 2
   httpRoute:
@@ -23,13 +23,13 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 yggQuestWorker:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
   replicas: 2
 
 bqAnalyticsWorker:
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5


### PR DESCRIPTION
Pin all ragnarok-breaker images to `git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5` for staging + production.

## Test plan
- [ ] After sync, pods pull the pinned image successfully