### PR TITLE
Remove heimdall rpc-1 from mainnet

### DIFF
--- a/planets/mainnet.json
+++ b/planets/mainnet.json
@@ -62,12 +62,10 @@
         "https://api-heimdall.9cscan.com"
       ],
       "headless.gql": [
-        "https://heimdall-rpc-1.nine-chronicles.com/graphql",
         "https://heimdall-rpc-2.nine-chronicles.com/graphql",
         "https://heimdall6.9capi.com/graphql"
       ],
       "headless.grpc": [
-        "http://heimdall-rpc-1.nine-chronicles.com:31238",
         "http://heimdall-rpc-2.nine-chronicles.com:31238",
         "http://heimdall6.9capi.com:31238"
       ],


### PR DESCRIPTION
Remove `heimdall-rpc-1` endpoints from `planets/mainnet.json`.

- `headless.gql`: drop `https://heimdall-rpc-1.nine-chronicles.com/graphql`
- `headless.grpc`: drop `http://heimdall-rpc-1.nine-chronicles.com:31238`

🤖 Generated with [Claude Code](https://claude.com/claude-code)