### PR TITLE
feat(9c-pt6): add validator-5 as a second odin preload peer

### DIFF
--- a/9c-pt6/network/odin.yaml
+++ b/9c-pt6/network/odin.yaml
@@ -17,6 +17,20 @@ global:
   resetSnapshot: false
   rollbackSnapshot: false
 
+  # Override the inherited single-seed peer list (lists are replaced, not merged).
+  # pt6 sits in the office/colo network and can only reach the colo seed and the
+  # colo MetalLB IPs; the planetarium.dev/EKS seeds don't even resolve from here.
+  # With just seed-1, a transient drop on that single connection halts preload
+  # with "There are no appropriate peers for preloading", which is how the
+  # snapshot store fell ~24 days behind. Add validator-5 (the single odin
+  # validator -> stable swarm key, always at tip) as a second peer for
+  # resilience. It is reachable from pt6 at its colo MetalLB IP on the swarm
+  # port (115.68.194.100:31234); there is no DNS for that swarm endpoint, so the
+  # raw IP is used (MetalLB IP has been stable for 300d+).
+  peerStrings:
+  - "027bd36895d68681290e570692ad3736750ceaab37be402442ffb203967f98f7b6,odin-tcp-seed-1.nine-chronicles.com,31234"
+  - "03a0f95711564d10c60ba1889d068c26cb8e5fcd5211d5aeb8810e133d629aa306,115.68.194.100,31234"
+
 # Disable components that pt6 does not run.
 seed:
   count: 0


### PR DESCRIPTION
## 배경
pt6 odin 스냅샷 preload는 peer가 **`odin-tcp-seed-1` 단 1개**였습니다. pt6(사내/콜로 네트워크)는 planetarium.dev/EKS seed들을 **DNS조차 못 해석**해서 추가 seed도 못 붙습니다. 단일 seed 연결이 잠깐 끊기면 preload가 `"There are no appropriate peers for preloading"`로 조기 종료 → store가 ~24일(5/26) 뒤처진 원인 중 하나였습니다. (실측: preload가 5/26→5/30 동기화 후 이 메시지로 멈춤)

## 변경
`9c-pt6/network/odin.yaml`의 `global.peerStrings`를 **pt6 한정** override(리스트는 병합 아니라 교체)하여 **validator-5를 2번째 peer로 추가**:

```
- "027bd368...,odin-tcp-seed-1.nine-chronicles.com,31234"   # 기존 seed
- "03a0f957...,115.68.194.100,31234"                          # validator-5 (신규)
```

- validator-5는 **단일 odin validator** → swarm 키가 고정(`03a0f957…`)이고 항상 tip. 단일 validator라 어차피 모든 블록 출처가 validator-5이므로 추가 부하 사실상 없음.
- pt6에서 콜로 MetalLB IP **115.68.194.100:31234(swarm)** 직접 도달 확인됨(`/dev/tcp` OPEN). 해당 swarm 엔드포인트용 DNS가 없어 raw IP 사용(MetalLB IP는 300d+ 고정).

## 검토 메모
- remote-headless-1(비-validator, 부하 안전)도 검토했으나 `--no-miner` + `--swarm-private-key` 미설정 → 재시작마다 swarm pubkey 랜덤 → static peer 불가라 제외.
- pt6에만 적용(9c-pt6 overlay) — 운영 odin 노드들(validator/rpc/headless)의 peer 설정엔 영향 없음.
- 적용: ArgoCD `pt6-odin` sync 후 다음 preload부터.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
