### PR TITLE
feat(ragnarok-breaker): anti-cheat alert Verse/Stage 표시 + image bump (git-e3545d1e)

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-46ffaee326dce0fe68dfba7cf19005d04d5f56e2
+    tag: git-e3545d1e3869858b336d85cdd20695d7a22cd828
 
 v8Gateway:
   image:
@@ -35,4 +35,4 @@ bqAnalyticsWorker:
 anticheatAlertWorker:
   enabled: true
   image:
-    tag: git-eba7fb42eaed54bed0513debd68f1db2a0ec639d
+    tag: git-e3545d1e3869858b336d85cdd20695d7a22cd828

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-46ffaee326dce0fe68dfba7cf19005d04d5f56e2
+    tag: git-e3545d1e3869858b336d85cdd20695d7a22cd828
 
 v8Gateway:
   image:
@@ -39,7 +39,7 @@ bqAnalyticsWorker:
 anticheatAlertWorker:
   enabled: true
   image:
-    tag: git-eba7fb42eaed54bed0513debd68f1db2a0ec639d
+    tag: git-e3545d1e3869858b336d85cdd20695d7a22cd828
 
 # Single shared ingest gateway for all payment envs (no app_env split) —
 # the only namespace that hosts it. The bulk `bump-image rb <hash>` keeps this

--- a/charts/ragnarok-breaker/templates/anticheat-alert-worker-deployment.yaml
+++ b/charts/ragnarok-breaker/templates/anticheat-alert-worker-deployment.yaml
@@ -28,6 +28,13 @@ spec:
         - name: anticheat-alert-worker
           image: "{{ .Values.anticheatAlertWorker.image.repository }}:{{ .Values.anticheatAlertWorker.image.tag }}"
           imagePullPolicy: {{ .Values.anticheatAlertWorker.image.pullPolicy }}
+          env:
+            # Slack alert 의 *Verse:* 라벨 소스 (예: ragnarok-breaker-prod-web2
+            # -> prod-web2). worker 가 prefix 를 떼고 표시한다.
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           envFrom:
             - secretRef:
                 name: ragnarok-breaker-env


### PR DESCRIPTION
## What
Anti-cheat Slack alerts (#9c-ragnarok-alert) now show **Verse** (`prod-web2`/`prod-web3`) and a **mode-specific id** (`*Stage:*` / `*Season:*` / `*Valhalla:*` / `*Degen Season:*`).

- **anticheat-alert-worker deployment**: inject `POD_NAMESPACE` via k8s Downward API (`metadata.namespace`). The worker strips the `ragnarok-breaker-` prefix → `*Verse:* prod-web2`. Template-level, applies to all envs (verse label appears wherever the alert-worker runs).
- **prod web2/web3**: bump `worker` + `anticheatAlertWorker` images to **`git-e3545d1e`** (petpop develop).

## Verified
petpop CI for `e3545d1e`: `build:worker` ✅ and `build:anticheat-alert-worker` ✅ (both SUCCESS — images pushed). App code (MR petpop!992) shipped with worker tests (modeRefId 5) + alert-worker tests (verse/mode-label 2), typecheck + biome clean, code-reviewed.

`git-e3545d1e` also carries the earlier worker fixes already running in prod (DPS SHOTS>MANA `ac9879526`, score core identical to prod tag `v0.0.25`), so this is additive — no behavior regression. CDN_ENV=prod (LEAGUE fix) is env/secret-based and unaffected.

## After merge
ArgoCD sync (manual-sync apps) recreates the worker + anticheat-alert-worker pods → picks up the new images + `POD_NAMESPACE`. I'll trigger the refresh+sync and verify the next alert shows Verse + Stage/Season.