### PR TITLE
feat(ragnarok-breaker): enable full worker set in dev (match staging)

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -3,19 +3,6 @@ externalSecretKey: ragnarok-breaker/dev-web2
 imagePullSecret:
   secretKey: ragnarok-breaker/dockerhub
 
-# dev: only leagueSnapshot runs; scheduler + 3 validation workers OFF
-# (scheduler is the producer for game/gameplay/summon validation queues —
-# leaving it on with the consumers off would pile up jobs in Redis.)
-workers:
-  scheduler:
-    enabled: false
-  gameValidator:
-    enabled: false
-  gameplayValidator:
-    enabled: false
-  summonValidator:
-    enabled: false
-
 worker:
   image:
     tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -3,17 +3,6 @@ externalSecretKey: ragnarok-breaker/dev-web3
 imagePullSecret:
   secretKey: ragnarok-breaker/dockerhub
 
-# dev: only leagueSnapshot runs; scheduler + 3 validation workers OFF
-workers:
-  scheduler:
-    enabled: false
-  gameValidator:
-    enabled: false
-  gameplayValidator:
-    enabled: false
-  summonValidator:
-    enabled: false
-
 worker:
   image:
     tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229


### PR DESCRIPTION
## What

Re-enables the full worker set in the rb **dev** environment so it matches **staging**.

dev had `scheduler` + the 3 validation workers (`gameValidator`, `gameplayValidator`, `summonValidator`) disabled — only `leagueSnapshot` ran. This drops the `workers:` override from `dev-web2` and `dev-web3` so both inherit the chart defaults (all 5 workers enabled), exactly like the staging overlays.

## Changes

- `9c-internal/ragnarok-breaker-dev-web2/values.yaml` — remove `workers:` disable block
- `9c-internal/ragnarok-breaker-dev-web3/values.yaml` — remove `workers:` disable block

Image tags are untouched (this PR is only about worker enablement).

## Why it's safe

`scheduler` is the producer for the game/gameplay/summon validation queues. The earlier dev config kept it off precisely so jobs wouldn't pile up in Redis with the consumers off. Turning the producer **and** its consumers back on together restores a consistent set — same as staging — so nothing accumulates.

## Verification

`helm template` of `templates/worker-deployments.yaml` now renders the same 5 worker Deployments in dev as in staging:

```
dev-web3 == staging-web3 ? YES
dev-web2 == staging-web2 ? YES
```

(scheduler, game-validator, gameplay-validator, summon-validator, league-snapshot). Full chart renders cleanly for both dev overlays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)