### PR TITLE
feat(ragnarok-breaker): add anticheat-alert-worker (Slack), prod only

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -29,3 +29,10 @@ bqAnalyticsWorker:
   enabled: true
   image:
     tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+
+# Anti-cheat → Slack alert worker (prod only). SLACK_VIOLATION_WEBHOOK_URL is
+# read from the ragnarok-breaker-env SecretsManager entry for this namespace.
+anticheatAlertWorker:
+  enabled: true
+  image:
+    tag: git-eba7fb42eaed54bed0513debd68f1db2a0ec639d

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -34,6 +34,13 @@ bqAnalyticsWorker:
   image:
     tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
+# Anti-cheat → Slack alert worker (prod only). SLACK_VIOLATION_WEBHOOK_URL is
+# read from the ragnarok-breaker-env SecretsManager entry for this namespace.
+anticheatAlertWorker:
+  enabled: true
+  image:
+    tag: git-eba7fb42eaed54bed0513debd68f1db2a0ec639d
+
 # Single shared ingest gateway for all payment envs (no app_env split) —
 # the only namespace that hosts it. The bulk `bump-image rb <hash>` keeps this
 # in sync (optional key: bumped here where present, skipped in overlays that

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -33,3 +33,10 @@ yggQuestWorker:
 bqAnalyticsWorker:
   image:
     tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+
+# Anti-cheat → Slack alert worker (prod only). SLACK_VIOLATION_WEBHOOK_URL is
+# read from the ragnarok-breaker-env SecretsManager entry for this namespace.
+anticheatAlertWorker:
+  enabled: true
+  image:
+    tag: git-eba7fb42eaed54bed0513debd68f1db2a0ec639d

--- a/charts/ragnarok-breaker/Chart.yaml
+++ b/charts/ragnarok-breaker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ragnarok-breaker
-description: Ragnarok Breaker workloads (workers + v8-gateway + ygg-redeem + log-stream + ygg-quest-worker)
+description: Ragnarok Breaker workloads (workers + v8-gateway + ygg-redeem + log-stream + ygg-quest-worker + bq-analytics-worker + bq-ingest-gateway + anticheat-alert-worker)
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: 0.2.0

--- a/charts/ragnarok-breaker/templates/anticheat-alert-worker-deployment.yaml
+++ b/charts/ragnarok-breaker/templates/anticheat-alert-worker-deployment.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.anticheatAlertWorker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: anticheat-alert-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: anticheat-alert-worker
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: anticheat-alert-worker
+spec:
+  replicas: {{ .Values.anticheatAlertWorker.replicas }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: anticheat-alert-worker
+  template:
+    metadata:
+      labels:
+        app: anticheat-alert-worker
+    spec:
+      {{- if .Values.imagePullSecret.secretKey }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret.name }}
+      {{- end }}
+      containers:
+        - name: anticheat-alert-worker
+          image: "{{ .Values.anticheatAlertWorker.image.repository }}:{{ .Values.anticheatAlertWorker.image.tag }}"
+          imagePullPolicy: {{ .Values.anticheatAlertWorker.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: ragnarok-breaker-env
+          resources:
+            {{- toYaml .Values.anticheatAlertWorker.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always
+{{- end }}

--- a/charts/ragnarok-breaker/values.yaml
+++ b/charts/ragnarok-breaker/values.yaml
@@ -172,6 +172,28 @@ bqAnalyticsWorker:
       cpu: 500m
       memory: 512Mi
 
+# === Anti-cheat alert worker → Slack ===
+# BullMQ consumer for the anticheat-alert queue (prefix `aca`). The server emits
+# anticheat_alert log events; log-stream routes them onto the queue; this worker
+# consumes them and POSTs to Slack. Per-env consumer (own Redis), so enabled in
+# each prod overlay (default off here). Reads from the ragnarok-breaker-env
+# ExternalSecret: REDIS_URL (required), SLACK_VIOLATION_WEBHOOK_URL (optional —
+# unset → notifications silently skipped), WORKER_CONCURRENCY (optional, dflt 5).
+anticheatAlertWorker:
+  enabled: false
+  image:
+    repository: planetariumhq/ragnarok-breaker-anticheat-alert-worker
+    tag: develop
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
 # === External payment backend → BigQuery analytics ingest gateway ===
 # Thin HTTP gateway (Bun.serve): POST /v1/events (Bearer auth) validates the
 # envelope and enqueues a bq_event job onto the bq-analytics-events BullMQ

--- a/scripts/bump-modules/rb.sh
+++ b/scripts/bump-modules/rb.sh
@@ -1,13 +1,16 @@
-# ragnarok-breaker chart — 7 independent images, one per workload.
+# ragnarok-breaker chart — 8 independent images, one per workload.
 # Usage:
-#   bump-image.sh rb <worker|v8-gateway|ygg-redeem|log-stream|ygg-quest-worker|bq-analytics-worker|bq-ingest-gateway> <hash>
+#   bump-image.sh rb <worker|v8-gateway|ygg-redeem|log-stream|ygg-quest-worker|bq-analytics-worker|bq-ingest-gateway|anticheat-alert-worker> <hash>
 #   bump-image.sh rb <hash>   # bump every workload at once
 #
-# bq-ingest-gateway is a single shared instance living only in prod-web3. The
-# bulk all-bump includes it as an OPTIONAL key, so `bump-image.sh rb <hash>`
-# keeps it in sync where it exists (prod-web3) and skips the overlays that lack
-# it. Its per-service bump still targets prod-web3 only:
-#   bump-image.sh rb bq-ingest-gateway <hash>
+# Two workloads are prod-only, so they're excluded from the bulk all-bump's
+# REQUIRED keys and included as OPTIONAL keys instead: `bump-image.sh rb <hash>`
+# bumps them where they exist and skips overlays that lack the key (no error).
+# Their per-service bumps target the prod overlays only:
+#   - bq-ingest-gateway      : single shared instance, prod-web3 only.
+#       bump-image.sh rb bq-ingest-gateway <hash>
+#   - anticheat-alert-worker : per-env Slack alert consumer, all three prod overlays.
+#       bump-image.sh rb anticheat-alert-worker <hash>
 #
 # Environments after the env×tier split (dev/staging/prod × web2/web3):
 # each env keyword resolves to multiple values files (legacy single-ns values
@@ -34,7 +37,7 @@ PRODUCTION_FILES=(
 DEV_FILE="${DEV_FILES[0]}"
 STAGING_FILE="${STAGING_FILES[0]}"
 PRODUCTION_FILE="${PRODUCTION_FILES[0]}"
-SUB_SERVICES=(worker v8-gateway ygg-redeem log-stream ygg-quest-worker bq-analytics-worker bq-ingest-gateway)
+SUB_SERVICES=(worker v8-gateway ygg-redeem log-stream ygg-quest-worker bq-analytics-worker bq-ingest-gateway anticheat-alert-worker)
 
 resolve_sub_service() {
   case "$1" in
@@ -82,6 +85,18 @@ resolve_sub_service() {
       STAGING_FILE="${STAGING_FILES[0]}"
       PRODUCTION_FILE="${PRODUCTION_FILES[0]}"
       ;;
+    anticheat-alert-worker)
+      TAG_KEYS=(".anticheatAlertWorker.image.tag")
+      SERVICE_LABEL="ragnarok-breaker-anticheat-alert-worker"
+      BRANCH_PREFIX="ragnarok-breaker-anticheat-alert-worker"
+      # prod-only workload (enabled in the three prod overlays). Scope every env
+      # keyword to the prod files so any --env (including the default `both`)
+      # only touches prod and never errors on dev/staging files that lack the key.
+      DEV_FILES=("${PRODUCTION_FILES[@]}")
+      STAGING_FILES=("${PRODUCTION_FILES[@]}")
+      DEV_FILE="${PRODUCTION_FILES[0]}"
+      STAGING_FILE="${PRODUCTION_FILES[0]}"
+      ;;
     *)
       echo "error: unknown rb sub-service '$1' (available: ${SUB_SERVICES[*]})" >&2
       return 1
@@ -98,10 +113,15 @@ resolve_all_sub_services() {
     ".yggQuestWorker.image.tag"
     ".bqAnalyticsWorker.image.tag"
   )
-  # bqIngestGateway lives only in prod-web3, so it's an OPTIONAL key: the bulk
-  # bump spans every env file but bumps this one only where it exists (prod-web3)
-  # and skips the overlays that lack it, instead of erroring on the missing key.
-  OPTIONAL_TAG_KEYS=(".bqIngestGateway.image.tag")
+  # Prod-only workloads are OPTIONAL keys: the bulk bump spans every env file but
+  # bumps these only where they exist (the prod overlays) and skips the overlays
+  # that lack them, instead of erroring on the missing key.
+  #   - bqIngestGateway      : prod-web3 only.
+  #   - anticheatAlertWorker : all three prod overlays.
+  OPTIONAL_TAG_KEYS=(
+    ".bqIngestGateway.image.tag"
+    ".anticheatAlertWorker.image.tag"
+  )
   SERVICE_LABEL="all ragnarok-breaker images"
   BRANCH_PREFIX="ragnarok-breaker-all"
 }


### PR DESCRIPTION
## What
Adds the new **anticheat-alert-worker** to the ragnarok-breaker chart and enables it in **prod only**.

Pipeline (from JiwonRB `feat/anticheat-slack-log-pipeline`): server emits `anticheat_alert` log events → `log-stream` routes them onto a BullMQ queue (`aca:anticheat-alert`) → **anticheat-alert-worker** consumes and POSTs to Slack via `SLACK_VIOLATION_WEBHOOK_URL`.

## Changes
- **New Deployment template** `templates/anticheat-alert-worker-deployment.yaml`, gated on `anticheatAlertWorker.enabled`. `envFrom` the shared `ragnarok-breaker-env` ExternalSecret, so `REDIS_URL` / `SLACK_VIOLATION_WEBHOOK_URL` / `WORKER_CONCURRENCY` all come from SecretsManager. Modeled on `bq-analytics-worker`.
- **Chart default** `anticheatAlertWorker.enabled: false`; **enabled in all three prod overlays** (`production`, `prod-web2`, `prod-web3`) — it's a per-env queue consumer (its own Redis), same as `bq-analytics-worker`.
- **Bump tooling** (`scripts/bump-modules/rb.sh`): new `anticheat-alert-worker` sub-service (per-service bump scoped to the prod overlays), and `.anticheatAlertWorker.image.tag` added as an **OPTIONAL** key in the bulk all-bump, so `bump-image rb <hash>` keeps it in sync where present and skips overlays that lack it (same approach as `bq-ingest-gateway`).
- Chart version `0.2.0` → `0.3.0`.

## ⚠️ Prerequisites before pods actually run (outside this repo)
1. **JiwonRB**: merge the feature to `main` **and add a `build:anticheat-alert-worker` CI job** — `planetariumhq/ragnarok-breaker-anticheat-alert-worker` is **not published yet** (no build job exists). Then bump the prod tag to the built `git-<sha>` via `bump-image rb anticheat-alert-worker <sha>` (or the bulk `bump-image rb <sha>`).
2. **SecretsManager**: add `SLACK_VIOLATION_WEBHOOK_URL` to the prod entries (`ragnarok-breaker/production`, `/prod-web2`, `/prod-web3`).

Until (1), the pinned tag `git-fe553cdb` has no image for this service, so the pod will `ImagePullBackOff` (no impact on other workloads). Per request, it's enabled now so it goes live automatically once the image is published.

## Test plan
- [x] `helm lint` passes; `helm template` renders `anticheat-alert-worker` in all 3 prod overlays and **not** in dev/staging.
- [x] Rendered spec: correct image, `envFrom: ragnarok-breaker-env`, replicas 1, resources 100m/256Mi–500m/512Mi.
- [x] `bash -n` on the bump scripts; bulk all-bump key sets verified (6 required + 2 optional); per-service `anticheat-alert-worker` bump scoped to the 3 prod files.
- [ ] After JiwonRB ships the image + secret, pod pulls and posts to Slack on a violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)