### PR TITLE
chore(ragnarok-breaker): pin dev worker image to git-13a9dcd

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-13a9dcd11cb6e65c3f22da05b85cf2deb5288533
 
 v8Gateway:
   image:

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-13a9dcd11cb6e65c3f22da05b85cf2deb5288533
 
 v8Gateway:
   image:


### PR DESCRIPTION
Pin ragnarok-breaker-worker to `git-13a9dcd11cb6e65c3f22da05b85cf2deb5288533` for dev.

## Test plan
- [ ] After sync, pods pull the pinned image successfully