### PR TITLE
chore(ragnarok-breaker): pin staging image to git-3171294

### DIFF
--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -5,27 +5,27 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
 
 v8Gateway:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
 
 logStream:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
 
 # web2: ygg / bigquery workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
 
 v8Gateway:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
 
 logStream:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
 
 yggRedeem:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
   httpRoute:
     enabled: true
     hostnames:
@@ -25,8 +25,8 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
 
 bqAnalyticsWorker:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
 
 v8Gateway:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
 
 yggRedeem:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
   httpRoute:
     enabled: true
     hostnames:
@@ -21,12 +21,12 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
 
 yggQuestWorker:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
 
 bqAnalyticsWorker:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-31712946f478c458df6ff04a9f438f157c4e7953


### PR DESCRIPTION
Pin all ragnarok-breaker images to `git-31712946f478c458df6ff04a9f438f157c4e7953` for staging.

## Test plan
- [ ] After sync, pods pull the pinned image successfully