### PR TITLE
chore(ragnarok-breaker): pin production worker image to git-2891069

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-e73218f076a6ae3997e28941f98120dd7486f073
+    tag: git-28910694e5950d3b262c54519e9cccf229e2963f
 
 v8Gateway:
   image:

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-e73218f076a6ae3997e28941f98120dd7486f073
+    tag: git-28910694e5950d3b262c54519e9cccf229e2963f
 
 v8Gateway:
   image:

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-e73218f076a6ae3997e28941f98120dd7486f073
+    tag: git-28910694e5950d3b262c54519e9cccf229e2963f
 
 v8Gateway:
   image:


### PR DESCRIPTION
## 변경
prod 안티치트 검증 워커(`ragnarok-breaker-worker`, stageValidation/leagueValidation) 이미지 태그를 RB develop HEAD 로 교체.

- `git-e73218f0…` → `git-28910694e5950d3b262c54519e9cccf229e2963f`
- 대상: `ragnarok-breaker-production`, `prod-web2`, `prod-web3` (worker 블록만; v8-gateway 등 다른 이미지는 미변경)

## 배경
RB MR !815 (IMPOSSIBLY_FAST_SUBMISSION 0점 사망 제출 면제) develop 머지본. 발할라 웨이브1 즉사(0점·0킬)를 워커 후검증이 `IMPOSSIBLY_FAST_SUBMISSION`(CRITICAL)으로 오탐 → prod silent ban 유발하던 문제를 수정. server-stamped 필드(score/phase/bustWave/finalScore)만 사용한 보수적 면제라 치팅 우회 구멍 없음(독립 코드리뷰 통과).

- develop HEAD: `28910694e5950d3b262c54519e9cccf229e2963f`
- 이미지 빌드: petpop develop 파이프라인 `build:worker` (pipeline 50401) **success**

🤖 Generated with [Claude Code](https://claude.com/claude-code)