### PR TITLE
chore(ragnarok-breaker): bump dev + staging + production image to git-fe553cd

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 v8Gateway:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 logStream:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 # web2: ygg workloads are disabled, but their image.tag is still
 # pinned so `bump-image rb <hash>` (bulk) stays uniform across env×tier and
@@ -21,13 +21,13 @@ logStream:
 yggRedeem:
   enabled: false
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 # bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 v8Gateway:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 logStream:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 # dev: ygg workloads run in staging only and bq-analytics runs in production
 # only; all disabled here, but image.tag stays pinned so `bump-image rb <hash>`
@@ -21,12 +21,12 @@ logStream:
 yggRedeem:
   enabled: false
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5

--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -5,28 +5,28 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 v8Gateway:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 logStream:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 # web2: ygg workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 # bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 v8Gateway:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 logStream:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 yggRedeem:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
   httpRoute:
     enabled: true
     hostnames:
@@ -25,10 +25,10 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 # bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 v8Gateway:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 yggRedeem:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
   httpRoute:
     enabled: true
     hostnames:
@@ -21,14 +21,14 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 yggQuestWorker:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 # bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5

--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,27 +5,27 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-f04e2fcf16e2305994d68edcde92f65861fd3b07
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 v8Gateway:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 logStream:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 # web2: ygg workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 bqAnalyticsWorker:
   enabled: true
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-f04e2fcf16e2305994d68edcde92f65861fd3b07
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 v8Gateway:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 logStream:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 yggRedeem:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
   deployment:
     replicas: 2
   httpRoute:
@@ -27,12 +27,12 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
   replicas: 2
 
 bqAnalyticsWorker:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 # Single shared ingest gateway for all payment envs (no app_env split) —
 # the only namespace that hosts it. The bulk `bump-image rb <hash>` keeps this
@@ -41,7 +41,7 @@ bqAnalyticsWorker:
 bqIngestGateway:
   enabled: true
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
   httpRoute:
     enabled: true
     hostnames:

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-f04e2fcf16e2305994d68edcde92f65861fd3b07
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 v8Gateway:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 yggRedeem:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
   deployment:
     replicas: 2
   httpRoute:
@@ -23,13 +23,13 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
 
 yggQuestWorker:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
   replicas: 2
 
 bqAnalyticsWorker:
   image:
-    tag: git-88dfcf9dd0b678c240a1385eead7b8fa2f1b6040
+    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5


### PR DESCRIPTION
Pin all ragnarok-breaker images to `git-fe553cdb29aaf4407494627485248980ba6b7db5` for dev + staging + production.

## Test plan
- [ ] After sync, pods pull the pinned image successfully