### PR TITLE
chore(ragnarok-breaker): bump dev + staging + production image to git-88dfcf9

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-848cb83a8669385fd20f599116e7f9e839f4a934
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 v8Gateway:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 logStream:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 # web2: ygg workloads are disabled, but their image.tag is still
 # pinned so `bump-image rb <hash>` (bulk) stays uniform across env×tier and
@@ -21,12 +21,12 @@ logStream:
 yggRedeem:
   enabled: false
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 bqAnalyticsWorker:
   enabled: true
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-848cb83a8669385fd20f599116e7f9e839f4a934
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 v8Gateway:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 logStream:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 yggRedeem:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
   httpRoute:
     enabled: true
     hostnames:
@@ -25,8 +25,8 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 bqAnalyticsWorker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040

--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -5,27 +5,27 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 v8Gateway:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 logStream:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 # web2: ygg workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 bqAnalyticsWorker:
   enabled: true
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 v8Gateway:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 logStream:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 yggRedeem:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
   httpRoute:
     enabled: true
     hostnames:
@@ -25,8 +25,8 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 bqAnalyticsWorker:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 v8Gateway:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 yggRedeem:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
   httpRoute:
     enabled: true
     hostnames:
@@ -21,12 +21,12 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 yggQuestWorker:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 bqAnalyticsWorker:
   image:
-    tag: git-5ed92f4a2154b502c361087c97e3e8c83d4df9ab
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040

--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,27 +5,27 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 v8Gateway:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 logStream:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 # web2: ygg workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 bqAnalyticsWorker:
   enabled: true
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 v8Gateway:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 logStream:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 yggRedeem:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
   deployment:
     replicas: 2
   httpRoute:
@@ -27,12 +27,12 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
   replicas: 2
 
 bqAnalyticsWorker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 # Single shared ingest gateway for all payment envs (no app_env split) —
 # the only namespace that hosts it. Image tag is bumped on its own via

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 v8Gateway:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 yggRedeem:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
   deployment:
     replicas: 2
   httpRoute:
@@ -23,13 +23,13 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 yggQuestWorker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
   replicas: 2
 
 bqAnalyticsWorker:
   image:
-    tag: git-ee184bdd7872759d9bd02acddc1982e849cdf4f2
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040


### PR DESCRIPTION
Pin all ragnarok-breaker images to `git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040` for dev + staging + production.

## Test plan
- [ ] After sync, pods pull the pinned image successfully