### PR TITLE
chore(seasonpass): bump api/worker/tracker to git-c5c0ed5

### DIFF
--- a/9c-main/external-services/values.yaml
+++ b/9c-main/external-services/values.yaml
@@ -27,7 +27,7 @@ volumeReclaimPolicy: "Retain"
 seasonpass:
   enabled: true
   image:
-    tag: "git-3c29100ff62f588ecf14dd50e48527c55bb02fe3"
+    tag: "git-c5c0ed5f4eb22b422a6c167339556eba512d8e66"
 
   api:
     enabled: true


### PR DESCRIPTION
## Summary
- Bumps seasonpass api/worker/tracker image to `git-c5c0ed5f4eb22b422a6c167339556eba512d8e66`
- Picks up [NineChronicles.SeasonPass#305](https://github.com/planetarium/NineChronicles.SeasonPass/pull/305): short-circuit empty `claim_reward` requests so the SeasonPass API stops creating ~7K no-op `Claim` rows/hour and stops exhausting its SQLAlchemy `QueuePool` under the OVH-bot burst.

## Context
- Production seasonpass-api had been throwing `QueuePool limit of size 10 overflow 20 reached, connection timed out, timeout 60.00` since the OVH bot (`51.83.6.194`) started farming ~391 agent addresses around 2026-06-01 KST.
- 87% of those bot requests had `reward_list == []` (already-claimed season). The early-return in #305 skips INSERT/commit/Celery dispatch on that path while keeping the same response shape, so the game client behavior is unchanged.

## Test plan
- [ ] After ArgoCD sync, verify pod uses new image tag (`kubectl -n 9c-external-services get pod -l app=seasonpass-api -o jsonpath='{.items[0].spec.containers[0].image}'`).
- [ ] Verify `QueuePool` alarms cease.
- [ ] Verify SUCCESS-path claims still produce blockchain transactions (12.1% baseline).
- [ ] Verify game client `/api/user/claim` still returns 200 + `reward_list=[]` for already-claimed seasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)