### PR TITLE
feat(iap): bump mainnet+internal to git-9321af4 (PLD-1349 product-import fix)

### DIFF
--- a/9c-internal/external-services/values.yaml
+++ b/9c-internal/external-services/values.yaml
@@ -85,14 +85,14 @@ iap:
   backoffice:
     enabled: false
     image:
-      tag: "git-9269aa2d47ea90b94ea9c749366fae14da8695e4"
+      tag: "git-9321af4246edb846db69a2c43df63cfbad5cfa16"
 
 
   api:
     enabled: true
     stage: "internal"
     image:
-      tag: "git-9269aa2d47ea90b94ea9c749366fae14da8695e4"
+      tag: "git-9321af4246edb846db69a2c43df63cfbad5cfa16"
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-internal-v2-seasonpass-worker"
 
@@ -100,6 +100,6 @@ iap:
     enabled: true
     stage: "internal"
     image:
-      tag: "git-9269aa2d47ea90b94ea9c749366fae14da8695e4"
+      tag: "git-9321af4246edb846db69a2c43df63cfbad5cfa16"
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-internal-v2-iap-worker"

--- a/9c-main/external-services/values.yaml
+++ b/9c-main/external-services/values.yaml
@@ -132,13 +132,13 @@ iap:
   backoffice:
     enabled: false
     image:
-      tag: "git-9269aa2d47ea90b94ea9c749366fae14da8695e4"
+      tag: "git-9321af4246edb846db69a2c43df63cfbad5cfa16"
 
   api:
     enabled: true
     stage: "mainnet"
     image:
-      tag: "git-9269aa2d47ea90b94ea9c749366fae14da8695e4"
+      tag: "git-9321af4246edb846db69a2c43df63cfbad5cfa16"
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-main-v2-iap-worker"
 
@@ -151,7 +151,7 @@ iap:
     enabled: true
     stage: "mainnet"
     image:
-      tag: "git-9269aa2d47ea90b94ea9c749366fae14da8695e4"
+      tag: "git-9321af4246edb846db69a2c43df63cfbad5cfa16"
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-main-v2-iap-worker"
 


### PR DESCRIPTION
## Summary

Bumps IAP image tags on both **mainnet** and **internal** to the latest main tip (`git-9321af4246edb846db69a2c43df63cfbad5cfa16`), which is the merge commit of [#469 (PLD-1349)](https://github.com/planetarium/NineChronicles.IAP/pull/469).

**Previous tag** (from [#3503](https://github.com/planetarium/9c-infra/pull/3503) PLD-1357 bump): `git-9269aa2d47ea90b94ea9c749366fae14da8695e4`  
**New tag**: `git-9321af4246edb846db69a2c43df63cfbad5cfa16`

## What this deploys (delta since last bump)

- **PLD-1349** — `POST /admin/products/import` no longer 400s when a CSV leaves `mileage` or `order` blank. `parse_int` grew a `default=` kwarg; the two NOT-NULL numeric columns coalesce to their DB defaults (0 / -1) instead of writing NULL and rolling back the whole batch. See [#469](https://github.com/planetarium/NineChronicles.IAP/pull/469).
- Cleanup: deleted three dead files under `apps/shared/shared/utils/` (`import_utils.py`, `r2.py`, `s3.py`) — 2024 restructure leftovers with zero importers. Not user-visible; no runtime impact.

## Diff

6 line changes across 2 files, `iap.backoffice/api/worker` all kept in lockstep with the same SHA (matches the pattern of prior IAP bumps including #3503).

- `9c-main/external-services/values.yaml`: `git-9269aa2d…` → `git-9321af42…` (×3)
- `9c-internal/external-services/values.yaml`: `git-9269aa2d…` → `git-9321af42…` (×3)

## Verification

- Source PR merged: [#469](https://github.com/planetarium/NineChronicles.IAP/pull/469) merged at 2026-07-01T07:16:34Z into `main`
- Docker builds succeeded for both `planetariumhq/iap-api:git-9321af42…` and `planetariumhq/iap-worker:git-9321af42…`

## Test plan

- [ ] Wait for ArgoCD sync on **internal**
- [ ] Retry the PLD-1349 repro: upload the failing product CSV (`9c_iap_list_-_product_0526.csv` or similar with blank `mileage`) to internal via 9c-backoffice → expect `200`, no batch rollback
- [ ] Spot-check `SELECT id, mileage, "order" FROM product` on internal — blank cells land on DB defaults
- [ ] Once internal is validated, monitor mainnet rollout via ArgoCD

🤖 Generated with [Claude Code](https://claude.com/claude-code)