### PR TITLE
fix(scripts): derive bump-image PR head from origin owner

### DIFF
--- a/scripts/bump-image.sh
+++ b/scripts/bump-image.sh
@@ -372,10 +372,22 @@ Pin ${SERVICE_LABEL} to \`$TAG\` for $body_envs.
 EOF
 )
 
+  # Derive the PR head ref from origin's GitHub owner so this works whether
+  # `origin` is the planetarium repo (same-repo PR) or a personal fork
+  # (cross-fork PR). The branch was pushed to `origin` just above, so the head
+  # owner must match origin's owner. Previously hardcoded to "Atralupus:".
+  local origin_owner head_ref
+  origin_owner="$(git remote get-url origin 2>/dev/null | sed -E 's#^.*github\.com[:/]([^/]+)/.*$#\1#')"
+  if [[ -n "$origin_owner" && "$origin_owner" != "planetarium" ]]; then
+    head_ref="${origin_owner}:${branch}"
+  else
+    head_ref="$branch"
+  fi
+
   gh pr create \
     --repo planetarium/9c-infra \
     --base main \
-    --head "Atralupus:$branch" \
+    --head "$head_ref" \
     --title "$title" \
     --body "$body"
 }


### PR DESCRIPTION
## 문제

`scripts/bump-image.sh`가 PR head를 `--head "Atralupus:$branch"`로 **하드코딩**하고 있었습니다. 브랜치는 `git push -u origin`으로 푸시하면서 head는 항상 Atralupus 포크에서 찾으므로, **`origin`=Atralupus 포크인 환경에서만** 정상 동작합니다. `origin`=planetarium인 클론에서 실행하면 브랜치는 planetarium에 푸시되지만 `gh pr create`가 Atralupus 포크에서 그 브랜치를 찾아 **실패**합니다.

## 수정

head owner를 `git remote get-url origin`에서 동적 도출:
- origin owner == planetarium → `--head "$branch"` (same-repo PR)
- 그 외(개인 포크) → `--head "owner:$branch"` (cross-fork PR)

브랜치를 푸시한 `origin`과 head owner가 항상 일치하므로 planetarium 직접 클론과 포크 클론 양쪽에서 동작합니다.

## 검증

이 fix를 적용한 스크립트로 worker 이미지 bump를 실제 생성: #3460 (dev), #3461 (staging) — origin=planetarium 환경에서 same-repo PR로 정상 생성됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)