### PR TITLE
feat(seasonpass): deploy SeasonPass#306 /ping resilience fix to mainnet

### DIFF
--- a/9c-main/external-services/values.yaml
+++ b/9c-main/external-services/values.yaml
@@ -27,7 +27,7 @@ volumeReclaimPolicy: "Retain"
 seasonpass:
   enabled: true
   image:
-    tag: "git-c5c0ed5f4eb22b422a6c167339556eba512d8e66"
+    tag: "git-cc9e3f81f28ea2a9b1b0284532222adf92cf7195"
 
   api:
     enabled: true


### PR DESCRIPTION
## What

Bump mainnet `seasonpass.image.tag` (`9c-main/external-services/values.yaml`) from `git-c5c0ed5f…` → `git-cc9e3f81f28ea2a9b1b0284532222adf92cf7195` to deploy [NineChronicles.SeasonPass#306](https://github.com/planetarium/NineChronicles.SeasonPass/pull/306).

## Why

`seasonpass-api` is in a liveness restart loop — **17 restarts in 3 days**, all `exit 137` (liveness kill). Each restart fires the season pass alarm.

**Service-side issue, not network/DB** (investigated 2026-06-28):
- During the API's pool-exhaustion deaths, the shared iwinv postgres served the independent `tx-tracker` (separate pool) with **0 errors**, and TCP connect latency from the API pod is **0–2 ms**.
- The API exhausts its **own** 30-conn pool in ~2-min concurrency bursts (anyio threadpool 40 > DB pool 30). With `pool_timeout=60s`, overflow requests pin threadpool threads for a full minute, so the **sync** `/ping` can't be scheduled → liveness times out → SIGKILL → restart (and the cold restart actually hurts).

#306 fixes it: `/ping` → `async def` (served on the event loop, survives threadpool saturation → no more spurious liveness kills) and `pool_timeout` 60s → 10s (faster recovery).

## Scope / blast radius

- `seasonpass.image.tag` is shared, so this restarts **api, beat, claim-worker, flower, and the 4 trackers**.
- Code diff `git-c5c0ed5f → git-cc9e3f8` is **only the 2 api files** (`apps/api/main.py`, `apps/api/app/dependencies.py`). `c5c0ed5f` is the same `skip-empty-claim` change as main HEAD `715a916`, so workers/trackers get equivalent code + a clean restart (the tx-tracker restart also clears any wedged pool).
- Images **verified present** in registry for `season-pass-api` / `-tracker` / `-worker` at `git-cc9e3f8…` (build_docker run success + Docker Hub 200).
- **mainnet only** — internal/other envs untouched (tag appears only here).

## Deploy note
external-services ArgoCD app may need a manual sync after merge.

## Follow-ups (not here)
- Merge #306 into season-pass `main` so the deployed image matches main (#306 = main + 1 commit; no drift afterward).
- Deeper: threadpool↔DB-pool capacity alignment; move GQL out of the DB session scope; tx-tracker resilience (try/finally + `pool_pre_ping`/`pool_recycle` + throughput-based health) to prevent its silent-death recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
