### PR TITLE
Enable BigQuery analytics worker for rb web2 environments

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -15,7 +15,7 @@ logStream:
   image:
     tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
 
-# web2: ygg / bigquery workloads are disabled, but their image.tag is still
+# web2: ygg workloads are disabled, but their image.tag is still
 # pinned so `bump-image rb <hash>` (bulk) stays uniform across env×tier and
 # a future promotion to web3 doesn't need a separate tag-fill step.
 yggRedeem:
@@ -27,6 +27,6 @@ yggQuestWorker:
   image:
     tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
 bqAnalyticsWorker:
-  enabled: false
+  enabled: true
   image:
     tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181

--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -15,7 +15,7 @@ logStream:
   image:
     tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
 
-# web2: ygg / bigquery workloads are disabled, but image.tag is pinned
+# web2: ygg workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
@@ -26,6 +26,6 @@ yggQuestWorker:
   image:
     tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
 bqAnalyticsWorker:
-  enabled: false
+  enabled: true
   image:
     tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181

--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -15,7 +15,7 @@ logStream:
   image:
     tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
 
-# web2: ygg / bigquery workloads are disabled, but image.tag is pinned
+# web2: ygg workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
@@ -26,6 +26,6 @@ yggQuestWorker:
   image:
     tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
 bqAnalyticsWorker:
-  enabled: false
+  enabled: true
   image:
     tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181


### PR DESCRIPTION
## What

Enable BigQuery transmission (`bqAnalyticsWorker`) for the ragnarok-breaker **web2** environments, which were previously all disabled.

| Environment | File | Change |
|---|---|---|
| prod-web2 | `9c-main/ragnarok-breaker-prod-web2/values.yaml` | `bqAnalyticsWorker.enabled: false → true` |
| staging-web2 | `9c-internal/ragnarok-breaker-staging-web2/values.yaml` | `bqAnalyticsWorker.enabled: false → true` |
| dev-web2 | `9c-internal/ragnarok-breaker-dev-web2/values.yaml` | `bqAnalyticsWorker.enabled: false → true` |

Only `bqAnalyticsWorker` is enabled; the `yggRedeem` / `yggQuestWorker` workloads remain disabled. The now-stale comment ("ygg / bigquery workloads are disabled") was updated to drop the bigquery mention.

## ⚠️ Pre-deploy check

`bq-analytics-worker` consumes env vars from the `ragnarok-breaker-env` secret, which is pulled wholesale from AWS Secrets Manager (us-east-2) via `dataFrom.extract`. For the worker to start cleanly, these keys must exist in each web2 secret path (`ragnarok-breaker/{prod,staging,dev}-web2`):

- `BQ_SERVICE_ACCOUNT_JSON_BASE64`
- `BQ_ANALYTICS_REDIS_URL`

Please confirm these are present in the web2 secret paths before merging/syncing, otherwise the worker will fail at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)