### PR TITLE
feat(monitoring): add ragnarok-breaker prod alerting via Grafana→Slack

### DIFF
--- a/9c-main/values.yaml
+++ b/9c-main/values.yaml
@@ -115,6 +115,13 @@ prometheus:
         static_configs:
           - targets:
             - longhorn-backend.longhorn-system.svc.cluster.local:9500
+      - job_name: kube-state-metrics
+        metrics_path: /metrics
+        scrape_interval: 30s
+        scrape_timeout: 10s
+        static_configs:
+          - targets:
+            - prometheus-kube-state-metrics.monitoring.svc.cluster.local:8080
 datadog:
   enabled: false
   clusterAgent:

--- a/common/bootstrap-v2/templates/grafana.yaml
+++ b/common/bootstrap-v2/templates/grafana.yaml
@@ -20,6 +20,11 @@ spec:
     targetRevision: 10.1.2
     helm:
       values: |-
+        envValueFrom:
+          SLACK_WEBHOOK_URL:
+            secretKeyRef:
+              name: slack
+              key: slack-webhook-rb
         datasources:
           datasources.yaml:
             apiVersion: 1
@@ -32,6 +37,145 @@ spec:
               url: http://prometheus-server.monitoring.svc.cluster.local
               access: proxy
               isDefault: true
+        alerting:
+          contactpoints.yaml:
+            apiVersion: 1
+            contactPoints:
+              - orgId: 1
+                name: ragnarok-infra-alert-slack
+                receivers:
+                  - uid: ragnarok-infra-alert-slack
+                    type: slack
+                    settings:
+                      url: $SLACK_WEBHOOK_URL
+          policies.yaml:
+            apiVersion: 1
+            policies:
+              - orgId: 1
+                receiver: ragnarok-infra-alert-slack
+          rules.yaml:
+            apiVersion: 1
+            groups:
+              - orgId: 1
+                name: ragnarok-breaker-alerts
+                folder: Ragnarok Breaker
+                interval: 1m
+                rules:
+                  - uid: rb-workload-unavailable
+                    title: RB Workload Unavailable
+                    noDataState: OK
+                    condition: C
+                    data:
+                      - refId: A
+                        relativeTimeRange: { from: 300, to: 0 }
+                        datasourceUid: prometheus
+                        model:
+                          expr: 'kube_deployment_status_replicas_unavailable{namespace=~"ragnarok-breaker-prod-web[23]"}'
+                          instant: true
+                      - refId: C
+                        datasourceUid: __expr__
+                        model:
+                          type: threshold
+                          expression: A
+                          conditions:
+                            - evaluator: { type: gt, params: [0] }
+                    for: 5m
+                    labels:
+                      severity: critical
+                    annotations:
+                      summary: 'RB workload {{`{{ "{{" }} $labels.deployment {{ "}}" }}`}} has unavailable replicas (ns: {{`{{ "{{" }} $labels.namespace {{ "}}" }}`}})'
+                  - uid: rb-crashloopbackoff
+                    title: RB CrashLoopBackOff
+                    noDataState: OK
+                    condition: C
+                    data:
+                      - refId: A
+                        relativeTimeRange: { from: 300, to: 0 }
+                        datasourceUid: prometheus
+                        model:
+                          expr: 'kube_pod_container_status_waiting_reason{namespace=~"ragnarok-breaker-prod-web[23]",reason="CrashLoopBackOff"}'
+                          instant: true
+                      - refId: C
+                        datasourceUid: __expr__
+                        model:
+                          type: threshold
+                          expression: A
+                          conditions:
+                            - evaluator: { type: gt, params: [0] }
+                    for: 5m
+                    labels:
+                      severity: critical
+                    annotations:
+                      summary: 'RB pod {{`{{ "{{" }} $labels.pod {{ "}}" }}`}} CrashLoopBackOff (container: {{`{{ "{{" }} $labels.container {{ "}}" }}`}}, ns: {{`{{ "{{" }} $labels.namespace {{ "}}" }}`}})'
+                  - uid: rb-imagepullbackoff
+                    title: RB ImagePullBackOff
+                    noDataState: OK
+                    condition: C
+                    data:
+                      - refId: A
+                        relativeTimeRange: { from: 300, to: 0 }
+                        datasourceUid: prometheus
+                        model:
+                          expr: 'kube_pod_container_status_waiting_reason{namespace=~"ragnarok-breaker-prod-web[23]",reason=~"ImagePullBackOff|ErrImagePull"}'
+                          instant: true
+                      - refId: C
+                        datasourceUid: __expr__
+                        model:
+                          type: threshold
+                          expression: A
+                          conditions:
+                            - evaluator: { type: gt, params: [0] }
+                    for: 5m
+                    labels:
+                      severity: warning
+                    annotations:
+                      summary: 'RB pod {{`{{ "{{" }} $labels.pod {{ "}}" }}`}} ImagePullBackOff (container: {{`{{ "{{" }} $labels.container {{ "}}" }}`}}, ns: {{`{{ "{{" }} $labels.namespace {{ "}}" }}`}})'
+                  - uid: rb-restart-flapping
+                    title: RB Container Restart Flapping
+                    noDataState: OK
+                    condition: C
+                    data:
+                      - refId: A
+                        relativeTimeRange: { from: 900, to: 0 }
+                        datasourceUid: prometheus
+                        model:
+                          expr: 'increase(kube_pod_container_status_restarts_total{namespace=~"ragnarok-breaker-prod-web[23]"}[15m])'
+                          instant: true
+                      - refId: C
+                        datasourceUid: __expr__
+                        model:
+                          type: threshold
+                          expression: A
+                          conditions:
+                            - evaluator: { type: gt, params: [3] }
+                    for: 0m
+                    labels:
+                      severity: warning
+                    annotations:
+                      summary: 'RB pod {{`{{ "{{" }} $labels.pod {{ "}}" }}`}} restarting repeatedly (container: {{`{{ "{{" }} $labels.container {{ "}}" }}`}}, ns: {{`{{ "{{" }} $labels.namespace {{ "}}" }}`}})'
+                  - uid: rb-v8-gateway-replicas
+                    title: RB v8-gateway Replicas Not 1
+                    noDataState: OK
+                    condition: C
+                    data:
+                      - refId: A
+                        relativeTimeRange: { from: 300, to: 0 }
+                        datasourceUid: prometheus
+                        model:
+                          expr: 'kube_deployment_spec_replicas{namespace=~"ragnarok-breaker-prod-web[23]",deployment="v8-gateway"}'
+                          instant: true
+                      - refId: C
+                        datasourceUid: __expr__
+                        model:
+                          type: threshold
+                          expression: A
+                          conditions:
+                            - evaluator: { type: gt, params: [1] }
+                    for: 1m
+                    labels:
+                      severity: critical
+                    annotations:
+                      summary: 'v8-gateway replicas > 1 in {{`{{ "{{" }} $labels.namespace {{ "}}" }}`}} — V8 4009 kick risk, must stay 1'
         persistence:
           enabled: true
         initChownData:


### PR DESCRIPTION
## 배경
prod 9c-main은 Alertmanager 비활성 + Prometheus가 kube-state-metrics 미스크랩이라 ragnarok-breaker prod 워크로드 다운을 자동 감지하는 알람이 없었음. 이미 떠 있는 KSM을 스크랩에 연결하고, 제거됐던(commit b1b981ef) Grafana 관리형 알림 패턴을 부활시켜 Slack `#9c-ragnarok-infra-alert`로 라우팅한다.

## 변경
- `9c-main/values.yaml`: `prometheus.server.extraScrapeConfigs`에 `kube-state-metrics` 잡 추가 → `kube_*` 메트릭 활성화 (rb뿐 아니라 클러스터 pod 알람 토대)
- `common/bootstrap-v2/templates/grafana.yaml`: `envValueFrom(SLACK_WEBHOOK_URL ← slack/slack-webhook-rb)` + alerting provisioning(contactPoint `ragnarok-infra-alert-slack`, policy, 룰 5종)

## 알람 룰 (대상 ns `ragnarok-breaker-prod-web[23]`)
| severity | 룰 | for | 임계 |
|---|---|---|---|
| 🔴 critical | Workload Unavailable | 5m | unavailable > 0 |
| 🔴 critical | CrashLoopBackOff | 5m | > 0 |
| 🟡 warning | ImagePullBackOff/ErrImagePull | 5m | > 0 |
| 🟡 warning | Restart Flapping | - | increase[15m] > 3 |
| 🔴 critical | v8-gateway Replicas Not 1 | 1m | > 1 (4009 kick 가드) |

## 검증 (9c-internal 격리 샌드박스 e2e)
임시 prometheus+grafana(12.2.0)+더미 워크로드로 PR과 동일한 스크랩 잡·룰 로직(ns만 치환) 사용해 처음부터 끝까지 확인:
- KSM 스크랩 → `kube_*` 수집, PromQL 5종 실데이터 매칭
- 룰 발화 + annotation 라벨 치환(`{{ $labels.x }}` tpl 이중 이스케이프) 정상
- 🔴 발화 → `#9c-ragnarok-infra-alert` 전달 확정 (`The incoming webhook was successful` / `Notify success`)
- 🟢 복구(resolved) → `#9c-ragnarok-infra-alert` 전달 확정

## 배포 주의 (머지 후)
- **auto-sync 아님** — `bootstrap` 앱 **수동 sync** 필요 (그래야 prometheus/grafana Application spec 갱신 → 두 앱이 auto-sync로 실반영)
- 시크릿 의존: `slack-webhook-rb` 키가 AWS `9c-main-v2/slack` **ap-northeast-2**(monitoring SecretStore가 읽는 리전)에 존재해야 함 → 반영 완료
- grafana pod 재기동 시 ~60s간 기본 email contactpoint로 갔다가 정책 로드 후 slack으로 전환되는 startup 아티팩트 있음 (무해)

🤖 Generated with [Claude Code](https://claude.com/claude-code)