### PR TITLE
Add ragnarok-breaker mail-send-worker (staging-web2)

### DIFF
--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -30,3 +30,15 @@ bqAnalyticsWorker:
   enabled: false
   image:
     tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+
+# 메일 지급 워커 — staging 검증용 활성화.
+# ⚠️ tag placeholder: ragnarok-breaker-mail-send-worker 이미지는 petpop MR !1210(build:mail-send-worker
+#    CI 잡 신설) 이 petpop main 에 머지되어 빌드·push 된 뒤에 존재한다. 그 git-<sha> 로 아래 tag 를
+#    bump 해야 ImagePullBackOff 없이 뜬다.
+# ⚠️ AWS SM ragnarok-breaker/staging-web2 에 다음 키 선행 추가 필요: MAIL_SENDER_V8_ACCOUNT,
+#    MAIL_SENDER_V8_VERSE(=staging-w2 verse), MAIL_SENDER_V8_ENV, MAIL_SENDER_V8_AUTH,
+#    MAIL_SEND_SLACK_WEBHOOK, MAIL_SEND_LIMITER_MAX, MAIL_SEND_LIMITER_MS (REDIS_URL 은 기존 공유).
+mailSendWorker:
+  enabled: true
+  image:
+    tag: git-PENDING-CI-BUILD

--- a/charts/ragnarok-breaker/templates/mail-send-worker-deployment.yaml
+++ b/charts/ragnarok-breaker/templates/mail-send-worker-deployment.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.mailSendWorker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mail-send-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: mail-send-worker
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: mail-send-worker
+spec:
+  replicas: {{ .Values.mailSendWorker.deployment.replicas }}
+  # 단일 큐 소비자 + 전용 mail-sender 세션 → 롤아웃 중 두 파드 동시 소비 방지.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: mail-send-worker
+  template:
+    metadata:
+      labels:
+        app: mail-send-worker
+    spec:
+      {{- if .Values.imagePullSecret.secretKey }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret.name }}
+      {{- end }}
+      containers:
+        - name: mail-send-worker
+          image: "{{ .Values.mailSendWorker.image.repository }}:{{ .Values.mailSendWorker.image.tag }}"
+          imagePullPolicy: {{ .Values.mailSendWorker.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.mailSendWorker.deployment.port }}
+          env:
+            # HTTP /enqueue 서버 포트. 나머지 env(MAIL_SENDER_V8_*, MAIL_SEND_SLACK_WEBHOOK,
+            # MAIL_SEND_LIMITER_*, REDIS_URL) 는 ragnarok-breaker-env(AWS SM) 에서 주입.
+            - name: MAIL_SEND_HTTP_PORT
+              value: {{ .Values.mailSendWorker.deployment.port | quote }}
+          envFrom:
+            - secretRef:
+                name: ragnarok-breaker-env
+          # mail-send 는 별도 health 엔드포인트가 없으므로 TCP 로 포트 리스닝만 확인.
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.mailSendWorker.deployment.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.mailSendWorker.deployment.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.mailSendWorker.deployment.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mail-send-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: mail-send-worker
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: mail-send-worker
+spec:
+  # 내부 전용(ClusterIP) — 운영자는 port-forward 로 /enqueue 에 POST. 외부 노출 없음.
+  type: ClusterIP
+  selector:
+    app: mail-send-worker
+  ports:
+    - name: http
+      port: {{ .Values.mailSendWorker.service.port }}
+      targetPort: {{ .Values.mailSendWorker.deployment.port }}
+      protocol: TCP
+{{- end }}

--- a/charts/ragnarok-breaker/values.yaml
+++ b/charts/ragnarok-breaker/values.yaml
@@ -194,6 +194,32 @@ anticheatAlertWorker:
       cpu: 500m
       memory: 512Mi
 
+# === Mail payout worker (BullMQ mail-send consumer + HTTP /enqueue) ===
+# recipient 1인 = job 1개 소비 → 전용 mail-sender V8 세션으로 sendMailIdempotent 호출.
+# HTTP /enqueue 는 운영자 mail.send 토큰 검증 후 job 투입. 기본 off — env 별 override 에서 enable.
+# 다른 워커(services/worker, BullMQ prefix 'worker')와 같은 Redis DB(REDIS_URL)를 공유하되
+# prefix 'mail-send' 로 키 공간 분리. 필요 env(ragnarok-breaker-env AWS SM): MAIL_SENDER_V8_ACCOUNT,
+# MAIL_SENDER_V8_VERSE, MAIL_SENDER_V8_ENV, MAIL_SENDER_V8_AUTH[, MAIL_SENDER_V8_REMOTE_URL],
+# MAIL_SEND_SLACK_WEBHOOK, MAIL_SEND_LIMITER_MAX, MAIL_SEND_LIMITER_MS, REDIS_URL.
+mailSendWorker:
+  enabled: false
+  image:
+    repository: planetariumhq/ragnarok-breaker-mail-send-worker
+    tag: develop
+    pullPolicy: IfNotPresent
+  service:
+    port: 3100
+  deployment:
+    replicas: 1
+    port: 3100
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
 # === External payment backend → BigQuery analytics ingest gateway ===
 # Thin HTTP gateway (Bun.serve): POST /v1/events (Bearer auth) validates the
 # envelope and enqueues a bq_event job onto the bq-analytics-events BullMQ


### PR DESCRIPTION
## Summary
Adds the `mail-send-worker` (ragnarok-breaker mail payout worker) to the `ragnarok-breaker` chart and enables it on **staging-web2 only** for now.

- `charts/ragnarok-breaker/templates/mail-send-worker-deployment.yaml` — Deployment (single replica, Recreate) + internal ClusterIP Service for the HTTP `/enqueue` endpoint. `envFrom: ragnarok-breaker-env`, tcpSocket probes, default `enabled: false`.
- `charts/ragnarok-breaker/values.yaml` — `mailSendWorker` defaults (image, port 3100, resources).
- `9c-internal/ragnarok-breaker-staging-web2/values.yaml` — `enabled: true` + tag placeholder.

Shares one Redis DB with the existing `worker` (via `REDIS_URL`) but a distinct BullMQ prefix (`mail-send` vs `worker`) so key spaces do not collide.

## Prereqs before it runs on staging (not blocking merge; ImagePullBackOff / auth failures until done)
1. **Image tag** — bump `mailSendWorker.image.tag` in staging-web2 from the `git-PENDING-CI-BUILD` placeholder to the `git-<sha>` produced by the petpop `build:mail-send-worker` CI job. That job ships in petpop MR !1210 and first pushes the image when !1210 merges to petpop `main`.
2. **AWS SM `ragnarok-breaker/staging-web2`** — add `MAIL_SENDER_V8_ACCOUNT`, `MAIL_SENDER_V8_VERSE` (staging-w2 verse), `MAIL_SENDER_V8_ENV`, `MAIL_SENDER_V8_AUTH`, `MAIL_SEND_SLACK_WEBHOOK`, `MAIL_SEND_LIMITER_MAX`, `MAIL_SEND_LIMITER_MS`. (`REDIS_URL` already shared.)
3. The `MAIL_SENDER_V8_ACCOUNT` must be registered in petpop `admin.ts` ROLE_ACCOUNTS.mailSendWorker with the `mail.send` permission.

🤖 Generated with Claude Code