### PR TITLE
chore(ragnarok-breaker): pin staging worker image to git-13a9dcd

### DIFF
--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-13a9dcd11cb6e65c3f22da05b85cf2deb5288533
 
 v8Gateway:
   image:

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-13a9dcd11cb6e65c3f22da05b85cf2deb5288533
 
 v8Gateway:
   image:

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-13a9dcd11cb6e65c3f22da05b85cf2deb5288533
 
 v8Gateway:
   image:


### PR DESCRIPTION
Pin ragnarok-breaker-worker to `git-13a9dcd11cb6e65c3f22da05b85cf2deb5288533` for staging.

## Test plan
- [ ] After sync, pods pull the pinned image successfully