### PR TITLE
Enable mail-send-worker on prod web2/web3

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -36,3 +36,18 @@ anticheatAlertWorker:
   enabled: true
   image:
     tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+
+# 메일 지급 워커 — prod web2 활성화. tag = petpop build:mail-send-worker 산출 이미지
+#   (env-agnostic, SM 으로 env 주입 → staging 검증 이미지 재사용).
+# 호스트명은 /mail-send 스킬의 mailSendWorkerUrlOf('prod','web2') 파생값과 1:1 일치해야 함.
+# 발송 계정: MAIL_SENDER_V8_* 미설정 시 ragnarok-breaker/prod-web2 의 V8_ACCOUNT/_VERSE/_AUTH/_ENV
+#   로 폴백. 해당 계정이 prod verse 에서 mailSendWorker role 로 등록돼 있어야 실제 발송 가능.
+# 선택: Slack 알림은 AWS SM 에 MAIL_SEND_SLACK_WEBHOOK 추가 시 활성(미설정 시 skip).
+mailSendWorker:
+  enabled: true
+  image:
+    tag: git-2661018f2dc44c9484398f7b14ad27e0e0388f45
+  httpRoute:
+    enabled: true
+    hostnames:
+      - rb-mail-send-prod-web2.9c.gg

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -41,6 +41,21 @@ anticheatAlertWorker:
   image:
     tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
 
+# 메일 지급 워커 — prod web3 활성화. tag = petpop build:mail-send-worker 산출 이미지
+#   (env-agnostic, SM 으로 env 주입 → staging 검증 이미지 재사용).
+# 호스트명은 /mail-send 스킬의 mailSendWorkerUrlOf('prod','web3') 파생값과 1:1 일치해야 함.
+# 발송 계정: MAIL_SENDER_V8_* 미설정 시 ragnarok-breaker/prod-web3 의 V8_ACCOUNT/_VERSE/_AUTH/_ENV
+#   로 폴백. 해당 계정이 prod verse 에서 mailSendWorker role 로 등록돼 있어야 실제 발송 가능.
+# 선택: Slack 알림은 AWS SM 에 MAIL_SEND_SLACK_WEBHOOK 추가 시 활성(미설정 시 skip).
+mailSendWorker:
+  enabled: true
+  image:
+    tag: git-2661018f2dc44c9484398f7b14ad27e0e0388f45
+  httpRoute:
+    enabled: true
+    hostnames:
+      - rb-mail-send-prod-web3.9c.gg
+
 # Single shared ingest gateway for all payment envs (no app_env split) —
 # the only namespace that hosts it. The bulk `bump-image rb <hash>` keeps this
 # in sync (optional key: bumped here where present, skipped in overlays that


### PR DESCRIPTION
## What

prod 의 web2·web3 네임스페이스에 mail-send-worker 를 활성화합니다. staging-web2 에서 검증한 워커를 prod 로 확장해, 운영자가 prod 유저에게 헤드리스로 보상 메일을 발송할 수 있게 합니다.

- `9c-main/ragnarok-breaker-prod-web2/values.yaml` — mailSendWorker 블록 추가 (enabled + image + HTTPRoute)
- `9c-main/ragnarok-breaker-prod-web3/values.yaml` — 동일

각 override 는 Deployment(Recreate 단일 소비자) + ClusterIP Service + HTTPRoute 를 렌더합니다(차트 템플릿은 이미 존재, staging-web2 에서 배포 검증됨).

## Hostnames (코드 파생값과 1:1)

`/mail-send` 스킬이 워커 URL 을 `mailSendWorkerUrlOf(env, flavor)` = `https://rb-mail-send-<env>-<flavor>.9c.gg` 로 파생하므로 HTTPRoute 호스트명을 그에 맞춥니다:

- prod web2 → `rb-mail-send-prod-web2.9c.gg`
- prod web3 → `rb-mail-send-prod-web3.9c.gg`

## Image

mail-send-worker 이미지는 env-agnostic(env 는 `ragnarok-breaker-env` SM 주입)이라 staging 에서 검증한 태그 `git-2661018f2dc44c9484398f7b14ad27e0e0388f45` 를 그대로 재사용합니다.

## 배포 전 운영 체크 (머지 후 ArgoCD sync 전에 확인)

- **발송 계정 role**: 워커는 `MAIL_SENDER_V8_*` 미설정 시 각 ns 의 `ragnarok-breaker/prod-web2`·`prod-web3` SM 의 `V8_ACCOUNT/_VERSE/_AUTH/_ENV` 로 폴백합니다. 이 계정이 **prod verse 에서 `mailSendWorker` role 로 등록**돼 있어야 실제 발송이 됩니다(admin.ts). 미등록이면 preview 는 되나 confirm 발송이 실패할 수 있음.
- **Slack 알림(선택)**: 원하면 각 SM 에 `MAIL_SEND_SLACK_WEBHOOK` 추가(미설정 시 알림 skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)