### PR TITLE
chore(ragnarok-breaker): pin production worker image to git-f04e2fc

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-f04e2fcf16e2305994d68edcde92f65861fd3b07
 
 v8Gateway:
   image:

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-f04e2fcf16e2305994d68edcde92f65861fd3b07
 
 v8Gateway:
   image:

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-f04e2fcf16e2305994d68edcde92f65861fd3b07
 
 v8Gateway:
   image:


### PR DESCRIPTION
Pin ragnarok-breaker-worker to `git-f04e2fcf16e2305994d68edcde92f65861fd3b07` for production (web2 + web3 + production overlays).

최신 develop 커밋(`f04e2fcf1`, MR !769 머지 — anti-cheat false-positive 5건 수정)의 worker 이미지로 prod worker 워크로드를 갱신합니다. worker 외 다른 워크로드(v8-gateway/log-stream/ygg-*/bq-analytics)는 이 커밋에서 빌드되지 않아 변경하지 않습니다.

## Test plan
- [ ] After sync, prod worker pods pull `git-f04e2fcf16e2305994d68edcde92f65861fd3b07` successfully