### PR TITLE
chore(ragnarok-breaker): pin dev worker image to git-848cb83a

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-13a9dcd11cb6e65c3f22da05b85cf2deb5288533
+    tag: git-848cb83a8669385fd20f599116e7f9e839f4a934
 
 v8Gateway:
   image:

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-13a9dcd11cb6e65c3f22da05b85cf2deb5288533
+    tag: git-848cb83a8669385fd20f599116e7f9e839f4a934
 
 v8Gateway:
   image:


### PR DESCRIPTION
Pin ragnarok-breaker-worker to \`git-848cb83a8669385fd20f599116e7f9e839f4a934\` for dev (petpop/develop tip).

## 포함 변경 (petpop 4 MR 머지 결과)

- **RB-1646 fix(worker)**: `clientEnemies` collection hydration — stripped v3 master data 분리 후 worker 가 enemy `health/speed/atk` 못 가져오던 root cause. `wave-progression` 의 `DPS_IMPOSSIBLE_CLEAR` / `WAVE_CLEAR_TIME_TOO_FAST` / `SPAWN_BOTTLENECK_FAIL` 검증이 `weightedAvgHP=NaN` 가드에 silent skip 되던 dormant 상태 해제.
- **RB-1647 fix(anti-cheat)**: `WAVE_SHOP_HISTORY_MISSING` (CRITICAL) violation 신규 — client 가 `waveShopHistory: []` 빈 array 로 보내면 server `validateClear` + worker `validateAllWaveShops` 의 wave-shop check loop 가 진입 안 해 모든 wave-shop violation 자동 skip 되던 bypass 차단.
- **RB-1648 docs(worker)**: `predictedScoreCeiling` measure-only 의도 명시 (코드 동작 변화 0).
- **RB-1650 chore(worker)**: dead validator (`clearTimeMs=0` dormant gate stale comment + `HISTORY_ACCOUNT_MISMATCH`/`SEED_VALUE_MISMATCH` defense-in-depth) 코멘트 정리.

## Test plan

- [ ] After sync, pods pull the pinned image successfully
- [ ] Worker validation 이 정상 작동 (`record failed` log 없음, `validated=true workerViolationCodes=[...]` stamp)
- [ ] worker harness 재발사로 S2/S2v/S3/S3v 가 이제 DPS_IMPOSSIBLE_CLEAR / WAVE_CLEAR_TIME_TOO_FAST 발화 확인
- [ ] 새 S4 시나리오 (`waveShopHistory: []`) 로 WAVE_SHOP_HISTORY_MISSING CRITICAL ban + slack 확인