### PR TITLE
feat(seasonpass): bump mainnet image to git-bfbe0b2 (deploy #310 status-backfill lock fix + full stack)

### DIFF
--- a/9c-main/external-services/values.yaml
+++ b/9c-main/external-services/values.yaml
@@ -27,20 +27,25 @@ volumeReclaimPolicy: "Retain"
 seasonpass:
   enabled: true
   image:
-    # SeasonPass #309 (tx-tracker GQL-out-of-txn) — stacked on #308 -> #306, so
-    # this bump ships all three at once on top of the live 887fe57:
+    # SeasonPass #310 (status backfill: drop early row lock) — stacked on
+    # #309 -> #308 -> #306, so this bump ships the whole stack on top of live
+    # 52e16aa:
     #   485b172  raise DB pool 30 -> 60 (absorb connection holds)        [#306]
     #   887fe57  API: call cleared-stage RPC outside the DB transaction  [#308]
     #   52e16aa  tracker: run tx-tracker GQL outside the DB transaction  [#309]
-    # #308 stopped API requests from holding a user_season_pass row lock
-    # idle-in-transaction across the slow GQL call (was piling up claim FOR
-    # UPDATE waiters and exhausting the pool -> block-status / invalid-claim
-    # alarms). #309 fixes the same anti-pattern in the tx-tracker, whose
-    # SELECT-then-GQL held a transaction idle for minutes (observed 448s),
-    # pinning the xmin horizon and blocking autovacuum on claim/user_season_pass.
+    #   bfbe0b2  API: resolve level before mutating target in backfill   [#310]
+    # #310 is the durable fix for the recurring lock convoy: the WorldClear
+    # on-read backfill set target.exp then called get_level(), whose SELECT
+    # autoflushed an UPDATE user_season_pass and took the row lock across the
+    # whole block. Concurrent polling of the same avatars + claim's FOR UPDATE
+    # convoyed and exhausted the pool -> block-status / invalid-claim alarms.
+    # The reorder (compute level first) keeps the row lock to the commit flush
+    # only; behaviour is unchanged. Complements the live ALTER ROLE timeouts
+    # (lock_timeout=10s / idle_in_transaction_session_timeout=60s /
+    # statement_timeout=30s) applied as the safety net.
     # No migration coupling: the partial index (#307) is already applied live and
     # the code works with or without it.
-    tag: "git-52e16aa37a83974234e7fef449453b8654ce658c"
+    tag: "git-bfbe0b2ccd1905f4d9dee59363b38e2755b79ed5"
 
   api:
     enabled: true


### PR DESCRIPTION
## What

Bumps the mainnet `seasonpass.image.tag` from `git-52e16aa` to `git-bfbe0b2`.

SeasonPass #310 is **stacked on #309 → #308 → #306**, so this single tag bump ships the whole stack on top of the currently-live `52e16aa`:

| commit | change | PR |
|---|---|---|
| `485b172` | raise DB pool 30 → 60 | #306 |
| `887fe57` | API: call cleared-stage RPC outside the DB transaction | #308 |
| `52e16aa` | tracker: run tx-tracker GQL outside the DB transaction | #309 |
| `bfbe0b2` | API: resolve level before mutating target in backfill | #310 |

The live `52e16aa` already includes #306+#308+#309; this adds #310 on top.

## Why (#310)

Durable fix for the **recurring lock convoy** (block-status / invalid-claim alarms that re-fired after #308/#309). The WorldClear on-read backfill in `user_status`/`all_user_status` set `target.exp` and then called `get_level()`, whose SELECT **autoflushed an `UPDATE user_season_pass`** — taking the row lock *before* the SELECT and holding it across the rest of the block. Concurrent polling of the same popular avatars + claim's `SELECT ... FOR UPDATE` on the same rows convoyed and exhausted the pool.

The reorder (resolve the level from `cleared_stage` **before** mutating `target`) means the only write is the single `UPDATE` at commit, so the row lock is held just for that flush. **Behaviour and persisted `exp`/`level` are unchanged** (`get_level(cleared_stage) == get_level(target.exp)`).

## Tests

Adds the first regression tests for the status endpoints (`apps/api/tests/test_user_status.py`): zero-exp backfill persisted, non-zero left untouched + RPC skipped, `cleared_stage==0` stays zero, and `/status/all`. 4 pass against the local-postgres harness; the only suite failures are the pre-existing `test_burn_asset_*` (local Celery/redis unavailable), confirmed failing identically on the base.

## Safety net already live

`ALTER ROLE seasonpass` timeouts are already applied on mainnet (`lock_timeout=10s` / `idle_in_transaction_session_timeout=60s` / `statement_timeout=30s`), so even a residual convoy can't spiral. #310 removes the convoy at the source.

## Migrations

**None coupled.** The #307 partial index is already applied live; the code works with or without it.

## Deploy

⚠️ The `git-bfbe0b2` image build was triggered by the #310 push and may still be in progress — **confirm it's on Docker Hub before syncing** (else ImagePullBackOff). ArgoCD `9c-external-services` has no auto-sync; after merge:
```
kubectl -n argocd patch applications.argoproj.io 9c-external-services --type merge \
  -p '{"operation":{"initiatedBy":{"username":"admin"},"sync":{"revision":"HEAD"}}}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)