### PR TITLE
chore(ragnarok-breaker): bump dev + staging + production image to git-017ec5c

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 v8Gateway:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 logStream:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 # web2: ygg workloads are disabled, but their image.tag is still
 # pinned so `bump-image rb <hash>` (bulk) stays uniform across env×tier and
@@ -21,13 +21,13 @@ logStream:
 yggRedeem:
   enabled: false
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 # bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 v8Gateway:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 logStream:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 # dev: ygg workloads run in staging only and bq-analytics runs in production
 # only; all disabled here, but image.tag stays pinned so `bump-image rb <hash>`
@@ -21,12 +21,12 @@ logStream:
 yggRedeem:
   enabled: false
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48

--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -5,28 +5,28 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 v8Gateway:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 logStream:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 # web2: ygg workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 # bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 v8Gateway:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 logStream:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 yggRedeem:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
   httpRoute:
     enabled: true
     hostnames:
@@ -25,10 +25,10 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 # bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 v8Gateway:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 yggRedeem:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
   httpRoute:
     enabled: true
     hostnames:
@@ -21,14 +21,14 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 yggQuestWorker:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 # bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48

--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,27 +5,27 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 v8Gateway:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 logStream:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 # web2: ygg workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 bqAnalyticsWorker:
   enabled: true
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 v8Gateway:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 logStream:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 yggRedeem:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
   deployment:
     replicas: 2
   httpRoute:
@@ -27,12 +27,12 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
   replicas: 2
 
 bqAnalyticsWorker:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 # Single shared ingest gateway for all payment envs (no app_env split) —
 # the only namespace that hosts it. The bulk `bump-image rb <hash>` keeps this
@@ -41,7 +41,7 @@ bqAnalyticsWorker:
 bqIngestGateway:
   enabled: true
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
   httpRoute:
     enabled: true
     hostnames:

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 v8Gateway:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 yggRedeem:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
   deployment:
     replicas: 2
   httpRoute:
@@ -23,13 +23,13 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
 
 yggQuestWorker:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
   replicas: 2
 
 bqAnalyticsWorker:
   image:
-    tag: git-fe553cdb29aaf4407494627485248980ba6b7db5
+    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48


### PR DESCRIPTION
Pin all ragnarok-breaker images to `git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48` for dev + staging + production.

## Test plan
- [ ] After sync, pods pull the pinned image successfully