### PR TITLE
chore(ragnarok-breaker): disable bq-analytics in staging+dev, ygg in dev-web3

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -26,7 +26,8 @@ yggQuestWorker:
   enabled: false
   image:
     tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+# bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
-  enabled: true
+  enabled: false
   image:
     tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -15,18 +15,18 @@ logStream:
   image:
     tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
+# dev: ygg workloads run in staging only and bq-analytics runs in production
+# only; all disabled here, but image.tag stays pinned so `bump-image rb <hash>`
+# (bulk) stays uniform across env×tier.
 yggRedeem:
+  enabled: false
   image:
     tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
-  httpRoute:
-    enabled: true
-    hostnames:
-      - ygg-redeem-dev.9c.gg
-
 yggQuestWorker:
+  enabled: false
   image:
     tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
-
 bqAnalyticsWorker:
+  enabled: false
   image:
     tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040

--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -25,7 +25,8 @@ yggQuestWorker:
   enabled: false
   image:
     tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+# bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
-  enabled: true
+  enabled: false
   image:
     tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -27,6 +27,8 @@ yggQuestWorker:
   image:
     tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
+# bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
+  enabled: false
   image:
     tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -27,6 +27,8 @@ yggQuestWorker:
   image:
     tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
 
+# bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
+  enabled: false
   image:
     tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040


### PR DESCRIPTION
## What
- **bq-analytics-worker** → `enabled: false` in every **staging** and **dev** overlay (it should run in production only):
  - `9c-internal/ragnarok-breaker-staging/values.yaml`
  - `9c-internal/ragnarok-breaker-staging-web2/values.yaml`
  - `9c-internal/ragnarok-breaker-staging-web3/values.yaml`
  - `9c-internal/ragnarok-breaker-dev-web2/values.yaml`
  - `9c-internal/ragnarok-breaker-dev-web3/values.yaml`
- **ygg-redeem** and **ygg-quest-worker** → `enabled: false` in **dev-web3** (they should run in staging only; dev-web2 was already off). Legacy staging and staging-web3 keep them.

## How
Disabled via `enabled: false` with `image.tag` left pinned, matching the existing web2 convention so the bulk `bump-image rb <hash>` stays uniform across env×tier (those tag keys are required by the bumper).

## Test plan
- [x] `yq` parse OK on all 5 files; all required bulk-bump tag keys still present.
- [x] `helm template` on **dev-web3**: renders only worker/v8-gateway/log-stream — no ygg-redeem, ygg-quest-worker, or bq-analytics-worker.
- [x] `helm template` on **staging-web3**: still renders both ygg deployments (+ ygg-redeem Service/HTTPRoute), and no bq-analytics-worker.
- [ ] After sync, the disabled pods are removed and staging ygg workloads stay healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)