### PR TITLE
chore(ragnarok-breaker): bump production worker image to git-0a9b098

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-3a44eb22b8d75f6db7e6561c759ad7c63fc51267
+    tag: git-0a9b09831e771faebd51453de0dd3f2680155e5b
 
 v8Gateway:
   image:

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-3a44eb22b8d75f6db7e6561c759ad7c63fc51267
+    tag: git-0a9b09831e771faebd51453de0dd3f2680155e5b
 
 v8Gateway:
   image:


### PR DESCRIPTION
## What
Bump the **ragnarok-breaker worker** image for **prod web2 + web3** from `git-3a44eb22b` (2026-06-12) to `git-0a9b0983` (current petpop `develop` HEAD).

Worker-only bump — v8-gateway / log-stream / ygg / bq / anticheat-alert images are unchanged.

## Why
The deployed worker (`git-3a44eb22b`, 06-12) predates two anti-cheat fixes already on `develop`+`main`, causing **false positives** in `#9c-ragnarok-alert`:

- `ac9879526` (06-14) — fix DPS reconstruction collapsing to ~0 DPS on `SHOTS > MANA` builds. Legit players were flagged `DPS_IMPOSSIBLE_CLEAR` / `DPS_CLEAR_TIME_INFEASIBLE` with `predictedDPS≈15`.
- `ccf17a73b` (06-14) — clamp `clearSpeedRatio` to `[0,1]`.

Replaying an actual flagged prod record against `git-0a9b0983` restores a healthy `predictedDPS` and a `valid` verdict.

## Safety
- DPS calc is worker-side only (no server counterpart) → no server/worker skew from the DPS changes.
- Shared score core (`packages/shared/src/server-score-inputs.ts`) is **identical** between `0a9b0983` and the live prod tag `v0.0.25` → no new `SCORE_RECONSTRUCTION_MISMATCH`. The only `score.ts` diff is a defense-in-depth clamp with **zero effect on normal plays** (clearTimeMs ∈ [0, timeLimit] already maps to [0,1]).

## Pre-merge check
Please confirm petpop CI built & pushed `planetariumhq/ragnarok-breaker-worker:git-0a9b09831e771faebd51453de0dd3f2680155e5b` (I couldn't verify — private registry + CI token scope). It should exist since petpop builds the worker on every `develop` (default-branch) commit.

> Note: the separate LEAGUE `SCORE_RECONSTRUCTION_MISMATCH` FPs are fixed by the `CDN_ENV=prod` secret change (handled out-of-band), not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)