### PR TITLE
fix(snapshot): alert + fail when preload finds no appropriate peers

### DIFF
--- a/charts/all-in-one/scripts/snapshots/preload_headless.sh
+++ b/charts/all-in-one/scripts/snapshots/preload_headless.sh
@@ -95,13 +95,28 @@ function wait_preloading() {
 
   tail -f "$HEADLESS_LOG" | grep "Block #" &
 
-  if timeout 144000 tail -f "$HEADLESS_LOG" | grep -m1 -e "preloading is no longer needed" -e "There are no appropriate peers for preloading" $(echo "$CUTOFF_GREP"); then
-    sleep 5
-  else
-    senderr "grep failed. Failed to preload." $1
-    kill "$PID"
+  # Capture WHICH terminal line appeared instead of treating them all as success.
+  # "There are no appropriate peers for preloading" means the node could NOT find
+  # peers to sync from (e.g. APV mismatch or unreachable seed) -> it is NOT caught
+  # up. Previously this matched the same grep as the real success message, so the
+  # job silently "completed" on a stale store (odin snapshot froze ~24 days at the
+  # 2026-05-26 APV bump). Now it alerts and aborts.
+  MATCH=$(timeout 144000 tail -f "$HEADLESS_LOG" | grep -m1 -e "preloading is no longer needed" -e "There are no appropriate peers for preloading" $(echo "$CUTOFF_GREP") || true)
+
+  if [ -z "$MATCH" ]; then
+    senderr "Preload timed out with no completion log."
+    kill "$PID" || true
     exit 1
   fi
+
+  if echo "$MATCH" | grep -q "There are no appropriate peers for preloading"; then
+    senderr "Preload found NO appropriate peers (likely APV mismatch or unreachable seed); store may be stale. Aborting."
+    kill "$PID" || true
+    exit 1
+  fi
+
+  echo "[INFO] Preload completed: $MATCH"
+  sleep 5
 }
 
 


### PR DESCRIPTION
## 배경
odin 메인넷 partition 스냅샷이 block 18454260 (2026-05-26)에서 ~24일간 묻혀 있던 **두 번째 근본원인**입니다. (첫 번째는 R2 업로드 403 — 별도로 처리됨.)

## 문제
`preload_headless.sh`의 `wait_preloading()`이 동기화 종료 신호를 이렇게 처리했습니다:
```sh
if timeout ... | grep -m1 -e "preloading is no longer needed" \
                          -e "There are no appropriate peers for preloading"; then
  sleep 5            # ← 둘 다 "성공"으로 처리
else
  senderr ...; exit 1
fi
```
`"There are no appropriate peers for preloading"`는 **동기화할 적절한 peer를 못 찾았다**(APV 불일치 / seed 도달 불가 등)는 **실패** 신호인데, 성공 메시지와 같은 grep에 묶여 있어 **exit 0으로 조용히 넘어갔습니다**. 그 결과 stale store(5/26)로 스냅샷이 매주 "성공" 생성됐고 아무 알람도 없었습니다. (실제로 pt6가 APV 200430으로 돌며 200440 네트워크와 불일치 → no peers → 24일 stale.)

## 변경
매칭된 라인을 캡처해 분기:
- **"no appropriate peers"** → `senderr`(Slack) + `exit 1` (잡 실패)
- **timeout**(완료 로그 없음) → `senderr` + `exit 1`
- `"preloading is no longer needed"` / `FORCE_CUTOFF_BLOCK` 블록 도달 → 성공 유지

이제 preload가 막히면 stale 스냅샷을 만드는 대신 **Slack 알람 + 잡 실패**로 드러납니다.

## 검증
4개 분기 standalone 테스트 통과: timeout·no-peers → 실패(알람), done·cutoff → 성공.

## 배포
ArgoCD sync 후 다음 잡부터 적용. ⚠️ **APV bump 시 `pt6-odin` 앱도 반드시 sync** (이번 staleness의 근본원인이 pt6-odin 미sync였음 — auto-sync 검토 권장).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
