### PR TITLE
chore(ragnarok-breaker): bump dev + staging worker image to git-13a9dcd

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-13a9dcd11cb6e65c3f22da05b85cf2deb5288533
 
 v8Gateway:
   image:

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-13a9dcd11cb6e65c3f22da05b85cf2deb5288533
 
 v8Gateway:
   image:

--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-13a9dcd11cb6e65c3f22da05b85cf2deb5288533
 
 v8Gateway:
   image:

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-13a9dcd11cb6e65c3f22da05b85cf2deb5288533
 
 v8Gateway:
   image:

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-13a9dcd11cb6e65c3f22da05b85cf2deb5288533
 
 v8Gateway:
   image:


### PR DESCRIPTION
## 변경

rb **worker** 이미지를 `git-13a9dcd11cb6e65c3f22da05b85cf2deb5288533`로 bump (worker 한정).

- 적용: **dev** (web2, web3) + **staging** (legacy, web2, web3) — 총 5개 values
- v8-gateway / log-stream / ygg-redeem / ygg-quest-worker / bq-analytics-worker tag는 **변경 없음**

## 커밋 정보

`13a9dcd1` = petpop develop tip "Merge fix/RB-meta-tags-sheet-pin" (2026-06-09). `services/worker/src/workers/gameplay-validation-core.ts` + `packages/shared/master-data/sheet-pins.ts` 변경 포함.

## 검증

- **엔트리 호환**: 이 커밋의 `services/worker/src/entry/`는 polling 2종(`stage-validation-worker` / `league-validation-worker`)뿐 → main에 머지된 차트(#3458)와 일치. (옛 trigger 엔트리 없음 → crashloop 없음)
- **이미지 존재**: 이 커밋이 `services/worker/**` + `packages/shared/**`를 변경 → rb CI의 `build:worker` 트리거 경로에 해당하므로 worker 이미지가 빌드됨 (develop-hash 미빌드 함정 회피).

## 롤아웃

ArgoCD 수동 sync. dev에서 먼저 polling 워커 정상 기동 확인 후 staging sync 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)