### PR TITLE
Expose mail-send-worker via HTTPRoute (rb-mail-send-staging.9c.gg)

### DIFF
--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -40,3 +40,7 @@ mailSendWorker:
   enabled: true
   image:
     tag: git-2661018f2dc44c9484398f7b14ad27e0e0388f45
+  httpRoute:
+    enabled: true
+    hostnames:
+      - rb-mail-send-staging.9c.gg

--- a/charts/ragnarok-breaker/templates/mail-send-worker-httproute.yaml
+++ b/charts/ragnarok-breaker/templates/mail-send-worker-httproute.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.mailSendWorker.enabled .Values.mailSendWorker.httpRoute.enabled .Values.mailSendWorker.httpRoute.hostnames }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mail-send-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: mail-send-worker
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: mail-send-worker
+spec:
+  parentRefs:
+    - name: {{ .Values.mailSendWorker.httpRoute.gatewayName }}
+      namespace: {{ .Values.mailSendWorker.httpRoute.gatewayNamespace }}
+      sectionName: web
+    - name: {{ .Values.mailSendWorker.httpRoute.gatewayName }}
+      namespace: {{ .Values.mailSendWorker.httpRoute.gatewayNamespace }}
+      sectionName: websecure
+  hostnames:
+    {{- range .Values.mailSendWorker.httpRoute.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: mail-send-worker
+          port: {{ .Values.mailSendWorker.service.port }}
+{{- end }}

--- a/charts/ragnarok-breaker/values.yaml
+++ b/charts/ragnarok-breaker/values.yaml
@@ -219,6 +219,11 @@ mailSendWorker:
       limits:
         cpu: 500m
         memory: 512Mi
+  httpRoute:
+    enabled: false
+    hostnames: []
+    gatewayName: traefik-gateway
+    gatewayNamespace: traefik
 
 # === External payment backend → BigQuery analytics ingest gateway ===
 # Thin HTTP gateway (Bun.serve): POST /v1/events (Bearer auth) validates the


### PR DESCRIPTION
## Summary
Expose the `mail-send-worker` `/enqueue` endpoint externally via a Gateway API HTTPRoute (mirrors ygg-redeem), on **rb-mail-send-staging.9c.gg** for staging-web2.

- `charts/ragnarok-breaker/templates/mail-send-worker-httproute.yaml` — HTTPRoute (traefik gateway web/websecure), PathPrefix `/` → `mail-send-worker` Service :3100.
- `charts/ragnarok-breaker/values.yaml` — `mailSendWorker.httpRoute` defaults (enabled:false).
- `9c-internal/ragnarok-breaker-staging-web2/values.yaml` — enable + hostname `rb-mail-send-staging.9c.gg`.

Every request is still gated by the worker's operator auth (`assertMailSendPermission` bearer), so exposure does not bypass the mail.send permission check.

🤖 Generated with Claude Code