### PR TITLE
feat(snapshot): make pt6 odin partition cronjob viable (SSD store split, R2-direct upload, rclone concurrency)

### DIFF
--- a/9c-pt6/network/odin.yaml
+++ b/9c-pt6/network/odin.yaml
@@ -121,6 +121,15 @@ snapshot:
   sourceLabel: "pt6"
   path: "main/partition"
 
+  # pt6 publish tuning (see charts/all-in-one/values.yaml for semantics):
+  # - on-prem -> AWS S3 large multipart PUTs hang here, so skip the GLACIER
+  #   archive and upload to R2 directly from local;
+  # - the uplink is single-stream window-limited (~0.6MB/s @ 4 -> ~3.4MB/s @ 16);
+  # - skip the redundant >4G split-parts pass (clients fall back to whole file).
+  archiveToS3: false
+  rcloneUploadConcurrency: 16
+  uploadSplitParts: false
+
   fullSnapshot:
     enabled: false
     suspend: false
@@ -143,12 +152,16 @@ snapshot:
     schedule: "0 0 * * 0"
     suspend: false
     zstd: false
-    # Hybrid layout: RocksDB chain on SSD (fast random I/O), snapshot zip on HDD
-    # (large sequential writes, preserves SSD life). Both PVCs pre-created
-    # manually on pt6 (see plan file Phase 2e).
+    # Hybrid layout: the full odin store (~430G) does not fit on pt6's 466G SSD,
+    # and create-snapshot's CopyStates is unusably slow on HDD (random I/O). So
+    # the store lives on the SSD host dir (/opt/odin-store) EXCEPT the bulk `tx`
+    # column family (268G), submounted from the HDD at /data/headless/tx. The
+    # snapshot zips go to the HDD-backed output PVC. (Host dirs pre-created on pt6.)
     volumeMode: hybrid
     chainDataVolume:
-      name: snapshot-chain-data-pt6
+      hostPath: /opt/odin-store
+    txVolume:
+      hostPath: /data/snapshot-chain-data/tx
     outputVolume:
       name: snapshot-output-pt6
     volume:

--- a/charts/all-in-one/scripts/snapshots/partition/upload_snapshot.sh
+++ b/charts/all-in-one/scripts/snapshots/partition/upload_snapshot.sh
@@ -19,6 +19,20 @@ COMPRESSION_LEVEL="${9:-0}"
 PRESERVE_PARTITIONS="${10:-false}"
 PART_LENGTH="${11:-3}"
 
+# --- Publish tuning (Helm values; bash :- defaults keep legacy behavior) ---
+# archiveToS3=false skips the AWS S3 GLACIER archive and uploads to R2 directly
+# from the local files. Needed on pt6 where large multipart PUTs to AWS S3 hang
+# (on-prem -> AWS network path) while Cloudflare R2 uploads work fine.
+ARCHIVE_TO_S3="{{ $.Values.snapshot.archiveToS3 }}"; ARCHIVE_TO_S3="${ARCHIVE_TO_S3:-true}"
+# Parallel chunk streams per rclone upload. pt6's uplink is single-stream
+# window-limited (~0.6MB/s at the default 4); 16 streams reach ~3.4MB/s.
+RCLONE_CONCURRENCY="{{ $.Values.snapshot.rcloneUploadConcurrency }}"; RCLONE_CONCURRENCY="${RCLONE_CONCURRENCY:-4}"
+# uploadSplitParts=false skips re-uploading >4G files as .partNNN chunks.
+# download_snapshot.sh's test_ext_path tries .part001 then falls back to the
+# whole file, so parts are an optimisation, not a requirement; skipping roughly
+# halves the state upload (no second 64G pass) on slow uplinks like pt6.
+UPLOAD_SPLIT_PARTS="{{ $.Values.snapshot.uploadSplitParts }}"; UPLOAD_SPLIT_PARTS="${UPLOAD_SPLIT_PARTS:-true}"
+
 function setup_rclone() {
   RCLONE_CONFIG_DIR="/root/.config/rclone"
   mkdir -p "$RCLONE_CONFIG_DIR"
@@ -94,6 +108,45 @@ function wait_all() {
   return "$rc"
 }
 
+# Publish one artifact (snapshot zip / state / metadata) to its R2 destinations,
+# crossing the WAN with the local file only ONCE regardless of dest count:
+#   ARCHIVE_TO_S3=true : upload local -> S3 GLACIER archive, then server-side
+#                        copy S3 -> each R2 destination.
+#   ARCHIVE_TO_S3=false: upload local -> first R2 destination, then server-side
+#                        copy R2 -> the remaining R2 destinations.
+# Usage: publish_artifact <local_file> <s3_archive_path> <r2_dest> [r2_dest ...]
+function publish_artifact() {
+  local local_file="$1" s3_path="$2"
+  shift 2
+  local up_flags="--no-traverse --s3-disable-checksum --s3-upload-cutoff=64M --s3-chunk-size=64M --s3-upload-concurrency=$RCLONE_CONCURRENCY --retries 5 --low-level-retries 10"
+  local copy_flags="--no-traverse --s3-disable-checksum --s3-copy-cutoff 1G --retries 5 --low-level-retries 10"
+  local source
+  if [ "$ARCHIVE_TO_S3" = "true" ]; then
+    echo "[INFO] Archiving to S3: $s3_path"
+    # Explicit check: set -e is suppressed inside a function called from `if !`,
+    # so a bare failing command would not abort — fail loudly here instead.
+    if ! rclone copyto "$local_file" "$s3_path" $up_flags; then
+      echo "[ERROR] S3 archive failed: $s3_path"
+      return 1
+    fi
+    source="$s3_path"
+  else
+    source="$1"
+    shift
+    echo "[INFO] Uploading to R2 (S3 archive skipped): $source"
+    retry_until_success rclone copyto "$local_file" "$source" $up_flags
+  fi
+  local pids=() dest
+  for dest in "$@"; do
+    echo "[INFO] Copying to $dest"
+    retry_until_success rclone copyto "$source" "$dest" $copy_flags &
+    pids+=($!)
+  done
+  if [ "${#pids[@]}" -gt 0 ] && ! wait_all "${pids[@]}"; then
+    return 1
+  fi
+}
+
 function make_and_upload_snapshot() {
   echo "[DEBUG] Args: $1"
   OUTPUT_DIR="${1:-/data/snapshots}"
@@ -126,139 +179,79 @@ function make_and_upload_snapshot() {
   DEST_PATH="r2:9c-snapshots/$SNAPSHOT_PATH"
   ARCHIVE_PATH="s3:9c-snapshots-archive/$SNAPSHOT_PATH/archive"
 
+  # Upload order: data first (partition zip, then state + split parts), and the
+  # metadata/latest.json pointer LAST (see below) so the public latest.json never
+  # points at a snapshot whose state_latest.zip is not yet fully uploaded — this
+  # window is ~hours on a slow uplink like pt6.
+
+  # 1) partition snapshot zip
   ARCHIVED_SNAPSHOT_PATH="$ARCHIVE_PATH/snapshots/${NOW}_$SNAPSHOT_FILENAME"
-  echo "[INFO] Archiving snapshot: $ARCHIVED_SNAPSHOT_PATH"
-  rclone copyto "$LATEST_SNAPSHOT" "$ARCHIVED_SNAPSHOT_PATH" \
-    --s3-upload-cutoff 512M \
-    --s3-chunk-size 512M \
-    --s3-disable-checksum \
-    --multi-thread-streams 4 \
-    --no-traverse \
-    --retries 5 \
-    --low-level-retries 10
-
-  echo "[INFO] Copying snapshot to latest path: $DEST_PATH/$SNAPSHOT_FILENAME"
-  snapshot_pids=()
-  retry_until_success rclone copyto "$ARCHIVED_SNAPSHOT_PATH" "$DEST_PATH/$SNAPSHOT_FILENAME" \
-    --no-traverse \
-    --s3-disable-checksum \
-    --s3-copy-cutoff 1G \
-    --retries 5 \
-    --low-level-retries 10 &
-  snapshot_pids+=($!)
-  retry_until_success rclone copyto "$ARCHIVED_SNAPSHOT_PATH" "$DEST_PATH/$SNAPSHOT_LATEST_FILENAME" \
-    --no-traverse \
-    --s3-disable-checksum \
-    --s3-copy-cutoff 1G \
-    --retries 5 \
-    --low-level-retries 10 &
-  snapshot_pids+=($!)
-  retry_until_success rclone copyto "$ARCHIVED_SNAPSHOT_PATH" "$DEST_PATH/internal/$SNAPSHOT_FILENAME" \
-    --no-traverse \
-    --s3-disable-checksum \
-    --s3-copy-cutoff 1G \
-    --retries 5 \
-    --low-level-retries 10 &
-  snapshot_pids+=($!)
-  retry_until_success rclone copyto "$ARCHIVED_SNAPSHOT_PATH" "$DEST_PATH/internal/$SNAPSHOT_LATEST_FILENAME" \
-    --no-traverse \
-    --s3-disable-checksum \
-    --s3-copy-cutoff 1G \
-    --retries 5 \
-    --low-level-retries 10 &
-  snapshot_pids+=($!)
-
-  if ! wait_all "${snapshot_pids[@]}"; then
+  if ! publish_artifact "$LATEST_SNAPSHOT" "$ARCHIVED_SNAPSHOT_PATH" \
+      "$DEST_PATH/$SNAPSHOT_FILENAME" \
+      "$DEST_PATH/$SNAPSHOT_LATEST_FILENAME" \
+      "$DEST_PATH/internal/$SNAPSHOT_FILENAME" \
+      "$DEST_PATH/internal/$SNAPSHOT_LATEST_FILENAME"; then
     senderr "Failed to upload partition snapshot to R2 ($DEST_PATH)."
     exit 1
   fi
 
-  if [ -n "$LATEST_METADATA" ]; then
-    ARCHIVED_METADATA_PATH="$ARCHIVE_PATH/metadata/${NOW}_$METADATA_FILENAME"
-    echo "[INFO] Archiving metadata: $ARCHIVED_METADATA_PATH"
-    rclone copyto "$LATEST_METADATA" "$ARCHIVED_METADATA_PATH" --no-traverse --retries 5 --low-level-retries 10
-
-    echo "[INFO] Copying metadata to latest path: $DEST_PATH/$METADATA_FILENAME"
-    metadata_pids=()
-    rclone copyto "$ARCHIVED_METADATA_PATH" "$DEST_PATH/$METADATA_FILENAME" --no-traverse --retries 5 --low-level-retries 10 &
-    metadata_pids+=($!)
-    rclone copyto "$ARCHIVED_METADATA_PATH" "$DEST_PATH/latest.json" --no-traverse --retries 5 --low-level-retries 10 &
-    metadata_pids+=($!)
-    rclone copyto "$ARCHIVED_METADATA_PATH" "$DEST_PATH/internal/$METADATA_FILENAME" --no-traverse --retries 5 --low-level-retries 10 &
-    metadata_pids+=($!)
-    rclone copyto "$ARCHIVED_METADATA_PATH" "$DEST_PATH/internal/latest.json" --no-traverse --retries 5 --low-level-retries 10 &
-    metadata_pids+=($!)
-    rclone copyto "$ARCHIVED_METADATA_PATH" "$DEST_PATH/internal/mainnet_latest.json" --no-traverse --retries 5 --low-level-retries 10 &
-    metadata_pids+=($!)
-
-    if ! wait_all "${metadata_pids[@]}"; then
-      senderr "Failed to upload metadata/latest.json to R2 ($DEST_PATH)."
-      exit 1
-    fi
-  fi
-
+  # 2) state
   ARCHIVED_STATE_PATH="$ARCHIVE_PATH/states/${NOW}_$STATE_FILENAME"
-  echo "[INFO] Archiving state: $ARCHIVED_STATE_PATH"
-  rclone copyto "$LATEST_STATE" "$ARCHIVED_STATE_PATH" \
-    --s3-upload-cutoff 512M \
-    --s3-chunk-size 512M \
-    --s3-disable-checksum \
-    --multi-thread-streams 4 \
-    --no-traverse \
-    --retries 5 \
-    --low-level-retries 10
-
-  echo "[INFO] Copying state to latest path (with retry): $DEST_PATH/$STATE_FILENAME"
-  state_pids=()
-  retry_until_success rclone copyto "$ARCHIVED_STATE_PATH" "$DEST_PATH/$STATE_FILENAME" \
-    --no-traverse \
-    --s3-disable-checksum \
-    --s3-copy-cutoff 1G \
-    --retries 5 \
-    --low-level-retries 10 &
-  state_pids+=($!)
-
-  retry_until_success rclone copyto "$ARCHIVED_STATE_PATH" "$DEST_PATH/internal/$STATE_FILENAME" \
-    --no-traverse \
-    --s3-disable-checksum \
-    --s3-copy-cutoff 1G \
-    --retries 5 \
-    --low-level-retries 10 &
-  state_pids+=($!)
-
-  if ! wait_all "${state_pids[@]}"; then
+  if ! publish_artifact "$LATEST_STATE" "$ARCHIVED_STATE_PATH" \
+      "$DEST_PATH/$STATE_FILENAME" \
+      "$DEST_PATH/internal/$STATE_FILENAME"; then
     senderr "Failed to upload state snapshot to R2 ($DEST_PATH)."
     exit 1
   fi
 
-  part_pids=()
-  _parallel_count=0
-  for file in $( find "$OUTPUT_DIR" -size +4G ); do
-    split -b 4GB "$file" "$file.part" --numeric-suffixes=1 -a $PART_LENGTH
-    for part in "$file.part"*; do
-      retry_until_success rclone copyto "$part" "$DEST_PATH/${part##*/}" \
-        --s3-upload-cutoff 64M \
-        --s3-chunk-size 64M \
-        --s3-disable-checksum \
-        --multi-thread-streams 2 \
-        --retries 5 \
-        --low-level-retries 10 \
-        --no-traverse && echo "[INFO] Copied $DEST_PATH/${part##*/}" && rm "$part" &
-      part_pids+=($!)
-      _parallel_count=$(( _parallel_count + 1 ))
-      if [ $(( _parallel_count % 5 )) -eq 0 ]; then
-        if ! wait_all "${part_pids[@]}"; then
-          senderr "Failed to upload split part to R2 ($DEST_PATH)."
-          exit 1
+  # 3) split parts of any >4G file (state). Optional: download_snapshot.sh falls
+  #    back to the whole file when parts are absent, so this is skippable on slow
+  #    uplinks to avoid a second full-size pass.
+  if [ "$UPLOAD_SPLIT_PARTS" = "true" ]; then
+    part_pids=()
+    _parallel_count=0
+    for file in $( find "$OUTPUT_DIR" -size +4G ); do
+      split -b 4GB "$file" "$file.part" --numeric-suffixes=1 -a $PART_LENGTH
+      for part in "$file.part"*; do
+        retry_until_success rclone copyto "$part" "$DEST_PATH/${part##*/}" \
+          --s3-upload-cutoff 64M \
+          --s3-chunk-size 64M \
+          --s3-disable-checksum \
+          --s3-upload-concurrency=$RCLONE_CONCURRENCY \
+          --retries 5 \
+          --low-level-retries 10 \
+          --no-traverse && echo "[INFO] Copied $DEST_PATH/${part##*/}" && rm "$part" &
+        part_pids+=($!)
+        _parallel_count=$(( _parallel_count + 1 ))
+        if [ $(( _parallel_count % 5 )) -eq 0 ]; then
+          if ! wait_all "${part_pids[@]}"; then
+            senderr "Failed to upload split part to R2 ($DEST_PATH)."
+            exit 1
+          fi
+          part_pids=()
         fi
-        part_pids=()
-      fi
+      done
     done
-  done
 
-  if [ "${#part_pids[@]}" -gt 0 ] && ! wait_all "${part_pids[@]}"; then
-    senderr "Failed to upload split part to R2 ($DEST_PATH)."
-    exit 1
+    if [ "${#part_pids[@]}" -gt 0 ] && ! wait_all "${part_pids[@]}"; then
+      senderr "Failed to upload split part to R2 ($DEST_PATH)."
+      exit 1
+    fi
+  fi
+
+  # 4) metadata + latest.json LAST — the public pointer flips to this snapshot
+  #    only now, after the zip/state/parts above are all in place.
+  if [ -n "$LATEST_METADATA" ]; then
+    ARCHIVED_METADATA_PATH="$ARCHIVE_PATH/metadata/${NOW}_$METADATA_FILENAME"
+    if ! publish_artifact "$LATEST_METADATA" "$ARCHIVED_METADATA_PATH" \
+        "$DEST_PATH/$METADATA_FILENAME" \
+        "$DEST_PATH/latest.json" \
+        "$DEST_PATH/internal/$METADATA_FILENAME" \
+        "$DEST_PATH/internal/latest.json" \
+        "$DEST_PATH/internal/mainnet_latest.json"; then
+      senderr "Failed to upload metadata/latest.json to R2 ($DEST_PATH)."
+      exit 1
+    fi
   fi
 
   SNAPSHOT_INDEX=""

--- a/charts/all-in-one/templates/_snapshot_partition_helpers.tpl
+++ b/charts/all-in-one/templates/_snapshot_partition_helpers.tpl
@@ -9,9 +9,16 @@ Three modes are supported, determined by snapshot.partition.volumeMode:
       the same PVC. Matches the pre-existing 9c-main baremetal-1 setup.
 
   "hybrid"
-    - Two PVCs: snapshot.partition.chainDataVolume.name (SSD-backed) for
-      /data/headless, snapshot.partition.outputVolume.name (HDD-backed)
-      for /data/snapshots and /data/snapshot_logs.
+    - chainDataVolume (SSD-backed) for /data/headless, outputVolume
+      (HDD-backed) for /data/snapshots and /data/snapshot_logs.
+    - chainDataVolume accepts EITHER `.name` (a pre-created PVC) OR
+      `.hostPath` (a host directory). hostPath is used on pt6 where the
+      full odin store does not fit on the SSD: everything except the bulk
+      `tx` column family lives on the SSD host dir, and `tx` (268G) is
+      submounted from the HDD via the optional `txVolume.hostPath` at
+      /data/headless/tx. This keeps the random-I/O-heavy `states` CF on
+      SSD (create-snapshot's CopyStates is otherwise unusably slow on HDD)
+      while the bulk tx stays on the cheap HDD.
     - Intended for pt6 where Samsung 850 PRO SSD handles RocksDB random
       I/O while the Toshiba HDD absorbs large sequential zip writes.
 
@@ -27,6 +34,10 @@ helpers below.
 {{- if eq $.Values.snapshot.partition.volumeMode "hybrid" }}
 - name: chain-data
   mountPath: /data/headless
+{{- if $.Values.snapshot.partition.txVolume }}
+- name: tx-data
+  mountPath: /data/headless/tx
+{{- end }}
 - name: snapshot-output
   mountPath: /data/snapshots
 - name: snapshot-output
@@ -44,8 +55,20 @@ helpers below.
 {{- define "snapshot.partition.volumes" -}}
 {{- if eq $.Values.snapshot.partition.volumeMode "hybrid" }}
 - name: chain-data
+  {{- if $.Values.snapshot.partition.chainDataVolume.hostPath }}
+  hostPath:
+    path: {{ $.Values.snapshot.partition.chainDataVolume.hostPath }}
+    type: Directory
+  {{- else }}
   persistentVolumeClaim:
     claimName: {{ $.Values.snapshot.partition.chainDataVolume.name }}
+  {{- end }}
+{{- if $.Values.snapshot.partition.txVolume }}
+- name: tx-data
+  hostPath:
+    path: {{ $.Values.snapshot.partition.txVolume.hostPath }}
+    type: Directory
+{{- end }}
 - name: snapshot-output
   persistentVolumeClaim:
     claimName: {{ $.Values.snapshot.partition.outputVolume.name }}

--- a/charts/all-in-one/values.yaml
+++ b/charts/all-in-one/values.yaml
@@ -65,6 +65,18 @@ externalSecret:
 
 snapshot:
   downloadSnapshot: false
+  # Publish tuning (consumed by partition/upload_snapshot.sh). Defaults preserve
+  # legacy behavior; pt6 overrides these (see 9c-pt6/network/odin.yaml):
+  #   archiveToS3=false       — skip the AWS S3 GLACIER archive, upload to R2
+  #                             directly from local. pt6's on-prem->AWS path
+  #                             hangs on large multipart PUTs; R2 works fine.
+  #   rcloneUploadConcurrency — parallel chunk streams per rclone upload
+  #                             (pt6's uplink is single-stream window-limited).
+  #   uploadSplitParts=false  — skip re-uploading >4G files as .partNNN chunks
+  #                             (download_snapshot.sh falls back to the whole file).
+  archiveToS3: true
+  rcloneUploadConcurrency: 4
+  uploadSplitParts: true
   fullSnapshot:
     enabled: false
     suspend: false
@@ -80,16 +92,21 @@ snapshot:
     compressionLevel: 0
     # Volume layout for the snapshot CronJob.
     #   "single" (default) — one PVC mounted at /data (existing 9c-main setup)
-    #   "hybrid"           — two PVCs: chainDataVolume (SSD) at /data/headless,
+    #   "hybrid"           — chainDataVolume (SSD) at /data/headless,
     #                        outputVolume (HDD) at /data/snapshots + /data/snapshot_logs
     volumeMode: "single"
     volume:
       create: false
       name: snapshot-volume-partition
-    # Used only when volumeMode=hybrid. PVCs must be pre-created on the
-    # target cluster with appropriate storageClassName.
+    # Used only when volumeMode=hybrid. PVCs must be pre-created on the target
+    # cluster. chainDataVolume accepts EITHER `name` (a PVC) OR `hostPath` (a
+    # host dir). When `txVolume.hostPath` is set, it is submounted at
+    # /data/headless/tx — lets the store live on SSD except the bulk tx CF (pt6).
     chainDataVolume:
       name: snapshot-chain-data
+      # hostPath: /opt/odin-store
+    # txVolume:
+    #   hostPath: /data/snapshot-chain-data/tx
     outputVolume:
       name: snapshot-output
     dp:


### PR DESCRIPTION
## 배경
pt6 odin 스냅샷 CronJob이 사실상 동작 불가였음 (공개 latest.json 5/26 동결). 2026-06-28 수동으로 6/28 스냅샷(#18815070) 발행하며 3가지 병목을 우회했고, **이 PR은 그 동작 구성을 차트에 반영**해 주간 partition + 일일 preload 크론잡이 무인 실행되도록 함.

3가지 병목:
1. **create CopyStates가 HDD에선 사용 불가** (state trie 랜덤 I/O) — 수일 소요
2. **upload가 AWS S3 GLACIER archive 단계에서 hang** (온프렘→AWS 대용량 multipart PUT)
3. R2 업로드도 rclone 기본 단일스트림 윈도우 제한으로 **~0.6MB/s** (63G state = 28h)

## 변경 (전부 하위호환 — 다른 네트워크 영향 없음)

### `_snapshot_partition_helpers.tpl`
hybrid `volumeMode`가 이제:
- `chainDataVolume.hostPath` 지원 (PVC `name`뿐 아니라 host dir)
- 선택적 `txVolume.hostPath` → `/data/headless/tx`로 submount

→ store를 SSD에 두되 덩치 `tx` CF(268G)만 HDD에. 랜덤 I/O 많은 `states`가 SSD에 있어 CopyStates 감내 가능. new_states는 SSD store 루트의 일반 디렉토리로 생성됨(별도 마운트면 create의 `Directory.Delete`가 "Device or resource busy"로 실패).

### `partition/upload_snapshot.sh`
- `snapshot.archiveToS3` (기본 true): false면 S3 GLACIER archive 건너뛰고 **R2에 로컬에서 직접 업로드**
- `snapshot.rcloneUploadConcurrency` (기본 4): 병렬 청크 스트림 (pt6 16 → ~3.4MB/s)
- `snapshot.uploadSplitParts` (기본 true): false면 >4G 파일의 `.partNNN` 재업로드 생략 (download_snapshot.sh가 whole 파일로 폴백)
- 각 산출물은 **WAN을 1회만** 건넘 (1회 업로드 후 나머지 R2/internal 경로는 server-side copy)
- **metadata/latest.json를 마지막에** 발행 (zip+state+parts 다 올라간 뒤) → 공개 포인터가 미완성 state를 가리키는 창 제거

### `values.yaml`
위 3개 키 기본값 추가 (archiveToS3:true, rcloneUploadConcurrency:4, uploadSplitParts:true) + hybrid hostPath/txVolume 주석.

### `9c-pt6/network/odin.yaml`
`chainDataVolume.hostPath=/opt/odin-store` + `txVolume.hostPath=/data/snapshot-chain-data/tx`; `archiveToS3=false`, `rcloneUploadConcurrency=16`, `uploadSplitParts=false`.

## 검증
- `helm template`: pt6 렌더(hostPath store + tx submount + 튜닝값) + heimdall 렌더(기존 `/output` 레이아웃·기본값 유지, 회귀 없음) 확인
- 렌더된 `upload_snapshot.sh` → `bash -n` 통과

## ⚠️ 머지/재개 전 주의
- pt6 host dir(`/opt/odin-store`, `/data/snapshot-chain-data/tx`)이 존재해야 함 (이번 인시던트로 이미 존재).
- odin cronjob 2개는 현재 **suspend** 상태. 머지+pt6-odin sync 후 **수동 partition 잡으로 1회 검증 후** unsuspend 권장.
- 이 변경으로 pt6에서 동작은 하나, 주간 비용은 여전히 **create ~8h(CopyStates는 CPU-bound, SSD로도 못 줄임) + upload ~5h ≈ 13h**. 근본적 경량화는 더 빠른 SSD/망 노드로 재배치(PR #3371) 또는 bypassCopystates 채택 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)