### PR TITLE
chore(ragnarok-breaker): bump dev + staging + production image to git-35a74b3

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 v8Gateway:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 logStream:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 # web2: ygg workloads are disabled, but their image.tag is still
 # pinned so `bump-image rb <hash>` (bulk) stays uniform across env×tier and
@@ -21,13 +21,13 @@ logStream:
 yggRedeem:
   enabled: false
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 # bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 v8Gateway:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 logStream:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 # dev: ygg workloads run in staging only and bq-analytics runs in production
 # only; all disabled here, but image.tag stays pinned so `bump-image rb <hash>`
@@ -21,12 +21,12 @@ logStream:
 yggRedeem:
   enabled: false
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b

--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -5,28 +5,28 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 v8Gateway:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 logStream:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 # web2: ygg workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 # bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 v8Gateway:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 logStream:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 yggRedeem:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
   httpRoute:
     enabled: true
     hostnames:
@@ -25,10 +25,10 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 # bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 v8Gateway:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 yggRedeem:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
   httpRoute:
     enabled: true
     hostnames:
@@ -21,14 +21,14 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 yggQuestWorker:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 # bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b

--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,34 +5,34 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-e3545d1e3869858b336d85cdd20695d7a22cd828
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 v8Gateway:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 logStream:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 # web2: ygg workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 bqAnalyticsWorker:
   enabled: true
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 # Anti-cheat → Slack alert worker (prod only). SLACK_VIOLATION_WEBHOOK_URL is
 # read from the ragnarok-breaker-env SecretsManager entry for this namespace.
 anticheatAlertWorker:
   enabled: true
   image:
-    tag: git-e3545d1e3869858b336d85cdd20695d7a22cd828
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-e3545d1e3869858b336d85cdd20695d7a22cd828
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 v8Gateway:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 logStream:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 yggRedeem:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
   deployment:
     replicas: 2
   httpRoute:
@@ -27,19 +27,19 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
   replicas: 2
 
 bqAnalyticsWorker:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 # Anti-cheat → Slack alert worker (prod only). SLACK_VIOLATION_WEBHOOK_URL is
 # read from the ragnarok-breaker-env SecretsManager entry for this namespace.
 anticheatAlertWorker:
   enabled: true
   image:
-    tag: git-e3545d1e3869858b336d85cdd20695d7a22cd828
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 # Single shared ingest gateway for all payment envs (no app_env split) —
 # the only namespace that hosts it. The bulk `bump-image rb <hash>` keeps this
@@ -48,7 +48,7 @@ anticheatAlertWorker:
 bqIngestGateway:
   enabled: true
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
   httpRoute:
     enabled: true
     hostnames:

--- a/9c-main/ragnarok-breaker-production/values.yaml
+++ b/9c-main/ragnarok-breaker-production/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-3a44eb22b8d75f6db7e6561c759ad7c63fc51267
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 v8Gateway:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 yggRedeem:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
   deployment:
     replicas: 2
   httpRoute:
@@ -23,20 +23,20 @@ yggRedeem:
 
 logStream:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 yggQuestWorker:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
   replicas: 2
 
 bqAnalyticsWorker:
   image:
-    tag: git-017ec5c884d9033fea6985b5b73fa9a5ad0bee48
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
 # Anti-cheat → Slack alert worker (prod only). SLACK_VIOLATION_WEBHOOK_URL is
 # read from the ragnarok-breaker-env SecretsManager entry for this namespace.
 anticheatAlertWorker:
   enabled: true
   image:
-    tag: git-eba7fb42eaed54bed0513debd68f1db2a0ec639d
+    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b


### PR DESCRIPTION
Pin all ragnarok-breaker images to `git-35a74b3660456b21eb29b1342bc3d835070b815b` for dev + staging + production.

## Test plan
- [ ] After sync, pods pull the pinned image successfully