### PR TITLE
fix(longhorn): auto-apply filesystem-trim on headless node/validator StorageClass

### DIFF
--- a/charts/all-in-one/templates/storageclass-longhorn.yaml
+++ b/charts/all-in-one/templates/storageclass-longhorn.yaml
@@ -11,6 +11,11 @@ parameters:
   numberOfReplicas: '1'
   staleReplicaTimeout: '2880'
   nodeSelector: {{ .Release.Name }}
+  # Auto-apply periodic filesystem-trim to volumes provisioned by this SC
+  # (headless rpc/validator nodes + heimdall bridge-service). Without trim,
+  # RocksDB compaction churn bloats the sparse Longhorn replica far past the
+  # live fs usage and eventually fills the node disk (ENOSPC → replica faulted).
+  recurringJobSelector: '[{"name":"filesystem-trim","isGroup":false}]'
 provisioner: driver.longhorn.io
 reclaimPolicy: {{ .Values.volumeReclaimPolicy }}
 allowVolumeExpansion: true


### PR DESCRIPTION
## 배경 (2026-07-05 heimdall rpc-1 장애)

heimdall **rpc-1(remote-headless-1)** 이 `/data/headless` **I/O error**로 CrashLoop → 근본원인은 **Longhorn filesystem-trim 누락으로 인한 sparse replica bloat**.

- `<network>-longhorn` SC로 만든 headless rpc/validator 볼륨에 주기적 fs-trim이 안 걸려 있었음 (recurring job 2개가 `groups: []` → default 그룹에 배정된 job 없음)
- RocksDB compaction이 같은 논리공간을 계속 재기록 → discard 없으니 스냅샷 체인에 옛 블록 잔류 → **물리 replica가 686 GiB로 부풀음** (파일시스템 실사용은 ~25%뿐)
- heimdall-2 노드 디스크(687Gi) 100% full → 단일 replica ENOSPC fault → volume faulted → headless CrashLoop

복구는 완료(faulted 볼륨 삭제로 686Gi 회수 → validator-5 live-clone → txexec 삭제 → 재기동, tip 동기화 확인). 기존 rpc/validator 볼륨은 수동 라벨로 이미 트림 커버됨. **이 PR은 재발 방지(미래 볼륨 자동 트림).**

## 변경

`charts/all-in-one/templates/storageclass-longhorn.yaml` 의 `{{ .Release.Name }}-longhorn` SC에 `recurringJobSelector` 한 줄 추가:

```yaml
recurringJobSelector: '[{"name":"filesystem-trim","isGroup":false}]'
```

이 SC로 프로비저닝되는 **미래 볼륨이 자동으로 기존 `filesystem-trim` recurring job을 부여**받습니다.

## 스코프

| SC | 자동 트림 대상 |
|---|---|
| odin-longhorn | remote-headless(rpc+validator) 전용 ✅ |
| thor-longhorn | remote-headless(rpc+validator) 전용 ✅ |
| heimdall-longhorn | rpc+validator **+ bridge-service(의도)** + data-provider(현재 idle) |

monitoring / rmq / snapshot 볼륨은 **다른 SC** 사용 → 영향 없음.

## 롤아웃 주의

- **SC parameters는 immutable** → sync 시 SC를 **replace(또는 수동 delete 후 sync)** 해야 반영됨. ArgoCD가 immutable 필드 변경 apply 에러낼 수 있음.
- **기존 PV/PVC 바인딩엔 무영향** (SC는 프로비저닝 시점에만 사용). 기존 볼륨은 수동 라벨로 이미 커버.
- 참조하는 `filesystem-trim` RecurringJob CR은 현재 클러스터에 존재(338d). 추후 이 CR도 차트화 고려 가능.

## 테스트

- SC 템플릿 변경은 정적 문자열 추가라 렌더 로직 무영향. (로컬 `helm template` 전체 렌더는 ArgoCD가 조합하는 network values 필요 — 무관 서브차트 템플릿에서만 실패)

🤖 Generated with [Claude Code](https://claude.com/claude-code)