### PR TITLE
chore(ragnarok-breaker): roll back prod worker to git-3a44eb22b

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-0a9b09831e771faebd51453de0dd3f2680155e5b
+    tag: git-3a44eb22b8d75f6db7e6561c759ad7c63fc51267
 
 v8Gateway:
   image:

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-0a9b09831e771faebd51453de0dd3f2680155e5b
+    tag: git-3a44eb22b8d75f6db7e6561c759ad7c63fc51267
 
 v8Gateway:
   image:


### PR DESCRIPTION
## Urgent rollback — reverts #3481

#3481 pinned prod web2/web3 worker to `git-0a9b0983`, but **that image was never built**: petpop CI only runs `build:worker` on develop commits that touch `services/worker/**` or `packages/shared/**`, and the `0a9b0983` (master-data-seed chore) merge touched neither → no image → **ImagePullBackOff** on prod.

This restores the previously-running, known-good image **`git-3a44eb22b`** to recover prod.

## Next
A fresh worker image carrying the DPS fix (`ac9879526`, SHOTS>MANA) is being built out-of-band. Once its `build:worker` job **succeeds**, re-pin prod to that tag.
(Note: `0266888de` is the latest develop commit whose `build:worker` already succeeded and which contains the fix — a valid alternative if the new build isn't ready.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)