### PR TITLE
chore(ragnarok-breaker): pin production worker image to git-55f0ca0

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-55f0ca0126a2d3daebc63d2c616d638127c97cdb
 
 v8Gateway:
   image:

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-55f0ca0126a2d3daebc63d2c616d638127c97cdb
 
 v8Gateway:
   image:


### PR DESCRIPTION
Pin `ragnarok-breaker-worker` to `git-55f0ca0126a2d3daebc63d2c616d638127c97cdb` for production (prod-web2 + prod-web3). Worker-only bump; other services unchanged.

Brings the prod anti-cheat worker up to current develop (from `git-35a74b366`, 2026-06-19):
- Anti-cheat false-positive reductions (RB MR !1055): shop summon-pet DPS in spec reconstruction, clear-time quantization margin, one-directional SCORE_RECONSTRUCTION, and the score-ceiling gate for DPS-feasibility checks.
- LEAGUE added to the worker eventual-sweep post-validation (RB-1712 / W6).

## Prerequisite (Firestore index)
The eventual sweep now also polls LEAGUE (in addition to DEGEN_LEAGUE), which requires the composite index `leagueHistory: validated(asc) + createdAt(asc)` (query scope: collection) in each prod verse's Firestore — same shape already present for stageHistory/valhallaHistory, and being created for degenLeagueHistory. Create the leagueHistory index before/with this rollout to avoid `FAILED_PRECONDITION` on LEAGUE polls.

## Test plan
- [ ] After ArgoCD sync, prod-web2/web3 worker pods pull `git-55f0ca01...` successfully
- [ ] worker logs show `queryUnvalidatedRecords` for STAGE/VALHALLA/DEGEN_LEAGUE/LEAGUE without `FAILED_PRECONDITION`
