### PR TITLE
chore(ragnarok-breaker): pin production worker image to git-e73218f

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-e73218f076a6ae3997e28941f98120dd7486f073
 
 v8Gateway:
   image:

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-e73218f076a6ae3997e28941f98120dd7486f073
 
 v8Gateway:
   image:

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-e73218f076a6ae3997e28941f98120dd7486f073
 
 v8Gateway:
   image:


### PR DESCRIPTION
## 요약
prod 워커 이미지를 최신 develop 빌드로 갱신.

- `worker.image.tag`: `git-017ec5c8` (v0.0.21 릴리즈) → `git-e73218f076a6ae3997e28941f98120dd7486f073` (develop tip)
- 대상: `ragnarok-breaker-production`, `ragnarok-breaker-prod-web2`, `ragnarok-breaker-prod-web3` 의 `worker` 블록만 (다른 서비스 태그는 v0.0.21 유지)

## 컨텍스트
- e73218f0 = `petpop/ragnarok-breaker` develop tip (Merge `fix/cleartime-spawn-floor`, 2026-06-11 03:17 UTC)
- v0.0.21(017ec5c8) develop 콘텐츠를 모두 포함 + 신규 11개 커밋(anti-cheat: clearTime 스폰완료 floor, score multipliers, P6/P7 검증 등). 즉 forward 이동
- 직전 #3465 와 동일 패턴 — 워커를 릴리즈 태그보다 앞선 develop 커밋에 고정해 anti-cheat 픽스를 prod 워커에 선반영

## 검증
- 이미지 빌드 확인: develop pipeline 50352 `build:worker` **success** (2026-06-11 03:20:36 UTC) → `planetariumhq/ragnarok-breaker-worker:git-e73218f0…` 푸시 완료