### PR TITLE
fix(ragnarok-breaker): migrate worker chart to log-stream trigger model

### DIFF
--- a/charts/ragnarok-breaker/values.yaml
+++ b/charts/ragnarok-breaker/values.yaml
@@ -4,29 +4,23 @@ imagePullSecret:
   name: ragnarok-breaker-regcred
   secretKey: ""
 
-# === Worker: single image, 5 entry points ===
+# === Worker: single image, 3 entry points ===
 worker:
   image:
     repository: planetariumhq/ragnarok-breaker-worker
     tag: develop
     pullPolicy: IfNotPresent
 
+# Anti-cheat validation is log-stream-triggered (MR-C refactor): seed and
+# gameplay validation run as BullMQ consumers fed by log-stream trigger jobs.
+# The old polling scheduler and the separate game/gameplay/summon validators
+# were removed upstream; their entry files no longer exist in the image.
+# All three workers reach V8 only through v8-gateway and share Redis (REDIS_URL).
 workers:
-  scheduler:
+  seedTrigger:
     enabled: true
     replicas: 1
-    command: ["bun", "run", "services/worker/src/entry/scheduler.entry.ts"]
-    resources:
-      requests:
-        cpu: 100m
-        memory: 256Mi
-      limits:
-        cpu: 500m
-        memory: 512Mi
-  gameValidator:
-    enabled: true
-    replicas: 1
-    command: ["bun", "run", "services/worker/src/entry/game-worker.entry.ts"]
+    command: ["bun", "run", "services/worker/src/entry/seed-trigger-worker.entry.ts"]
     resources:
       requests:
         cpu: 200m
@@ -34,21 +28,10 @@ workers:
       limits:
         cpu: "1"
         memory: 1Gi
-  gameplayValidator:
+  gameplayTrigger:
     enabled: true
     replicas: 1
-    command: ["bun", "run", "services/worker/src/entry/gameplay-worker.entry.ts"]
-    resources:
-      requests:
-        cpu: 200m
-        memory: 512Mi
-      limits:
-        cpu: "1"
-        memory: 1Gi
-  summonValidator:
-    enabled: true
-    replicas: 1
-    command: ["bun", "run", "services/worker/src/entry/summon-worker.entry.ts"]
+    command: ["bun", "run", "services/worker/src/entry/gameplay-trigger-worker.entry.ts"]
     resources:
       requests:
         cpu: 200m


### PR DESCRIPTION
## Problem

dev-web2/dev-web3 worker pods are in `CrashLoopBackOff`:

```
error: Module not found "services/worker/src/entry/game-worker.entry.ts"
```

### Root cause

The worker image was refactored upstream (**MR-C**, JiwonRB commit `9eba4170`): the polling **scheduler** and the separate **game / gameplay / summon** validator entry points were deleted and replaced by log-stream-triggered BullMQ workers. But the chart's `workers` map still invoked the old, now-deleted entry files.

| env | worker image (cluster) | `game-validator` cmd | result |
|---|---|---|---|
| dev-web2 / dev-web3 | `git-955b6e6` (new) | `game-worker.entry.ts` (deleted) | **CrashLoopBackOff** |
| staging / prod | `git-c30a3ca5` (old) | `game-worker.entry.ts` (present) | running — **for now** |

Only `leagueSnapshot` survived (its `league-worker.entry.ts` still exists), which is why dev was fine before its workers were re-enabled. **staging/prod are a latent landmine** — they only work because their pods still run the old `c30a3ca5` image; they will crash identically the moment they roll to `955b6e6`.

## Fix

Replace the stale 5-worker map with the 3 entry points that actually exist in the image:

| chart key | command | deployment |
|---|---|---|
| `seedTrigger` | `seed-trigger-worker.entry.ts` | `ragnarok-breaker-seed-trigger` |
| `gameplayTrigger` | `gameplay-trigger-worker.entry.ts` | `ragnarok-breaker-gameplay-trigger` |
| `leagueSnapshot` | `league-worker.entry.ts` (unchanged) | `ragnarok-breaker-league-snapshot` |

Removed: `scheduler`, `gameValidator`, `gameplayValidator`, `summonValidator`.

- **No env/secret changes** — new workers reuse `REDIS_URL` + `V8_GATEWAY_URL` + `WORKER_CONCURRENCY` and declare no new required env (verified in the worker source).
- **No template change** — `worker-deployments.yaml` ranges over the `workers` map; only values changed.
- **No env overlay overrides `workers`**, so the rename applies uniformly to dev/staging/prod.

## Verification

`helm template` for all 8 env value files renders cleanly with exactly the 3 new worker Deployments; the 4 old worker names render 0 times. All 3 rendered command paths exist in the `git-955b6e6` image tree.

## Deploy notes

- ArgoCD prune is **not** enabled on these Applications, so after sync the 4 old Deployments (`scheduler`, `game-validator`, `gameplay-validator`, `summon-validator`) won't be auto-removed — prune via the ArgoCD sync option or `kubectl delete deploy` them manually.
- Out of scope (JiwonRB repo, FYI): `docker-compose.yml` and `PROJECT/system/infra/worker-system.md` still describe the old 5-worker model and should be updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)