### PR TITLE
chore(ragnarok-breaker): bump prod worker to git-46ffaee32 (DPS FP fix)

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-3a44eb22b8d75f6db7e6561c759ad7c63fc51267
+    tag: git-46ffaee326dce0fe68dfba7cf19005d04d5f56e2
 
 v8Gateway:
   image:

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-3a44eb22b8d75f6db7e6561c759ad7c63fc51267
+    tag: git-46ffaee326dce0fe68dfba7cf19005d04d5f56e2
 
 v8Gateway:
   image:


### PR DESCRIPTION
## What
Re-pin prod web2/web3 worker to **`git-46ffaee32`**. Forward from the rollback (#3482).

## Verified
petpop CI `build:worker` for `46ffaee32` **succeeded** (job 315228, finished 2026-06-18 05:24 UTC) → image is pushed. (The earlier `git-0a9b0983` pin had no image — that build was never run — which caused the ImagePullBackOff we rolled back from.)

## Why
`git-46ffaee32` (develop, 2026-06-18 02:31) carries the anti-cheat fixes missing from the deployed `git-3a44eb22b` (06-12):
- `ac9879526` (06-14) — SHOTS>MANA DPS reconstruction fix → stops `DPS_IMPOSSIBLE_CLEAR` / `DPS_CLEAR_TIME_INFEASIBLE` false positives (`predictedDPS≈15-16` on legit upgraded loadouts)
- clearSpeedRatio `[0,1]` clamp (`fix/score-cleartime-negative-clamp`)
- clientItems DPS / W3 / HP fixes

## Safety
Worker-only bump. `packages/shared/src/server-score-inputs.ts` is byte-identical to live prod tag `v0.0.25`; the `score.ts` clearSpeedRatio clamp has **zero effect on normal plays** (clearTimeMs ∈ [0, timeLimit] already maps to [0,1]) → no new `SCORE_RECONSTRUCTION_MISMATCH`.

After merge I'll trigger the ArgoCD sync (these apps are manual-sync).