### PR TITLE
chore(ragnarok-breaker): pin dev image to git-955b6e6

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 v8Gateway:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 logStream:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 # web2: ygg / bigquery workloads are disabled, but their image.tag is still
 # pinned so `bump-image rb <hash>` (bulk) stays uniform across env×tier and
@@ -21,12 +21,12 @@ logStream:
 yggRedeem:
   enabled: false
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 v8Gateway:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 logStream:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 yggRedeem:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
   httpRoute:
     enabled: true
     hostnames:
@@ -25,8 +25,8 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
 
 bqAnalyticsWorker:
   image:
-    tag: git-c30a3ca55eb0d29347c65e5fd90336e37c71d229
+    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5


### PR DESCRIPTION
Pin all ragnarok-breaker images to `git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5` for dev.

## Test plan
- [ ] After sync, pods pull the pinned image successfully