### PR TITLE
chore(ragnarok-breaker): bump dev + staging + production image to git-ed410c7

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 v8Gateway:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 logStream:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 # web2: ygg / bigquery workloads are disabled, but their image.tag is still
 # pinned so `bump-image rb <hash>` (bulk) stays uniform across env×tier and
@@ -21,12 +21,12 @@ logStream:
 yggRedeem:
   enabled: false
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 v8Gateway:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 logStream:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 yggRedeem:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
   httpRoute:
     enabled: true
     hostnames:
@@ -25,8 +25,8 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 bqAnalyticsWorker:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b

--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -5,27 +5,27 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 v8Gateway:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 logStream:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 # web2: ygg / bigquery workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 v8Gateway:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 logStream:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 yggRedeem:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
   httpRoute:
     enabled: true
     hostnames:
@@ -25,8 +25,8 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 bqAnalyticsWorker:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 v8Gateway:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 yggRedeem:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
   httpRoute:
     enabled: true
     hostnames:
@@ -21,12 +21,12 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 yggQuestWorker:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 bqAnalyticsWorker:
   image:
-    tag: git-31712946f478c458df6ff04a9f438f157c4e7953
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b

--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,27 +5,27 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 v8Gateway:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 logStream:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 # web2: ygg / bigquery workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 v8Gateway:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 logStream:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 yggRedeem:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
   deployment:
     replicas: 2
   httpRoute:
@@ -27,12 +27,12 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
   replicas: 2
 
 bqAnalyticsWorker:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 # Single shared ingest gateway for all payment envs (no app_env split) —
 # the only namespace that hosts it. Image tag is bumped on its own via

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 v8Gateway:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 yggRedeem:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
   deployment:
     replicas: 2
   httpRoute:
@@ -23,13 +23,13 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
 
 yggQuestWorker:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b
   replicas: 2
 
 bqAnalyticsWorker:
   image:
-    tag: git-955b6e679f7bd31cf95461b8a4fc31ad9bed31b5
+    tag: git-ed410c759359e5a808810f46c3117dd1642f5b8b


### PR DESCRIPTION
Pin all ragnarok-breaker images to `git-ed410c759359e5a808810f46c3117dd1642f5b8b` for dev + staging + production.

## Test plan
- [ ] After sync, pods pull the pinned image successfully