### PR TITLE
Rename mail-send-worker staging HTTPRoute host to -web2 domain

### DIFF
--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -43,4 +43,4 @@ mailSendWorker:
   httpRoute:
     enabled: true
     hostnames:
-      - rb-mail-send-staging.9c.gg
+      - rb-mail-send-staging-web2.9c.gg


### PR DESCRIPTION
## What

staging mail-send-worker 의 HTTPRoute 호스트명을 web2 네이밍 규칙에 맞게 변경합니다.

`rb-mail-send-staging.9c.gg` → `rb-mail-send-staging-web2.9c.gg`

## Why

PR #3514 에서 HTTPRoute 를 처음 노출할 때 옛 도메인(`rb-mail-send-staging.9c.gg`)으로 머지됐습니다. staging 은 web2/web3 를 호스트명으로 구분하므로 mail-send-worker(web2) 도 `-web2` suffix 로 통일합니다. 실제 워커 배포/시크릿은 `ragnarok-breaker-staging-web2` 네임스페이스이며 코드도 `-web2` 도메인을 기대합니다.

## Scope

- `9c-internal/ragnarok-breaker-staging-web2/values.yaml` 한 줄 (hostname)

ArgoCD sync 시 HTTPRoute 호스트가 교체됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)