### PR TITLE
chore(ragnarok-breaker): pin production worker image to git-3a44eb2

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-f54b1028d985f1e935629f291de74a2572f6efba
+    tag: git-3a44eb22b8d75f6db7e6561c759ad7c63fc51267
 
 v8Gateway:
   image:

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-f54b1028d985f1e935629f291de74a2572f6efba
+    tag: git-3a44eb22b8d75f6db7e6561c759ad7c63fc51267
 
 v8Gateway:
   image:

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-f54b1028d985f1e935629f291de74a2572f6efba
+    tag: git-3a44eb22b8d75f6db7e6561c759ad7c63fc51267
 
 v8Gateway:
   image:


### PR DESCRIPTION
Pin `ragnarok-breaker-worker` to `git-3a44eb22b8d75f6db7e6561c759ad7c63fc51267` for production (production + prod-web2 + prod-web3).

최신 develop(`3a44eb22b`) 워커 이미지로 prod 갱신. 이 빌드 포함 변경:
- **SPAWN_BOTTLENECK_FAIL 오탐 수정** — staggered 스폰 상한이 t=0 첫 스폰을 누락(`floor`)해 LEAGUE 정상 클리어(enemy8 265=물리상한)가 744 vs 743 으로 헛플래그되던 문제를 `1+floor` 보정 + 동기 autoban 과 동일 margin(×1.25) 적용으로 해결 (petpop ragnarok-breaker !826).

worker 이미지만 bump (develop 3a44eb22b 파이프라인에서 `build:worker` 만 재빌드됨 — 다른 이미지는 해당 SHA 태그 없음).

## Test plan
- [ ] After sync, pods pull the pinned image successfully