### PR TITLE
fix(ragnarok-breaker): point worker chart at polling entrypoints

### DIFF
--- a/charts/ragnarok-breaker/values.yaml
+++ b/charts/ragnarok-breaker/values.yaml
@@ -4,23 +4,27 @@ imagePullSecret:
   name: ragnarok-breaker-regcred
   secretKey: ""
 
-# === Worker: single image, 3 entry points ===
+# === Worker: single image, 2 entry points ===
 worker:
   image:
     repository: planetariumhq/ragnarok-breaker-worker
     tag: develop
     pullPolicy: IfNotPresent
 
-# Anti-cheat validation is log-stream-triggered (MR-C refactor): seed and
-# gameplay validation run as BullMQ consumers fed by log-stream trigger jobs.
-# The old polling scheduler and the separate game/gameplay/summon validators
-# were removed upstream; their entry files no longer exist in the image.
-# All three workers reach V8 only through v8-gateway and share Redis (REDIS_URL).
+# Anti-cheat validation is polling-based (upstream refactor): each worker runs
+# its own BullMQ repeatable scheduler and sweeps the V8 game-history collection
+# for `validated == false` rows, runs gameplay validation, and writes the
+# result back via admin.markRecordValidated (collection update + autoban +
+# slack). The old log-stream trigger path and the seed/gameplay trigger workers
+# were removed upstream; their entry files no longer exist in the image. Both
+# workers reach V8 only through v8-gateway and share Redis (REDIS_URL).
+#   - stageValidation : STAGE + VALHALLA sweep, every STAGE_VALIDATION_INTERVAL_MS  (default 30s)
+#   - leagueValidation: LEAGUE finalize + snapshot, every LEAGUE_VALIDATION_INTERVAL_MS (default 1h)
 workers:
-  seedTrigger:
+  stageValidation:
     enabled: true
     replicas: 1
-    command: ["bun", "run", "services/worker/src/entry/seed-trigger-worker.entry.ts"]
+    command: ["bun", "run", "services/worker/src/entry/stage-validation-worker.entry.ts"]
     resources:
       requests:
         cpu: 200m
@@ -28,21 +32,10 @@ workers:
       limits:
         cpu: "1"
         memory: 1Gi
-  gameplayTrigger:
+  leagueValidation:
     enabled: true
     replicas: 1
-    command: ["bun", "run", "services/worker/src/entry/gameplay-trigger-worker.entry.ts"]
-    resources:
-      requests:
-        cpu: 200m
-        memory: 512Mi
-      limits:
-        cpu: "1"
-        memory: 1Gi
-  leagueSnapshot:
-    enabled: true
-    replicas: 1
-    command: ["bun", "run", "services/worker/src/entry/league-worker.entry.ts"]
+    command: ["bun", "run", "services/worker/src/entry/league-validation-worker.entry.ts"]
     resources:
       requests:
         cpu: 200m


### PR DESCRIPTION
## 무엇을 / 왜

ragnarok-breaker 워커가 upstream에서 **log-stream trigger 방식 → self-scheduled polling 방식**으로 리팩터되면서 워커 엔트리 파일이 교체됐습니다. 옛 파일 3개(`seed-trigger-worker` / `gameplay-trigger-worker` / `league-worker`)는 삭제됐고, 현재 전 환경에 핀된 워커 이미지(dev/prod `git-ee184bd`, staging `git-5ed92f4`)에는 새 엔트리 2개만 존재합니다:

- `services/worker/src/entry/stage-validation-worker.entry.ts`
- `services/worker/src/entry/league-validation-worker.entry.ts`

하지만 차트(`charts/ragnarok-breaker/values.yaml`)의 `workers` 맵은 여전히 **삭제된 파일**을 `command`로 가리키고 있었습니다. 현재 ArgoCD apps는 `OutOfSync`(auto-sync 없음)라 옛 이미지로 돌아 멀쩡하지만, 누군가 sync하는 순간 워커 컨테이너가 없는 엔트리 파일을 실행하려다 **전부 CrashLoopBackOff** 됩니다.

## 변경

`workers` 맵의 trigger 3키 → polling 2키로 교체:

- `seedTrigger` + `gameplayTrigger` → **`stageValidation`** (`stage-validation-worker.entry.ts`, STAGE + VALHALLA 스윕, 기본 30s)
- `leagueSnapshot` → **`leagueValidation`** (`league-validation-worker.entry.ts`, LEAGUE finalize+snapshot, 기본 1h)

폴링 워커는 V8 game-history 컬렉션을 `validated == false`로 스캔 → gameplay 검증 → `admin.markRecordValidated`로 write-back(컬렉션 갱신 + autoban + slack). 모두 v8-gateway 경유, Redis 공유.

env overlay 8개는 image tag만 덮어쓰고 `workers` 맵은 chart default를 상속하므로, **이 단일 파일 변경이 전 env×tier에 적용**됩니다. sync 시 ArgoCD가 새 Deployment 2개 생성 + 옛 3개(`ragnarok-breaker-{seed-trigger,gameplay-trigger,league-snapshot}`) prune.

## 검증

- `helm template`로 prod-web3 overlay 렌더 확인: `ragnarok-breaker-stage-validation` / `-league-validation` Deployment가 새 엔트리 파일을 실행, 옛 trigger 참조 0건.
- 워커 엔트리 파일 존재 여부는 petpop `develop` tip(`5ed92f4`) 및 `main` tip(`ee184bd`)에서 `git ls-tree`로 직접 확인.

## 롤아웃 (권장 순서)

⚠️ 이 차트가 머지되기 전에 rb 이미지 bump를 prod에 sync하면 crashloop. 차트 머지 후:

1. **dev-web2/web3** 먼저 sync → polling 워커(`stage-validation`, `league-validation`) 정상 기동 + 옛 deployment prune 확인
2. 이상 없으면 **staging → prod** 순으로 sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)