### PR TITLE
fix(ragnarok-breaker): keep bq-ingest-gateway in the bulk image bump

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -35,12 +35,13 @@ bqAnalyticsWorker:
     tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
 # Single shared ingest gateway for all payment envs (no app_env split) —
-# the only namespace that hosts it. Image tag is bumped on its own via
-# `bump-image rb bq-ingest-gateway <hash>` (excluded from the bulk all-bump).
+# the only namespace that hosts it. The bulk `bump-image rb <hash>` keeps this
+# in sync (optional key: bumped here where present, skipped in overlays that
+# lack it); a targeted `bump-image rb bq-ingest-gateway <hash>` also works.
 bqIngestGateway:
   enabled: true
   image:
-    tag: git-088af99e6359ab9062796dd43fca5a43b92335f5
+    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
   httpRoute:
     enabled: true
     hostnames:

--- a/scripts/bump-image.sh
+++ b/scripts/bump-image.sh
@@ -142,6 +142,11 @@ BRANCH_PREFIX=""
 STAGING_FILE=""
 PRODUCTION_FILE=""
 TAG_KEYS=()
+# Optional keys: bumped where present, skipped (not errored) where absent.
+# For workloads that live in only some overlays (e.g. rb's bq-ingest-gateway,
+# prod-web3 only) so a bulk bump can keep them in sync without failing on the
+# files that lack the key.
+OPTIONAL_TAG_KEYS=()
 SUB_SERVICES=()
 # shellcheck disable=SC1090
 source "$MODULE_FILE"
@@ -284,27 +289,41 @@ branch_for() {
   esac
 }
 
+rewrite_tag_line() {
+  # Rewrite only the `tag:` line at $2 in file $1, preserving every other line
+  # (blank lines, comments, other keys) and the original quote style
+  # (`tag: git-x` vs `tag: "git-x"`).
+  local file="$1" line_num="$2" original replacement
+  original="$(sed -n "${line_num}p" "$file")"
+  if [[ "$original" == *'tag: "'* ]]; then
+    replacement="\\1 \"${TAG}\""
+  else
+    replacement="\\1 ${TAG}"
+  fi
+  sed -i.bak -E "${line_num}s|(^[[:space:]]*tag:)[[:space:]]*.*|${replacement}|" "$file"
+  rm -f "${file}.bak"
+}
+
 update_file_tags() {
-  # Rewrite only the `tag:` line of each TAG_KEYS entry in the file,
-  # preserving every other line (blank lines, comments, other keys) and the
-  # original quote style (`tag: git-x` vs `tag: "git-x"`).
   local file="$1"
-  local key line_num original replacement
+  local key line_num
+  # Required keys: must exist in the file, else error.
   for key in "${TAG_KEYS[@]}"; do
     line_num="$(yq "$key | line" "$file")"
     if [[ -z "$line_num" || "$line_num" == "null" || "$line_num" == "0" ]]; then
       echo "error: key '$key' not found in $file" >&2
       return 1
     fi
-    original="$(sed -n "${line_num}p" "$file")"
-    if [[ "$original" == *'tag: "'* ]]; then
-      replacement="\\1 \"${TAG}\""
-    else
-      replacement="\\1 ${TAG}"
-    fi
-    sed -i.bak -E "${line_num}s|(^[[:space:]]*tag:)[[:space:]]*.*|${replacement}|" "$file"
-    rm -f "${file}.bak"
+    rewrite_tag_line "$file" "$line_num"
   done
+  # Optional keys: bump where present, skip silently where absent.
+  if [[ "${#OPTIONAL_TAG_KEYS[@]:-0}" -gt 0 ]]; then
+    for key in "${OPTIONAL_TAG_KEYS[@]}"; do
+      line_num="$(yq "$key | line" "$file")"
+      [[ -z "$line_num" || "$line_num" == "null" || "$line_num" == "0" ]] && continue
+      rewrite_tag_line "$file" "$line_num"
+    done
+  fi
 }
 
 ORIGINAL_BRANCH="$(git rev-parse --abbrev-ref HEAD)"

--- a/scripts/bump-modules/rb.sh
+++ b/scripts/bump-modules/rb.sh
@@ -1,11 +1,13 @@
 # ragnarok-breaker chart — 7 independent images, one per workload.
 # Usage:
 #   bump-image.sh rb <worker|v8-gateway|ygg-redeem|log-stream|ygg-quest-worker|bq-analytics-worker|bq-ingest-gateway> <hash>
-#   bump-image.sh rb <hash>   # bump every workload at once (except bq-ingest-gateway)
+#   bump-image.sh rb <hash>   # bump every workload at once
 #
-# bq-ingest-gateway is a single shared instance living only in prod-web3, so it
-# is NOT part of the bulk all-bump and its per-service bump targets prod-web3
-# only. Bump it explicitly: bump-image.sh rb bq-ingest-gateway <hash>
+# bq-ingest-gateway is a single shared instance living only in prod-web3. The
+# bulk all-bump includes it as an OPTIONAL key, so `bump-image.sh rb <hash>`
+# keeps it in sync where it exists (prod-web3) and skips the overlays that lack
+# it. Its per-service bump still targets prod-web3 only:
+#   bump-image.sh rb bq-ingest-gateway <hash>
 #
 # Environments after the env×tier split (dev/staging/prod × web2/web3):
 # each env keyword resolves to multiple values files (legacy single-ns values
@@ -96,8 +98,10 @@ resolve_all_sub_services() {
     ".yggQuestWorker.image.tag"
     ".bqAnalyticsWorker.image.tag"
   )
-  # bqIngestGateway is intentionally excluded — it lives only in prod-web3 and
-  # the bulk bump spans every env file, most of which lack the key.
+  # bqIngestGateway lives only in prod-web3, so it's an OPTIONAL key: the bulk
+  # bump spans every env file but bumps this one only where it exists (prod-web3)
+  # and skips the overlays that lack it, instead of erroring on the missing key.
+  OPTIONAL_TAG_KEYS=(".bqIngestGateway.image.tag")
   SERVICE_LABEL="all ragnarok-breaker images"
   BRANCH_PREFIX="ragnarok-breaker-all"
 }


### PR DESCRIPTION
## Problem
The bulk `bump-image.sh rb <hash>` **excluded** `bqIngestGateway` because it lives only in `prod-web3`, and `update_file_tags` errors on any `TAG_KEY` missing from a values file. So the recent bump to `git-88dfcf9` (#3464) moved every other rb workload but left `prod-web3`'s `bqIngestGateway` pinned to the stale `git-088af99`.

## Fix
- **`scripts/bump-image.sh`**: introduce `OPTIONAL_TAG_KEYS` — bumped where present, **skipped (not errored)** where absent. Factor the tag rewrite into `rewrite_tag_line()`.
- **`scripts/bump-modules/rb.sh`**: include `.bqIngestGateway.image.tag` as an optional key in the bulk all-bump, so a plain `bump-image.sh rb <hash>` keeps it in sync wherever it exists (today: `prod-web3` only) and skips overlays that lack it. The targeted `bump-image.sh rb bq-ingest-gateway <hash>` still works.
- **`9c-main/ragnarok-breaker-prod-web3/values.yaml`**: pin `bqIngestGateway` to `git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040`, matching the other rb workloads in that overlay.

## Test plan
- [x] `bash -n` passes on both scripts.
- [x] Functional test under bash 3.2 + `set -euo pipefail` on real overlay copies: `prod-web3` (has the key) bumps all 7 workloads with exit 0; `staging-web3` (lacks the key) bumps the 6 required keys and skips the optional one with **no error**.
- [ ] After sync, the bq-ingest-gateway pod pulls `git-88dfcf9` successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)