### PR TITLE
chore(ragnarok-breaker): pin staging image to git-5ed92f4

### DIFF
--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -5,27 +5,27 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
 
 v8Gateway:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
 
 logStream:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
 
 # web2: ygg workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
 bqAnalyticsWorker:
   enabled: true
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
 
 v8Gateway:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
 
 logStream:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
 
 yggRedeem:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
   httpRoute:
     enabled: true
     hostnames:
@@ -25,8 +25,8 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
 
 bqAnalyticsWorker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
 
 v8Gateway:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
 
 yggRedeem:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
   httpRoute:
     enabled: true
     hostnames:
@@ -21,12 +21,12 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
 
 yggQuestWorker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
 
 bqAnalyticsWorker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab


### PR DESCRIPTION
Pin all ragnarok-breaker images to `git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab` for staging.

## Test plan
- [ ] After sync, pods pull the pinned image successfully