### PR TITLE
Bump 9c-main backoffice image to PLD-1351 (git-d945d34)

### DIFF
--- a/9c-main/external-services/values.yaml
+++ b/9c-main/external-services/values.yaml
@@ -124,7 +124,7 @@ backoffice:
 
   image:
     pullPolicy: Always
-    tag: "git-f6382618f1c2e72a8e88fbbc5c61d8bf3f5574f9"
+    tag: "git-d945d346ac524e5f9cdab2334e607472e10ca443"
 
 
 iap:


### PR DESCRIPTION
## 요약
9c-main 백오피스(`planetariumhq/nine-chronicles-backoffice`) 이미지를 PLD-1351 변경이 포함된 태그로 업데이트합니다.

- 대상: `9c-main/external-services/values.yaml` → `backoffice.image.tag`
- `git-f6382618...` (`Bump lib9c`) → **`git-d945d346ac524e5f9cdab2334e607472e10ca443`**

## 배포 내용 (NineChronicles.Backoffice PLD-1351 / PR #80)
공지생성기가 GitHub PR을 만들어 수동 머지하던 흐름을 제거하고, 공지 JSON을 `9c-assets` S3 버킷(`live-assets/Json/TextNotice{,_JP,_KR}.json`)에 직접 업로드 + CloudFront 무효화로 즉시 반영하도록 변경한 버전입니다. (NCU/이벤트 배너와 동일 방식)

- 백오피스 PR: planetarium/NineChronicles.Backoffice#80

## 참고
- 이 태그(`git-d945d34...`)는 백오피스 PR #80의 **PR 헤드 커밋 이미지**입니다. 백오피스 PR #80 CI가 해당 이미지를 빌드/푸시한 뒤 이 인프라 PR을 머지해야 합니다.
- 백오피스 실행 환경에 `NC_AWS_*` + `NC_CLOUDFRONT_DISTRIBUTION_ID` 및 `9c-assets` 쓰기/CloudFront 무효화 권한 필요(NCU/이벤트 기능이 이미 사용 중).

🤖 Generated with [Claude Code](https://claude.com/claude-code)