### PR TITLE
feat(9c-main heimdall): swap validator-5 onto rpc-1's fresh snapshot volume

### DIFF
--- a/9c-main/network/heimdall.yaml
+++ b/9c-main/network/heimdall.yaml
@@ -159,7 +159,7 @@ validator:
 
   storage:
     volumeNames:
-    - "remote-headless-data-2-remote-headless-2-0"
+    - "remote-headless-data-1-remote-headless-1-0"
 
   tolerations:
   - effect: NoSchedule
@@ -216,7 +216,7 @@ remoteHeadless:
 
   storage:
     volumeNames:
-    - remote-headless-data-1-remote-headless-1-0
+    - remote-headless-data-2-remote-headless-2-0
 
   tolerations:
   - effect: NoSchedule


### PR DESCRIPTION
## 배경
- `validator-5`가 옛 rpc-2 볼륨(`remote-headless-data-2-remote-headless-2-0`)에서 돌고 있었고 불안정했음 (23일간 21회 재시작).
- `remote-headless-1`(rpc-1)을 6/25 신규 partition 스냅샷으로 복구 → `remote-headless-data-1-remote-headless-1-0`, 현재 tip(#10279757)에서 healthy.

## 변경
`9c-main/network/heimdall.yaml`에서 validator ↔ remoteHeadless의 `storage.volumeNames`를 맞바꿈:
- validator: `remote-headless-data-2-...` → **`remote-headless-data-1-...`** (rpc-1의 깨끗한 복구본)
- remoteHeadless(rpc-1): `remote-headless-data-1-...` → **`remote-headless-data-2-...`**

## 안전성
- 두 store 모두 같은 tip(#10279757) → 뒤로 점프 없음 = 이중서명 위험 없음.
- validator 서명 정체성은 `private-keys` 시크릿에서 오므로 store 교체와 무관.

## 적용 절차 (머지 후 라이브)
RWO라 양쪽 동시 마운트 불가 → 다음 순서로 진행:
1. `validator-5` + `remote-headless-1` 둘 다 `replicas=0` (볼륨 detach)
2. ArgoCD **selective sync** (두 StatefulSet만, `--prune` 없이) → 스왑된 claimName + replicas=1 적용
3. validator 먼저 기동 검증 → rpc-1 기동 검증

> ⚠️ heimdall 앱이 다수 OutOfSync 상태라 **전체 sync 금지**. validator-5 / remote-headless-1 두 리소스만 selective sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)