### PR TITLE
chore(ragnarok-breaker): bump dev + staging + production image to git-ee184bd

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 v8Gateway:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 logStream:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 # web2: ygg workloads are disabled, but their image.tag is still
 # pinned so `bump-image rb <hash>` (bulk) stays uniform across env×tier and
@@ -21,12 +21,12 @@ logStream:
 yggRedeem:
   enabled: false
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 bqAnalyticsWorker:
   enabled: true
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 v8Gateway:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 logStream:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 yggRedeem:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
   httpRoute:
     enabled: true
     hostnames:
@@ -25,8 +25,8 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 bqAnalyticsWorker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2

--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -5,27 +5,27 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 v8Gateway:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 logStream:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 # web2: ygg workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 bqAnalyticsWorker:
   enabled: true
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 v8Gateway:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 logStream:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 yggRedeem:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
   httpRoute:
     enabled: true
     hostnames:
@@ -25,8 +25,8 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 bqAnalyticsWorker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 v8Gateway:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 yggRedeem:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
   httpRoute:
     enabled: true
     hostnames:
@@ -21,12 +21,12 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 yggQuestWorker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 bqAnalyticsWorker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2

--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,27 +5,27 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 v8Gateway:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 logStream:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 # web2: ygg workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 bqAnalyticsWorker:
   enabled: true
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 v8Gateway:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 logStream:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 yggRedeem:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
   deployment:
     replicas: 2
   httpRoute:
@@ -27,12 +27,12 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
   replicas: 2
 
 bqAnalyticsWorker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 # Single shared ingest gateway for all payment envs (no app_env split) —
 # the only namespace that hosts it. Image tag is bumped on its own via

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 v8Gateway:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 yggRedeem:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
   deployment:
     replicas: 2
   httpRoute:
@@ -23,13 +23,13 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
 
 yggQuestWorker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
   replicas: 2
 
 bqAnalyticsWorker:
   image:
-    tag: git-0a56f2e935f4387bd987f05e67e9fcf6d5e4c181
+    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2


### PR DESCRIPTION
Pin all ragnarok-breaker images to `git-ee184bdd7872759d9bd02acddc1982e849cdf4f2` for dev + staging + production.

## Test plan
- [ ] After sync, pods pull the pinned image successfully