### PR TITLE
Repin mail-send-worker staging-web2 to fixed image (git-2661018f2)

### DIFF
--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -39,4 +39,4 @@ bqAnalyticsWorker:
 mailSendWorker:
   enabled: true
   image:
-    tag: git-00b238563ba03c1d6fad23b5e0eb19ed252b58d6
+    tag: git-2661018f2dc44c9484398f7b14ad27e0e0388f45


### PR DESCRIPTION
## Summary
Repin the `mail-send-worker` staging-web2 image to `git-2661018f2dc44c9484398f7b14ad27e0e0388f45`.

The earlier pin (`git-00b238563`, merged in the previous PR) points to an image that **crashes at runtime**: `Cannot find module '@rb/v8-client/polyfills'` — the mail-send-worker Dockerfile was missing the workspace source COPYs (`packages/shared`, `packages/v8-client`). That was fixed in petpop, and `git-2661018f2` is the image built after the fix.

Merge to let ArgoCD roll staging-web2 forward to the working image.

🤖 Generated with Claude Code