### PR TITLE
feat(seasonpass): bump mainnet image to git-52e16aa (deploy #309 tx-tracker + #306+#308)

### DIFF
--- a/9c-main/external-services/values.yaml
+++ b/9c-main/external-services/values.yaml
@@ -27,16 +27,20 @@ volumeReclaimPolicy: "Retain"
 seasonpass:
   enabled: true
   image:
-    # SeasonPass #308 (fix/gql-outside-db-txn) — stacked on #306, so this bump
-    # ships both at once on top of the live ba5228c:
+    # SeasonPass #309 (tx-tracker GQL-out-of-txn) — stacked on #308 -> #306, so
+    # this bump ships all three at once on top of the live 887fe57:
     #   485b172  raise DB pool 30 -> 60 (absorb connection holds)        [#306]
-    #   887fe57  call cleared-stage RPC outside the DB transaction       [#308]
-    # The #308 refactor stops requests from holding a user_season_pass row
-    # lock idle-in-transaction across the slow GQL call, which was piling up
-    # claim FOR UPDATE waiters and exhausting the pool -> block-status /
-    # invalid-claim alarms. No migration coupling: the partial index (#307)
-    # is already applied live and the code works with or without it.
-    tag: "git-887fe57d97ef1524db91f3873e803c3689e0aeab"
+    #   887fe57  API: call cleared-stage RPC outside the DB transaction  [#308]
+    #   52e16aa  tracker: run tx-tracker GQL outside the DB transaction  [#309]
+    # #308 stopped API requests from holding a user_season_pass row lock
+    # idle-in-transaction across the slow GQL call (was piling up claim FOR
+    # UPDATE waiters and exhausting the pool -> block-status / invalid-claim
+    # alarms). #309 fixes the same anti-pattern in the tx-tracker, whose
+    # SELECT-then-GQL held a transaction idle for minutes (observed 448s),
+    # pinning the xmin horizon and blocking autovacuum on claim/user_season_pass.
+    # No migration coupling: the partial index (#307) is already applied live and
+    # the code works with or without it.
+    tag: "git-52e16aa37a83974234e7fef449453b8654ce658c"
 
   api:
     enabled: true


### PR DESCRIPTION
## What

Bumps the mainnet `seasonpass.image.tag` from `git-887fe57` to `git-52e16aa`.

SeasonPass #309 (`tx-tracker GQL-out-of-txn`) is **stacked on #308 → #306**, so this single tag bump ships all three on top of the currently-live `887fe57`:

| commit | change | PR |
|---|---|---|
| `485b172` | raise DB pool 30 → 60 | #306 |
| `887fe57` | API: call cleared-stage RPC outside the DB transaction | #308 |
| `52e16aa` | tracker: run tx-tracker GQL outside the DB transaction | #309 |

The currently-live `887fe57` already includes #306+#308; this adds #309 on top, so the API behaviour is unchanged and only the tracker gains the fix.

## Why (#309)

Found while investigating the mainnet seasonpass DB after the #308 deploy. `tx_tracker.track_tx()` opened a session, `SELECT`ed up to 200 unsettled claims, then **held that transaction open** while it ran a per-claim headless GQL batch — sitting **idle-in-transaction for 448s** (observed live via `pg_stat_activity`) when a node was slow. It's a plain `SELECT` (no `FOR UPDATE`) so it blocked nothing and raised no alarms, but the long-lived transaction **pinned the xmin horizon and blocked autovacuum** on `claim` / `user_season_pass` (dead tuples in the hundreds of thousands; `user_season_pass` had never been autovacuumed).

#309 splits it into read → GQL (no txn) → write, with the write guarded (`id` + `tx_id` + still-`STAGED`/`INVALID`) so a settled `SUCCESS`/`FAILURE` is never clobbered by a stale GQL result.

## Review

`code-reviewer` verdict on #309: **merge — logic correct, read/write sessions independent & pool-safe, no money-path regression.** The one recommended hardening (the still-unsettled status guard on the write) is included in `52e16aa`.

## Migrations

**None coupled.** The #307 partial index is already applied live; the code works with or without it. Migrations are applied manually (no init-container/Job).

## Deploy

⚠️ The `git-52e16aa` image build was triggered by the #309 force-push and may still be in progress — **confirm the image is present on Docker Hub before syncing** (else ImagePullBackOff). ArgoCD `9c-external-services` has no auto-sync; after merge:
```
kubectl -n argocd patch applications.argoproj.io 9c-external-services --type merge \
  -p '{"operation":{"initiatedBy":{"username":"admin"},"sync":{"revision":"HEAD"}}}'
```

Note: season-pass #309 is a stacked PR (base `fix/gql-outside-db-txn`); for repo hygiene merge the stack in order #306 → #308 → #309 to main afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)