### PR TITLE
chore(ragnarok-breaker): pin prod worker to git-bbad6ee, realign anticheat-alert to live git-e3545d1

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-55f0ca0126a2d3daebc63d2c616d638127c97cdb
+    tag: git-bbad6ee167f7be3f42b4b3da5b9a7120b0a532ec
 
 v8Gateway:
   image:
@@ -35,4 +35,4 @@ bqAnalyticsWorker:
 anticheatAlertWorker:
   enabled: true
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-e3545d1e3869858b336d85cdd20695d7a22cd828

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-55f0ca0126a2d3daebc63d2c616d638127c97cdb
+    tag: git-bbad6ee167f7be3f42b4b3da5b9a7120b0a532ec
 
 v8Gateway:
   image:
@@ -39,7 +39,7 @@ bqAnalyticsWorker:
 anticheatAlertWorker:
   enabled: true
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-e3545d1e3869858b336d85cdd20695d7a22cd828
 
 # Single shared ingest gateway for all payment envs (no app_env split) —
 # the only namespace that hosts it. The bulk `bump-image rb <hash>` keeps this


### PR DESCRIPTION
프로덕션(prod-web2 + prod-web3) ragnarok-breaker 이미지를 **실제 배포 상태에 맞춰** 정렬 + worker bump.

## 변경
- `worker`: `git-55f0ca0` → `git-bbad6ee167f7be3f42b4b3da5b9a7120b0a532ec` — petpop develop `bbad6ee` (MR !1178, SPAWN_BOTTLENECK 오탐 수정 = 적용 난이도 SPAWN 배율 반영) 병합 커밋. build:worker 파이프라인 51285 성공(재시도 job 321804; 최초는 Docker Hub 푸시 일시오류 `invalid content range`).
- `anticheatAlertWorker`: `git-35a74b3` → `git-e3545d1e3869858b336d85cdd20695d7a22cd828` — **드리프트 정정**. main 은 bulk bump #3485 로 `git-35a74b3` 이나 클러스터는 `git-e3545d1`(커밋 5c215729 "anti-cheat alert Verse/Stage 표시")가 정상 가동 중. 이 상태로 싱크하면 존재하지 않는 `35a74b3` 이미지로 되돌아가 alert worker 가 깨지므로 live 로 맞춤.

## 정렬 확인 (context=default/prod, 2026-07-03)
logStream / v8Gateway / bqAnalyticsWorker / ygg-* / bqIngestGateway 는 이미 live=main(`git-35a74b3`) 이라 무변경. 머지+싱크 후 클러스터에서 실제로 바뀌는 건 **worker** 뿐.

## Test plan
- [ ] After sync, worker(stage/league-validation) pods pull git-bbad6ee successfully
- [ ] anticheat-alert-worker pods stay on git-e3545d1 (no revert)