### PR TITLE
feat(seasonpass): bump mainnet image to git-887fe57 (deploy #308 GQL-out-of-txn + #306 pool 60)

### DIFF
--- a/9c-main/external-services/values.yaml
+++ b/9c-main/external-services/values.yaml
@@ -27,7 +27,16 @@ volumeReclaimPolicy: "Retain"
 seasonpass:
   enabled: true
   image:
-    tag: "git-ba5228ce9985327092b3d0ea874620d3cade5721"
+    # SeasonPass #308 (fix/gql-outside-db-txn) — stacked on #306, so this bump
+    # ships both at once on top of the live ba5228c:
+    #   485b172  raise DB pool 30 -> 60 (absorb connection holds)        [#306]
+    #   887fe57  call cleared-stage RPC outside the DB transaction       [#308]
+    # The #308 refactor stops requests from holding a user_season_pass row
+    # lock idle-in-transaction across the slow GQL call, which was piling up
+    # claim FOR UPDATE waiters and exhausting the pool -> block-status /
+    # invalid-claim alarms. No migration coupling: the partial index (#307)
+    # is already applied live and the code works with or without it.
+    tag: "git-887fe57d97ef1524db91f3873e803c3689e0aeab"
 
   api:
     enabled: true


### PR DESCRIPTION
## What

Bumps the mainnet `seasonpass.image.tag` from `git-ba5228c` to `git-887fe57`.

#308 (`fix/gql-outside-db-txn`) is **stacked on #306**, so this single tag bump ships both on top of the currently-live `ba5228c`:

| commit | change | PR |
|---|---|---|
| `485b172` | raise DB pool 30 → 60 (absorb connection holds) | #306 |
| `887fe57` | call cleared-stage RPC **outside** the DB transaction | #308 |

(Live `ba5228c` already had `cc9e3f8` async `/ping` + `ba5228c` anyio threadpool cap.)

## Why

Repeated **block-status / invalid-claim** alarms (Assertible → PagerDuty / #9c-mainnet-alert). Root cause caught live via `pg_stat_activity`: a status request held a `user_season_pass` row lock **idle-in-transaction** for 150s+ while doing a slow `get_last_cleared_stage` GQL call. That piled up claim `SELECT ... FOR UPDATE` waiters (up to ~1300s), drove the SQLAlchemy pool to 30/30, and timed out every DB endpoint → both monitors tripped together.

#308 moves the GQL call out of the transaction in the three status paths (`get_default_usp` WORLD_CLEAR, `user_status`/`all_user_status` exp==0 refetch): capture the needed scalars, `rollback()` to release the connection/lock, **then** do the RPC. #306's pool 60 is the headroom backstop.

## Review

`code-reviewer` verdict: **merge — no blocking issues on the production money-path.**
- ✅ Verified: no `DetachedInstanceError` on happy path (FastAPI serializes before session teardown; expired-but-attached objects lazy-reload). `season_pass=` → `season_pass_id=` safe. No write loss. outer try/except handles RPC timeout without connection leak.
- 🟡 non-blocking follow-ups: (1) narrow `rollback()`→`commit()` concurrent-delete window can 500 on `ObjectDeletedError` (low probability — these rows are rarely deleted); (2) `expire_on_commit` lazy-reload adds extra checkouts at serialization (net-positive vs the long holds). 
- 🟢 minor: loop-var `pass_type` shadowing; status-endpoint test gap.

## Migrations

**None coupled.** The #307 partial index (`idx_claim_unsettled`) is already applied live, and this code works with or without it. Migrations are applied manually (no init-container/Job).

## Deploy

ArgoCD `9c-external-services` has no auto-sync — after merge, manual sync required:
```
kubectl -n argocd patch applications.argoproj.io 9c-external-services --type merge \
  -p '{"operation":{"initiatedBy":{"username":"admin"},"sync":{"revision":"HEAD"}}}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)