### PR TITLE
chore(ragnarok-breaker): bump production worker image to git-f54b102

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-28910694e5950d3b262c54519e9cccf229e2963f
+    tag: git-f54b1028d985f1e935629f291de74a2572f6efba
 
 v8Gateway:
   image:

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-28910694e5950d3b262c54519e9cccf229e2963f
+    tag: git-f54b1028d985f1e935629f291de74a2572f6efba
 
 v8Gateway:
   image:

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-28910694e5950d3b262c54519e9cccf229e2963f
+    tag: git-f54b1028d985f1e935629f291de74a2572f6efba
 
 v8Gateway:
   image:


### PR DESCRIPTION
## 변경
prod 안티치트 검증 워커(`ragnarok-breaker-worker`, stageValidation/leagueValidation) 이미지를 RB develop HEAD 로 교체.

- `git-28910694…` (#3474) → `git-f54b1028d985f1e935629f291de74a2572f6efba`
- 대상: `ragnarok-breaker-production`, `prod-web2`, `prod-web3` (worker 블록만)

## 배경
develop HEAD = RB MR **!816**(틀린 불변식 `HP_PHASE_MISMATCH` / `HP_SURVIVAL_REVIVE_CONFLICT` 발화 중단) + **!815**(IMPOSSIBLY_FAST 0점 사망 면제) 포함.
- !816: 발할라 정상 종료(타임아웃/클리어실패로 HP 남은 채 gameOver) 12.3% 를 오탐하던 `HP_PHASE_MISMATCH` emission 을 워커에서 제거 → #3474(git-28910694)에 남아있던 HP 오탐 알림이 이 범프로 사라짐.
- 이미지 빌드: petpop develop 파이프라인 `build:worker` (pipeline 50403) **success**.

## ⚠️ 머지 전 확인 (워커·서버 커플링)
이 워커(develop)는 score-forensics 검사 `SCORE_RECOMPUTE_DELTA` / `SCORE_RECONSTRUCTION_MISMATCH` 를 탐지해 V8 서버로 보냅니다. 이 코드들의 **advisory 분류(flag-only, 무알림/무밴)는 develop 에만 있고 petpop `main`(= prod V8 서버 릴리스)에는 아직 없습니다.** 따라서 prod V8 서버가 advisory 라우팅을 받기 전에 이 워커가 떠 있으면, 위 score-forensics 코드가 ban 대상으로 처리되어 알림/카운트(autoban 시 밴)가 발생할 수 있습니다.
→ **prod V8 서버에 advisory 라우팅(petpop 커밋 704e816ec)을 같이/먼저 배포**한 뒤 머지 권장. 또는 prod autoban off 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)