### PR TITLE
chore(seasonpass): relax api probe cadence to liveness 60s / readiness 10s

### DIFF
--- a/9c-internal/external-services/values.yaml
+++ b/9c-internal/external-services/values.yaml
@@ -42,7 +42,7 @@ seasonpass:
         path: /ping
         port: 8000
       initialDelaySeconds: 30
-      periodSeconds: 10
+      periodSeconds: 60
       timeoutSeconds: 5
       failureThreshold: 3
     readinessProbe:
@@ -50,9 +50,9 @@ seasonpass:
         path: /ping
         port: 8000
       initialDelaySeconds: 5
-      periodSeconds: 5
+      periodSeconds: 10
       timeoutSeconds: 3
-      failureThreshold: 2
+      failureThreshold: 3
 
   worker:
     enabled: true

--- a/9c-main/external-services/values.yaml
+++ b/9c-main/external-services/values.yaml
@@ -55,7 +55,7 @@ seasonpass:
         path: /ping
         port: 8000
       initialDelaySeconds: 30
-      periodSeconds: 10
+      periodSeconds: 60
       timeoutSeconds: 5
       failureThreshold: 3
     readinessProbe:
@@ -63,9 +63,9 @@ seasonpass:
         path: /ping
         port: 8000
       initialDelaySeconds: 5
-      periodSeconds: 5
+      periodSeconds: 10
       timeoutSeconds: 3
-      failureThreshold: 2
+      failureThreshold: 3
 
   worker:
     enabled: true


### PR DESCRIPTION
## Summary

Follow-up to #3440. The probe cadence I set there (liveness 10s / readiness 5s, ~18 probes/min combined) is too aggressive for a hang that takes minutes to develop. This tones it down to match the in-house convention used by `remote-headless` (liveness 60s / readiness 10s) and cuts probe load to ~7/min per pod.

| | Before (#3440) | After (this PR) |
|---|---|---|
| livenessProbe period | 10s | **60s** |
| livenessProbe failureThreshold | 3 | 3 |
| → hang detection latency | ~45s | ~180s |
| readinessProbe period | 5s | **10s** |
| readinessProbe failureThreshold | 2 | **3** |
| → drain latency | ~16s | ~30s |
| Combined probes/min | ~18 | ~7 |

180s liveness detection is still well within tolerance — the NineChronicles.SeasonPass#303 incident was a 70-minute gradual degradation. A few extra minutes before restart vs no auto-restart at all (pre-#3440 state) is a fine trade.

## Files changed

- `9c-main/external-services/values.yaml` — relax both probe `periodSeconds`, bump readiness `failureThreshold` 2→3.
- `9c-internal/external-services/values.yaml` — same change for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
