### PR TITLE
feat(seasonpass): deploy threadpool cap (fix QueuePool 500 alarms) to mainnet

### DIFF
--- a/9c-main/external-services/values.yaml
+++ b/9c-main/external-services/values.yaml
@@ -27,7 +27,7 @@ volumeReclaimPolicy: "Retain"
 seasonpass:
   enabled: true
   image:
-    tag: "git-cc9e3f81f28ea2a9b1b0284532222adf92cf7195"
+    tag: "git-ba5228ce9985327092b3d0ea874620d3cade5721"
 
   api:
     enabled: true


### PR DESCRIPTION
## What
Bump mainnet `seasonpass.image.tag` (`9c-main/external-services/values.yaml`) `git-cc9e3f8…` → `git-ba5228c…` to deploy the threadpool cap from [NineChronicles.SeasonPass#306](https://github.com/planetarium/NineChronicles.SeasonPass/pull/306).

## Why
Recurring PagerDuty/Assertible alarms **Test Invalid Claim** + **Test Block Status** (firing together, multiple times/day). Caught live: `seasonpass-api` DB pool (`pool_size 10 + max_overflow 20 = 30`) is smaller than the anyio threadpool (40) running FastAPI **sync** handlers. Under a traffic burst (~60–120 req/min) more handlers run than connections → excess block on checkout → **HTTP 500 `QueuePool limit … timed out`** on every DB endpoint → both monitors fail at once + `/api/season-pass/current` degrades.

postgres is healthy (TCP connect 0–2 ms, `tx-tracker` on the same DB unaffected) — purely an API-side capacity mismatch. The previously deployed `git-cc9e3f8` (async `/ping`) stopped the pod **restart loop** but not the pool exhaustion; this image caps the threadpool to 25 (< 30) so bursts queue instead of 500.

## Scope
- Shared `seasonpass.image.tag` → restarts api/beat/claim-worker/flower/4 trackers. Code delta vs `git-cc9e3f8` is **only `apps/api` (main.py, config.py)** — others get equivalent code + a clean restart.
- Images verified present for `season-pass-api`/`-tracker`/`-worker` at `git-ba5228c…`.
- mainnet only.

## Deploy note
`9c-external-services` ArgoCD app has no auto-sync — manual sync after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
