### PR TITLE
fix(snapshot): fail loudly on R2 upload failure + notify Slack on success

### DIFF
--- a/charts/all-in-one/scripts/snapshots/full/upload_snapshot.sh
+++ b/charts/all-in-one/scripts/snapshots/full/upload_snapshot.sh
@@ -67,6 +67,18 @@ function retry_until_success() {
   echo "[INFO] Command succeeded after $count attempt(s)."
 }
 
+# Wait on every background PID passed as args and return non-zero if ANY failed.
+# A bare `wait` (no args) always returns 0, so it silently swallowed background
+# upload failures (e.g. an R2 403): the Job would exit 0 and report success
+# while the public latest.json stayed stale. Collect PIDs and fail loudly.
+function wait_all() {
+  local pid rc=0
+  for pid in "$@"; do
+    if ! wait "$pid"; then rc=1; fi
+  done
+  return "$rc"
+}
+
 function make_and_upload_snapshot() {
   echo "[INFO] Starting make_and_upload_snapshot..."
   SNAPSHOT="$HOME/NineChronicles.Snapshot"
@@ -109,6 +121,7 @@ function make_and_upload_snapshot() {
   FINAL_NAME="9c-main-snapshot.zip"
   FINAL_DEST="$DEST_PATH/$FINAL_NAME"
 
+  upload_pids=()
   split -b 4GB "$LATEST_FULL_SNAPSHOT" "$FINAL_NAME.part" --numeric-suffixes=1 -a $PART_LENGTH
   for part in "$FINAL_NAME.part"*; do
     retry_until_success rclone copyto "$part" "$DEST_PATH/$part" \
@@ -119,6 +132,7 @@ function make_and_upload_snapshot() {
       --retries 5 \
       --low-level-retries 10 \
       --no-traverse && rm "$part" &
+    upload_pids+=($!)
   done
 
   echo "[INFO] Copying archive snapshot to $FINAL_DEST without re-upload..."
@@ -128,16 +142,21 @@ function make_and_upload_snapshot() {
     --retries 5 \
     --s3-copy-cutoff 1G \
     --low-level-retries 10 &
+  upload_pids+=($!)
 
   LATEST_METADATA=$(ls -t "$METADATA_DIR"/*.json 2>/dev/null | head -1 || true)
   if [ -n "$LATEST_METADATA" ]; then
     echo "[INFO] Uploading metadata $LATEST_METADATA..."
     rclone copyto "$LATEST_METADATA" "$DEST_PATH/latest.json" --no-traverse --retries 5 --low-level-retries 10 &
+    upload_pids+=($!)
   else
     echo "[INFO] No metadata file found to upload."
   fi
 
-  wait
+  if ! wait_all "${upload_pids[@]}"; then
+    senderr "Failed to upload full snapshot to R2 ($DEST_PATH)."
+    exit 1
+  fi
 
   echo "[INFO] Snapshot upload complete."
   rm "$LATEST_FULL_SNAPSHOT"

--- a/charts/all-in-one/scripts/snapshots/full/upload_snapshot.sh
+++ b/charts/all-in-one/scripts/snapshots/full/upload_snapshot.sh
@@ -29,6 +29,15 @@ function senderr() {
        "$SLACK_WEBHOOK"
 }
 
+# Success/info notification. Non-fatal (|| true): a failed Slack post must not
+# fail an otherwise-successful snapshot upload.
+function sendinfo() {
+  echo "$1"
+  curl -X POST -H 'Content-type: application/json' \
+       --data '{"text":"[K8S] '"$1"'"}' \
+       "$SLACK_WEBHOOK" || true
+}
+
 function setup_rclone() {
   RCLONE_CONFIG_DIR="/root/.config/rclone"
   mkdir -p "$RCLONE_CONFIG_DIR"
@@ -158,6 +167,7 @@ function make_and_upload_snapshot() {
     exit 1
   fi
 
+  sendinfo "Full snapshot uploaded OK: $SNAPSHOT_PATH/full ($BASENAME); latest.json updated."
   echo "[INFO] Snapshot upload complete."
   rm "$LATEST_FULL_SNAPSHOT"
   rm -rf "$METADATA_DIR"

--- a/charts/all-in-one/scripts/snapshots/partition/upload_snapshot.sh
+++ b/charts/all-in-one/scripts/snapshots/partition/upload_snapshot.sh
@@ -74,6 +74,18 @@ function retry_until_success() {
   echo "[INFO] Command succeeded after $count attempt(s)."
 }
 
+# Wait on every background PID passed as args and return non-zero if ANY failed.
+# A bare `wait` (no args) always returns 0, so it silently swallowed background
+# upload failures (e.g. an R2 403): the Job would exit 0 and report success
+# while the public latest.json stayed weeks stale. Collect PIDs and fail loudly.
+function wait_all() {
+  local pid rc=0
+  for pid in "$@"; do
+    if ! wait "$pid"; then rc=1; fi
+  done
+  return "$rc"
+}
+
 function make_and_upload_snapshot() {
   echo "[DEBUG] Args: $1"
   OUTPUT_DIR="${1:-/data/snapshots}"
@@ -118,32 +130,40 @@ function make_and_upload_snapshot() {
     --low-level-retries 10
 
   echo "[INFO] Copying snapshot to latest path: $DEST_PATH/$SNAPSHOT_FILENAME"
+  snapshot_pids=()
   retry_until_success rclone copyto "$ARCHIVED_SNAPSHOT_PATH" "$DEST_PATH/$SNAPSHOT_FILENAME" \
     --no-traverse \
     --s3-disable-checksum \
     --s3-copy-cutoff 1G \
     --retries 5 \
     --low-level-retries 10 &
+  snapshot_pids+=($!)
   retry_until_success rclone copyto "$ARCHIVED_SNAPSHOT_PATH" "$DEST_PATH/$SNAPSHOT_LATEST_FILENAME" \
     --no-traverse \
     --s3-disable-checksum \
     --s3-copy-cutoff 1G \
     --retries 5 \
     --low-level-retries 10 &
+  snapshot_pids+=($!)
   retry_until_success rclone copyto "$ARCHIVED_SNAPSHOT_PATH" "$DEST_PATH/internal/$SNAPSHOT_FILENAME" \
     --no-traverse \
     --s3-disable-checksum \
     --s3-copy-cutoff 1G \
     --retries 5 \
     --low-level-retries 10 &
+  snapshot_pids+=($!)
   retry_until_success rclone copyto "$ARCHIVED_SNAPSHOT_PATH" "$DEST_PATH/internal/$SNAPSHOT_LATEST_FILENAME" \
     --no-traverse \
     --s3-disable-checksum \
     --s3-copy-cutoff 1G \
     --retries 5 \
     --low-level-retries 10 &
+  snapshot_pids+=($!)
 
-  wait
+  if ! wait_all "${snapshot_pids[@]}"; then
+    senderr "Failed to upload partition snapshot to R2 ($DEST_PATH)."
+    exit 1
+  fi
 
   if [ -n "$LATEST_METADATA" ]; then
     ARCHIVED_METADATA_PATH="$ARCHIVE_PATH/metadata/${NOW}_$METADATA_FILENAME"
@@ -151,13 +171,22 @@ function make_and_upload_snapshot() {
     rclone copyto "$LATEST_METADATA" "$ARCHIVED_METADATA_PATH" --no-traverse --retries 5 --low-level-retries 10
 
     echo "[INFO] Copying metadata to latest path: $DEST_PATH/$METADATA_FILENAME"
+    metadata_pids=()
     rclone copyto "$ARCHIVED_METADATA_PATH" "$DEST_PATH/$METADATA_FILENAME" --no-traverse --retries 5 --low-level-retries 10 &
+    metadata_pids+=($!)
     rclone copyto "$ARCHIVED_METADATA_PATH" "$DEST_PATH/latest.json" --no-traverse --retries 5 --low-level-retries 10 &
+    metadata_pids+=($!)
     rclone copyto "$ARCHIVED_METADATA_PATH" "$DEST_PATH/internal/$METADATA_FILENAME" --no-traverse --retries 5 --low-level-retries 10 &
+    metadata_pids+=($!)
     rclone copyto "$ARCHIVED_METADATA_PATH" "$DEST_PATH/internal/latest.json" --no-traverse --retries 5 --low-level-retries 10 &
+    metadata_pids+=($!)
     rclone copyto "$ARCHIVED_METADATA_PATH" "$DEST_PATH/internal/mainnet_latest.json" --no-traverse --retries 5 --low-level-retries 10 &
+    metadata_pids+=($!)
 
-    wait
+    if ! wait_all "${metadata_pids[@]}"; then
+      senderr "Failed to upload metadata/latest.json to R2 ($DEST_PATH)."
+      exit 1
+    fi
   fi
 
   ARCHIVED_STATE_PATH="$ARCHIVE_PATH/states/${NOW}_$STATE_FILENAME"
@@ -172,12 +201,14 @@ function make_and_upload_snapshot() {
     --low-level-retries 10
 
   echo "[INFO] Copying state to latest path (with retry): $DEST_PATH/$STATE_FILENAME"
+  state_pids=()
   retry_until_success rclone copyto "$ARCHIVED_STATE_PATH" "$DEST_PATH/$STATE_FILENAME" \
     --no-traverse \
     --s3-disable-checksum \
     --s3-copy-cutoff 1G \
     --retries 5 \
     --low-level-retries 10 &
+  state_pids+=($!)
 
   retry_until_success rclone copyto "$ARCHIVED_STATE_PATH" "$DEST_PATH/internal/$STATE_FILENAME" \
     --no-traverse \
@@ -185,9 +216,14 @@ function make_and_upload_snapshot() {
     --s3-copy-cutoff 1G \
     --retries 5 \
     --low-level-retries 10 &
+  state_pids+=($!)
 
-  wait
+  if ! wait_all "${state_pids[@]}"; then
+    senderr "Failed to upload state snapshot to R2 ($DEST_PATH)."
+    exit 1
+  fi
 
+  part_pids=()
   _parallel_count=0
   for file in $( find "$OUTPUT_DIR" -size +4G ); do
     split -b 4GB "$file" "$file.part" --numeric-suffixes=1 -a $PART_LENGTH
@@ -200,14 +236,22 @@ function make_and_upload_snapshot() {
         --retries 5 \
         --low-level-retries 10 \
         --no-traverse && echo "[INFO] Copied $DEST_PATH/${part##*/}" && rm "$part" &
+      part_pids+=($!)
       _parallel_count=$(( _parallel_count + 1 ))
       if [ $(( _parallel_count % 5 )) -eq 0 ]; then
-        wait
+        if ! wait_all "${part_pids[@]}"; then
+          senderr "Failed to upload split part to R2 ($DEST_PATH)."
+          exit 1
+        fi
+        part_pids=()
       fi
     done
   done
 
-  wait
+  if [ "${#part_pids[@]}" -gt 0 ] && ! wait_all "${part_pids[@]}"; then
+    senderr "Failed to upload split part to R2 ($DEST_PATH)."
+    exit 1
+  fi
 
   if [ "$PRESERVE_PARTITIONS" = "false" ]; then
     rm "$LATEST_SNAPSHOT" "$LATEST_STATE" "$LATEST_METADATA"

--- a/charts/all-in-one/scripts/snapshots/partition/upload_snapshot.sh
+++ b/charts/all-in-one/scripts/snapshots/partition/upload_snapshot.sh
@@ -57,6 +57,14 @@ function senderr() {
     --data '{"text":"'"$SOURCE_PREFIX"'[K8S] '"$1"'. Check snapshot in {{ $.Values.clusterName }} cluster at upload_snapshot.sh."}' "$SLACK_WEBHOOK"
 }
 
+# Success/info notification. Non-fatal (|| true): a failed Slack post must not
+# fail an otherwise-successful snapshot upload.
+function sendinfo() {
+  echo "$1"
+  curl -X POST -H 'Content-type: application/json' \
+    --data '{"text":"'"$SOURCE_PREFIX"'[K8S] '"$1"'"}' "$SLACK_WEBHOOK" || true
+}
+
 function retry_until_success() {
   local max_attempts=100
   local delay=60
@@ -252,6 +260,12 @@ function make_and_upload_snapshot() {
     senderr "Failed to upload split part to R2 ($DEST_PATH)."
     exit 1
   fi
+
+  SNAPSHOT_INDEX=""
+  if [ -n "$LATEST_METADATA" ] && [ -f "$LATEST_METADATA" ]; then
+    SNAPSHOT_INDEX=$(grep -oE '"Index":[0-9]+' "$LATEST_METADATA" 2>/dev/null | head -1 | grep -oE '[0-9]+' || true)
+  fi
+  sendinfo "Partition snapshot uploaded OK: $SNAPSHOT_PATH block ${SNAPSHOT_INDEX:-?} ($SNAPSHOT_FILENAME); latest.json updated."
 
   if [ "$PRESERVE_PARTITIONS" = "false" ]; then
     rm "$LATEST_SNAPSHOT" "$LATEST_STATE" "$LATEST_METADATA"


### PR DESCRIPTION
## 배경

odin 메인넷 partition 스냅샷이 **block 18454260 (2026-05-26)** 에서 ~3주간 멈춰 있었습니다. 원인은 pt-6 odin 스냅샷 잡의 R2 업로드가 **403 (만료/폐기된 R2 토큰)** 으로 실패했는데도, 잡은 `exit 0` "Complete"로 떠서 **아무 알람도 안 뜬 silent failure** 였습니다. (R2 토큰은 별도로 교체해 복구 완료.)

## 근본 원인

`upload_snapshot.sh`의 R2 "latest path" 복사들이 백그라운드(`retry_until_success rclone copyto ... &`)로 돌고 뒤에 **인자 없는 `wait`** 가 옵니다. `wait`(no args)는 항상 0을 반환해서, `retry_until_success`가 100회 재시도 후 실패(`return 1`)해도 그 exit code가 **전부 버려집니다**. 그래서:

- 컨테이너 exit 0 → k8s Job "Complete" → Slack 알람 없음
- 공개 `latest.json`은 마지막 성공 업로드(5/26)에 동결
- 게다가 `PRESERVE_PARTITIONS=false` 정리 단계까지 진행돼 **업로드 실패한 zip을 삭제**

## 변경

**1. 실패 시 시끄럽게 (fail loudly)**
- 백그라운드 PID를 모아 각각 `wait`하고 하나라도 실패하면 non-zero를 반환하는 `wait_all` 헬퍼 추가
- 각 업로드 그룹(snapshot / metadata·latest.json / state / split parts)에서 `wait_all` 실패 시 **`senderr` + `exit 1`** → Job Fail + Slack 알람
- 실패 시 cleanup 전에 종료하므로 **업로드 안 된 데이터가 보존**됨

**2. 성공 시에도 알림 (요청사항)**
- 비치명적 `sendinfo()` 추가(`|| true` — 슬랙 실패가 정상 업로드를 깨지 않음)
- partition/full 업로드 완료 시 성공 메시지 전송. partition은 메타데이터에서 파싱한 **블록 높이**(`Index`)를 포함해 latest.json이 전진했음을 한눈에 확인 가능
- 대상 채널은 기존 실패 알림과 동일한 snapshot 웹훅 (주 1회 cadence라 노이즈 적음)

대상: all-in-one **partition + full** 업로드 스크립트. `partition-reset`은 해당 백그라운드/wait 패턴 없어 변경 없음.

## 검증

- `bash -n` 문법 검사 통과 (두 스크립트)
- `wait_all` 단위 테스트: 실패 감지 / 전체 성공 통과 / 빈 배열(`set -u`) 안전 확인
- 메타데이터 `Index` 파싱 테스트 통과
- 정상 업로드 경로 동작은 기존과 동일 — 실패 경로에서 exit 1 전파 + 양 경로 Slack 알림만 추가

## 배포 메모

ArgoCD sync 시 configmap(`*-snapshot-script-partition` 등)이 갱신되고, **다음 스냅샷 잡 실행부터** 적용됩니다 (실행 중 잡엔 영향 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
