### PR TITLE
feat(iap): bump mainnet+internal to git-9269aa2 (PLD-1357 season-pass exclusion)

### DIFF
--- a/9c-internal/external-services/values.yaml
+++ b/9c-internal/external-services/values.yaml
@@ -85,14 +85,14 @@ iap:
   backoffice:
     enabled: false
     image:
-      tag: "git-16af6a99a49d66857f0feb3ced1b78c45c0159a4"
+      tag: "git-9269aa2d47ea90b94ea9c749366fae14da8695e4"
 
 
   api:
     enabled: true
     stage: "internal"
     image:
-      tag: "git-16af6a99a49d66857f0feb3ced1b78c45c0159a4"
+      tag: "git-9269aa2d47ea90b94ea9c749366fae14da8695e4"
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-internal-v2-seasonpass-worker"
 
@@ -100,6 +100,6 @@ iap:
     enabled: true
     stage: "internal"
     image:
-      tag: "git-16af6a99a49d66857f0feb3ced1b78c45c0159a4"
+      tag: "git-9269aa2d47ea90b94ea9c749366fae14da8695e4"
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-internal-v2-iap-worker"

--- a/9c-main/external-services/values.yaml
+++ b/9c-main/external-services/values.yaml
@@ -132,13 +132,13 @@ iap:
   backoffice:
     enabled: false
     image:
-      tag: "git-1f5add5c11506199b4a6dc7f7128f395400f632a"
+      tag: "git-9269aa2d47ea90b94ea9c749366fae14da8695e4"
 
   api:
     enabled: true
     stage: "mainnet"
     image:
-      tag: "git-1f5add5c11506199b4a6dc7f7128f395400f632a"
+      tag: "git-9269aa2d47ea90b94ea9c749366fae14da8695e4"
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-main-v2-iap-worker"
 
@@ -151,7 +151,7 @@ iap:
     enabled: true
     stage: "mainnet"
     image:
-      tag: "git-1f5add5c11506199b4a6dc7f7128f395400f632a"
+      tag: "git-9269aa2d47ea90b94ea9c749366fae14da8695e4"
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-main-v2-iap-worker"
 


### PR DESCRIPTION
## Summary

Rolls out the IAP fix for **PLD-1357** to both **mainnet** and **internal** environments. Bumps `iap.backoffice`, `iap.api`, and `iap.worker` image tags — keeping the three in lockstep with the prior pattern (previous bump #466 followed the same convention).

**Source PR**: https://github.com/planetarium/NineChronicles.IAP/pull/468 (still open at time of writing — please merge that first, then this)

**New tag**: `git-9269aa2d47ea90b94ea9c749366fae14da8695e4` (built by CI, both `iap-api` and `iap-worker` Docker builds succeeded)

**Diff**: 6 line changes across 2 files
- `9c-main/external-services/values.yaml`: `git-1f5add5c…` → `git-9269aa2d…`
- `9c-internal/external-services/values.yaml`: `git-16af6a99…` → `git-9269aa2d…`

## What the fix does

`GET /api/admin/stats/product-sales` no longer includes season-pass style purchases (google_sku containing `pass`) in FAV/Item aggregation. These grants are actually performed by the SeasonPass service (see `purchase.py`'s `if "pass" in product.google_sku:` branch), so having them in IAP stats was causing them to be double-counted against SeasonPass's own `reward-claims` stats in the 9c-backoffice **Token Distribution** report.

## Impact scope

Only affects `/api/admin/stats/product-sales`. No changes to purchase flow, worker, other stats endpoints, or DB schema.

Downstream consumers of this endpoint (all in 9c-backoffice — no other repo hits this URL):
- `/products/sales-stats` Blazor page (IAP-only view — pass rows will disappear)
- `/stats/token-distribution` Blazor page (**combined view — double-count fixed**)
- `GET /api/iap/stats/product-sales` (backoffice REST proxy)
- `GET /api/stats/token-distribution` (backoffice REST proxy)

## Verification plan

- [ ] Merge source PR #468 first so this deploys code that's actually on `main`
- [ ] Wait for ArgoCD sync on **internal**; open 9c-backoffice → `/stats/token-distribution` (Internal 환경) → spot-check that pass tickers no longer appear twice
- [ ] Also verify `/products/sales-stats` (Internal) — pass tickers should be absent
- [ ] Once internal looks good, monitor mainnet rollout via ArgoCD
- [ ] Note: past monthly reports queried after this deploys will return lower IAP-side numbers than before — that's the intended fix (previous values were inflated by double-counting)

## Notes

- Currently pinned to the **fix branch head SHA** rather than a main merge commit, since the source PR is still awaiting review. If reviewers prefer to wait until #468 merges and re-pin to the merge commit, that's a one-line follow-up.
- `iap.backoffice.enabled` is `false` in both envs but its tag is bumped for lockstep consistency (matches the prior convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)