### PR TITLE
chore(heimdall): decommission rpc-2 (remote-headless-2) + realign validator config

### DIFF
--- a/9c-main/network/heimdall.yaml
+++ b/9c-main/network/heimdall.yaml
@@ -24,8 +24,6 @@ global:
     data: 500Gi
   - name: remote-headless-data-2-remote-headless-2-0
     data: 500Gi
-  - name: remote-headless-data-3-remote-headless-3-0
-    data: 500Gi
   - name: data-provider-data-1
     data: 200Gi
 
@@ -33,7 +31,6 @@ RKE2:
   loadBalancerIPs:
   - 115.68.194.150/32
   - 115.68.194.151/32
-  - 115.68.194.214/32
   - 115.68.193.219/32
 
 externalSecret:
@@ -49,7 +46,6 @@ gateway:
     - heimdall-rpc.nine-chronicles.com
     backendRefs:
     - name: remote-headless-1
-    - name: remote-headless-2
     protocols:
     - web
     - grpc
@@ -149,7 +145,7 @@ validator:
   - "heimdall-node-validator-1.nine-chronicles.com"
 
   loadBalancerIPs:
-  - "115.68.194.214"
+  - "115.68.194.151"
 
   resources:
     limits:
@@ -157,7 +153,7 @@ validator:
 
   nodeSelector:
     node.kubernetes.io/network: heimdall
-    node.kubernetes.io/node-index: '3'
+    node.kubernetes.io/node-index: '2'
 
   storePath: "/data/headless"
 
@@ -172,7 +168,7 @@ validator:
     value: validator-test
 
 remoteHeadless:
-  count: 2
+  count: 1
   replicas: 1
 
   scheduledRestart:
@@ -183,17 +179,13 @@ remoteHeadless:
 
   hosts:
   - "heimdall-node-1.nine-chronicles.com"
-  - "heimdall-node-2.nine-chronicles.com"
 
   loadBalancerIPs:
   - 115.68.194.150
-  - 115.68.194.151
 
   nodeSelector:
   - node.kubernetes.io/network: heimdall
     node.kubernetes.io/node-index: '1'
-  - node.kubernetes.io/network: heimdall
-    node.kubernetes.io/node-index: '2'
 
   env:
   - name: Headless__AccessControlService__AccessControlServiceType
@@ -225,7 +217,6 @@ remoteHeadless:
   storage:
     volumeNames:
     - remote-headless-data-1-remote-headless-1-0
-    - remote-headless-data-3-remote-headless-3-0
 
   tolerations:
   - effect: NoSchedule

--- a/9c-main/values.yaml
+++ b/9c-main/values.yaml
@@ -96,7 +96,6 @@ prometheus:
               group: heimdall-rpc
             targets:
               - remote-headless-1.heimdall.svc.cluster.local:80
-              - remote-headless-2.heimdall.svc.cluster.local:80
           - labels:
               group: heimdall-validator
             targets:


### PR DESCRIPTION
## 배경

`9c-main-heimdall-3` 노드를 클러스터에서 제외(decommission)하기 위한 **GitOps 정리 PR**입니다. 이 노드엔 rpc-2(`remote-headless-2`)가 떠 있었고, 이미 라이브에서 `remote-headless-2`를 `replicas=0`으로 내린 상태입니다. 노드를 지운 뒤 ArgoCD sync가 rpc-2를 되살리거나 stale validator config 때문에 메인넷 validator가 죽지 않도록 repo를 정리합니다.

> ⚠️ heimdall 앱은 **auto-sync 없음** → 이 PR 머지만으로 라이브는 안 바뀝니다. 노드/볼륨 실삭제는 별도 라이브 작업으로 진행합니다.

## 변경 내용 (`9c-main/network/heimdall.yaml`, `9c-main/values.yaml`)

**rpc-2 폐기**
- `remoteHeadless.count` 2 → 1, `hosts`/`loadBalancerIPs`/`nodeSelector`/`storage.volumeNames`에서 rpc-2 슬롯 제거 → `remote-headless-1`만 렌더
- top-level `storage`에서 `remote-headless-data-3-remote-headless-3-0` 제거
- `gateway` `heimdall-rpc` 서비스 `backendRefs`에서 `remote-headless-2` 제거
- `RKE2.loadBalancerIPs`에서 `115.68.194.214/32`(rpc-2 IP) 제거
- `values.yaml` prometheus `heimdall-rpc` 스크레이프 타겟에서 `remote-headless-2.heimdall...` 제거(target-down 알람 방지)

**validator config drift 정리** (config가 stale, 실제 `validator-5`는 heimdall-2/.151에서 동작 중)
- `validator.nodeSelector` `node-index: '3'` → `'2'`
- `validator.loadBalancerIPs` `115.68.194.214` → `115.68.194.151`

## 검증 (`helm template` old vs new diff)

- ✅ **rpc-1(`remote-headless-1`) 렌더 100% 동일** — 남는 RPC 노드 영향 없음
- ✅ rpc-2 StatefulSet/Service/PVC(data-3) 일괄 제거, 렌더에 `.214`/`data-3` 0건
- ✅ `validator-5`는 LB IP(.214→.151)·nodeSelector(3→2)만 변경, **data-2 볼륨 보존**
- ✅ gateway backendRef·재시작 cron 모두 `remote-headless-1`만 대상
- IP 재배치: `.151`이 rh-2(제거)→validator로, `.214` 제거, `.150`(rpc-1) 불변 — 라이브와 일치

## 머지 후 남은 라이브 작업 (이 PR 범위 아님)
1. loki replica(heimdall-3) 다른 노드로 eviction/rebuild
2. rpc-2 StatefulSet/PVC/PV/Longhorn 볼륨(data-3) 삭제
3. Longhorn 노드 CR 제거 → `kubectl delete node 9c-main-heimdall-3`
4. iwinv VM 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)
