### PR TITLE
feat(seasonpass): deploy GQL-timeout fix + add api memory limits and /ping probes

### DIFF
--- a/9c-internal/external-services/values.yaml
+++ b/9c-internal/external-services/values.yaml
@@ -24,7 +24,7 @@ volumeReclaimPolicy: "Retain"
 seasonpass:
   enabled: true
   image:
-    tag: "git-a639ff2a107364c8d3df152e6c3b8e5f8e643c3d"
+    tag: "git-3c29100ff62f588ecf14dd50e48527c55bb02fe3"
 
   api:
     enabled: true
@@ -33,6 +33,26 @@ seasonpass:
       limits:
         cpu: 0.5
         memory: 1Gi
+
+    # /ping is a sync FastAPI route that runs in the same threadpool as
+    # request handlers, so it queues when the threadpool is exhausted by
+    # blocked GQL calls — exactly the hang signature we want to detect.
+    livenessProbe:
+      httpGet:
+        path: /ping
+        port: 8000
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /ping
+        port: 8000
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 2
 
   worker:
     enabled: true

--- a/9c-main/external-services/values.yaml
+++ b/9c-main/external-services/values.yaml
@@ -27,7 +27,7 @@ volumeReclaimPolicy: "Retain"
 seasonpass:
   enabled: true
   image:
-    tag: "git-a36430ffea00ddc915f686aff5998a31668f63d1"
+    tag: "git-3c29100ff62f588ecf14dd50e48527c55bb02fe3"
 
   api:
     enabled: true
@@ -36,6 +36,36 @@ seasonpass:
       node.kubernetes.io/node-index: "2"
       node.kubernetes.io/provisioner: "cloudv"
       node.kubernetes.io/type: "general"
+
+    # Bound memory so a runaway leak (e.g. NineChronicles.SeasonPass#303)
+    # is OOMKilled+auto-restarted instead of degrading until manual fix.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
+
+    # /ping is a sync FastAPI route that runs in the same threadpool as
+    # request handlers, so it queues when the threadpool is exhausted by
+    # blocked GQL calls — exactly the hang signature we want to detect.
+    livenessProbe:
+      httpGet:
+        path: /ping
+        port: 8000
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /ping
+        port: 8000
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 2
 
   worker:
     enabled: true

--- a/charts/external-services/templates/seasonpass-api.yaml
+++ b/charts/external-services/templates/seasonpass-api.yaml
@@ -71,6 +71,14 @@ spec:
           resources:
             {{- toYaml . | nindent 14 }}
           {{- end }}
+          {{- with $.Values.seasonpass.api.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.seasonpass.api.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8000
           name: seasonpass-api


### PR DESCRIPTION
## Summary

Deploy the GQL-timeout fix from [planetarium/NineChronicles.SeasonPass#304](https://github.com/planetarium/NineChronicles.SeasonPass/pull/304) and harden the mainnet `seasonpass-api` deployment so a future hang gets auto-restarted by k8s instead of requiring manual `kubectl rollout restart`.

Companion to NineChronicles.SeasonPass#303 / #304 — see those for the root cause analysis.

## What this PR does

1. **Bump `seasonpass.image.tag`** to `git-3c29100ff62f588ecf14dd50e48527c55bb02fe3` on both 9c-main and 9c-internal. The chart shares one tag across api/tracker/worker, so all three subcharts roll. Verified the three images exist on Docker Hub:
   - `planetariumhq/season-pass-api:git-3c29100ff62f588ecf14dd50e48527c55bb02fe3`
   - `planetariumhq/season-pass-tracker:git-3c29100ff62f588ecf14dd50e48527c55bb02fe3`
   - `planetariumhq/season-pass-worker:git-3c29100ff62f588ecf14dd50e48527c55bb02fe3`

2. **Add memory limits to mainnet `seasonpass-api`**. The 2026-05-27 incident pod had `resources: {}`, so the leak just kept growing (140 MiB → 644 MiB in ~70 min) until manual restart. New values mirror 9c-internal's ceiling:
   ```yaml
   resources:
     requests: { cpu: 100m, memory: 256Mi }
     limits:   { cpu: "1",  memory: 1Gi  }
   ```
   With this, a future runaway gets OOMKilled at ~1 GiB and k8s auto-restarts the pod.

3. **Add liveness/readiness probes** for `seasonpass-api` on both clusters via the existing chart template pattern. The chart template gets a `livenessProbe`/`readinessProbe` block rendered with `{{- with ... }}` so it only emits when the values are present.

   Probe target is `/ping` (returns `"pong"`, defined in [`apps/api/main.py:63`](https://github.com/planetarium/NineChronicles.SeasonPass/blob/main/apps/api/main.py#L63)). It's a **sync** FastAPI handler, so it runs in the same threadpool as the GQL-calling handlers — when the threadpool is exhausted by blocked downstream calls (the exact hang signature from #303), `/ping` queues too and the probe fails. That's the behavior we want.

   ```yaml
   livenessProbe:
     httpGet: { path: /ping, port: 8000 }
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 3   # ~45s of persistent hang before restart
   readinessProbe:
     httpGet: { path: /ping, port: 8000 }
     initialDelaySeconds: 5
     periodSeconds: 5
     timeoutSeconds: 3
     failureThreshold: 2   # ~16s to mark NotReady (drains traffic)
   ```

## Verification

`helm template` renders cleanly for both clusters; the rendered `seasonpass-api` Deployment has the bumped image, the resources block, and the two probes pointing at `/ping:8000`. All three season-pass images (api/tracker/worker) pick up the new tag from the shared `seasonpass.image.tag`.

## Rollout impact

- `seasonpass-api`, `seasonpass-claim-worker`, `seasonpass-beat`, `seasonpass-flower`, `seasonpass-odin-tracker`, `seasonpass-heimdall-tracker`, `seasonpass-thor-tracker`, `seasonpass-tx-tracker` will all roll to the new image on ArgoCD sync (both clusters).
- The image change is the app-side fix from #304 (GQL `requests` timeout + schema cache). No DB migration.
- Probes will start checking `/ping` immediately on the new pod. If `/ping` isn't reachable on the current image for some reason, readiness will fail and traffic gets drained — but `/ping` has been in `main.py` since at least 0.3.1 (the version field in the file), so this is safe.

## Files changed

- `charts/external-services/templates/seasonpass-api.yaml` — add templated liveness/readiness probe blocks.
- `9c-main/external-services/values.yaml` — bump tag, add `seasonpass.api.resources` and `livenessProbe`/`readinessProbe`.
- `9c-internal/external-services/values.yaml` — bump tag and add the same `livenessProbe`/`readinessProbe` (resources already present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
