### PR TITLE
feat(rb): add league-reward-worker + enable mail-send-worker on staging web3

### DIFF
--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -44,3 +44,15 @@ mailSendWorker:
     enabled: true
     hostnames:
       - rb-mail-send-staging-web2.9c.gg
+
+# 리그 보상 메일 워커 — staging 검증용 활성화. 같은 네임스페이스 mailSendWorker(위)를
+# 내부 DNS 로 호출한다. verseLabel 은 jobId suffix 로 web2/web3 간 고유해야 함.
+# ⚠ image.tag: petpop build:league-reward-worker 가 산출하는 git-<sha> 로 pin 필요
+#   (첫 배포 전 필수 — 아래 develop 은 임시). AWS SM ragnarok-breaker/staging-web2 에
+#   R2_PUBLIC_BASE·CDN_ENV 존재 확인, 발송 계정에 worker.records 권한 필요.
+leagueRewardWorker:
+  enabled: true
+  image:
+    tag: develop
+  config:
+    verseLabel: staging-w2

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -32,3 +32,27 @@ bqAnalyticsWorker:
   enabled: false
   image:
     tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+
+# 메일 지급 워커 — staging-web3 도 web2 와 동일하게 활성화(그간 web2 만 있었음).
+# tag = staging 검증 이미지(web2 와 동일). 발송 계정: 공유 워커/게이트웨이 계정 재사용
+#   (MAIL_SENDER_V8_* 없으면 V8_ACCOUNT/_VERSE/_AUTH/_ENV 폴백, 신규 SM 키 불필요).
+# ⚠ httproute 호스트 rb-mail-send-staging-web3.9c.gg 는 DNS/firewall 등록 필요.
+mailSendWorker:
+  enabled: true
+  image:
+    tag: git-2661018f2dc44c9484398f7b14ad27e0e0388f45
+  httpRoute:
+    enabled: true
+    hostnames:
+      - rb-mail-send-staging-web3.9c.gg
+
+# 리그 보상 메일 워커 — staging-web3 검증용 활성화. 위 mailSendWorker(web3)를 내부 DNS 호출.
+# verseLabel 은 web2 와 달라야 함(jobId 충돌 방지).
+# ⚠ image.tag: petpop build:league-reward-worker 산출 git-<sha> 로 pin 필요(develop 은 임시).
+#   AWS SM ragnarok-breaker/staging-web3 에 R2_PUBLIC_BASE·CDN_ENV 확인, 계정 worker.records 권한.
+leagueRewardWorker:
+  enabled: true
+  image:
+    tag: develop
+  config:
+    verseLabel: staging-w3

--- a/charts/ragnarok-breaker/templates/league-reward-worker-deployment.yaml
+++ b/charts/ragnarok-breaker/templates/league-reward-worker-deployment.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.leagueRewardWorker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: league-reward-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: league-reward-worker
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: league-reward-worker
+spec:
+  replicas: {{ .Values.leagueRewardWorker.deployment.replicas }}
+  # 단일 폴러 + BullMQ delayed confirm 소비자 → 롤아웃 중 두 파드 동시 폴링/confirm 방지.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: league-reward-worker
+  template:
+    metadata:
+      labels:
+        app: league-reward-worker
+    spec:
+      {{- if .Values.imagePullSecret.secretKey }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret.name }}
+      {{- end }}
+      containers:
+        - name: league-reward-worker
+          image: "{{ .Values.leagueRewardWorker.image.repository }}:{{ .Values.leagueRewardWorker.image.tag }}"
+          imagePullPolicy: {{ .Values.leagueRewardWorker.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.leagueRewardWorker.deployment.port }}
+          env:
+            # 헬스 포트 + mail-send-worker 내부 도메인 + verse 라벨(jobId suffix).
+            # 나머지 env(R2_PUBLIC_BASE, CDN_ENV, MAIL_SENDER_V8_*/V8_*, REDIS_URL,
+            # 선택 LEAGUE_REWARD_* 튜닝) 는 ragnarok-breaker-env(AWS SM) 에서 주입.
+            - name: LEAGUE_REWARD_HTTP_PORT
+              value: {{ .Values.leagueRewardWorker.deployment.port | quote }}
+            - name: MAIL_SEND_WORKER_URL
+              value: {{ .Values.leagueRewardWorker.config.mailSendWorkerUrl | quote }}
+            - name: LEAGUE_REWARD_VERSE_LABEL
+              value: {{ .Values.leagueRewardWorker.config.verseLabel | quote }}
+          envFrom:
+            - secretRef:
+                name: ragnarok-breaker-env
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.leagueRewardWorker.deployment.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.leagueRewardWorker.deployment.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.leagueRewardWorker.deployment.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always
+{{- end }}

--- a/charts/ragnarok-breaker/values.yaml
+++ b/charts/ragnarok-breaker/values.yaml
@@ -225,6 +225,40 @@ mailSendWorker:
     gatewayName: traefik-gateway
     gatewayNamespace: traefik
 
+# === League reward mail worker (리그 시즌 종료 → 보상 메일 자동 발송) ===
+# 폴링(기본 1h): R2 리그 시즌 종료 감지 → admin.getSeasonValidationStatus 로 모든 랭킹
+# 로우 validated 확인 → 보상 계산 → mailSendWorker /preview → 10분 뒤 /confirm 자동 확정.
+# mailSendWorker 를 같은 네임스페이스 내부 DNS(http://mail-send-worker:3100)로 호출하므로
+# 이 워커를 켜는 env 에는 mailSendWorker 도 함께 켜져 있어야 한다. 이중지급 방지 권위는
+# 결정론적 jobId(league-s{seasonId}-{verseLabel}) + 서버 receipt — redis 유실에도 안전.
+# 필요 env(ragnarok-breaker-env AWS SM): R2_PUBLIC_BASE, CDN_ENV, MAIL_SENDER_V8_*/V8_*
+#   (계정은 worker.records·user.read·mail.send 권한 필요), REDIS_URL.
+# 선택 튜닝 env: LEAGUE_REWARD_POLL_INTERVAL_MS, LEAGUE_REWARD_GRACE_MS,
+#   LEAGUE_REWARD_LOOKBACK_MS, LEAGUE_REWARD_CONFIRM_DELAY_MS, LEAGUE_REWARD_TTL_DAYS,
+#   LEAGUE_PASS_RUBY_MULT, LEAGUE_REWARD_ENTITLEMENT_INTERVAL_MS.
+# 기본 off — env 별 override 에서 enable + verseLabel 지정 + 이미지 태그 pin.
+leagueRewardWorker:
+  enabled: false
+  image:
+    repository: planetariumhq/ragnarok-breaker-league-reward-worker
+    tag: develop
+    pullPolicy: IfNotPresent
+  deployment:
+    replicas: 1
+    port: 3200
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+  config:
+    # 같은 네임스페이스 mail-send-worker ClusterIP Service.
+    mailSendWorkerUrl: http://mail-send-worker:3100
+    # jobId suffix. env 별 override 에서 반드시 고유값 지정(예 staging-w2 / staging-w3).
+    verseLabel: ""
+
 # === External payment backend → BigQuery analytics ingest gateway ===
 # Thin HTTP gateway (Bun.serve): POST /v1/events (Bearer auth) validates the
 # envelope and enqueues a bq_event job onto the bq-analytics-events BullMQ


### PR DESCRIPTION
## Summary
리그 시즌 종료 후 랭킹 보상 메일을 자동 발송하는 신규 워커 `league-reward-worker` 를 chart 에 추가하고, staging web2/web3 에서 활성화. 겸사겸사 그간 web2 에만 있던 `mail-send-worker` 를 staging web3 에도 활성화.

### Chart
- 신규 template `league-reward-worker-deployment.yaml` (Deployment only, default `enabled: false`). 폴링(기본 1h)으로 종료 리그 감지 → `admin.getSeasonValidationStatus` 로 모든 랭킹 로우 validated 확인 → R2 보상표로 계산 → `mail-send-worker` `/preview`→(10분)→`/confirm` 자동 확정.
- 같은 네임스페이스 `mail-send-worker` ClusterIP Service 를 내부 DNS(`http://mail-send-worker:3100`)로 호출 → 이 워커를 켜는 env 는 `mail-send-worker` 도 켜져 있어야 함.
- 멱등: 결정론적 `jobId=league-s{seasonId}-{verseLabel}` + 서버 receipt → redis 유실에도 이중지급 없음.
- `values.yaml` 에 default `leagueRewardWorker` 블록(off) 추가.

### Staging overrides
- `ragnarok-breaker-staging-web2`: `leagueRewardWorker` enable (verseLabel `staging-w2`).
- `ragnarok-breaker-staging-web3`: `leagueRewardWorker` enable (verseLabel `staging-w3`) **+ `mailSendWorker` enable** (host `rb-mail-send-staging-web3.9c.gg`).
- dev/prod 및 기타 env 는 무변경(default off).

### ⚠ ArgoCD sync 전 프리레퀴짓 (ops)
1. **이미지 태그 pin**: `leagueRewardWorker.image.tag` 를 petpop `build:league-reward-worker` 산출 `git-<sha>` 로 교체 (현재 `develop` 은 임시 placeholder). 해당 CI 잡은 petpop MR !1248 에 포함.
2. **AWS SM** `ragnarok-breaker/staging-web2`·`staging-web3` 에 `R2_PUBLIC_BASE`·`CDN_ENV` 존재 확인(미설정 시 워커 boot 실패). 발송 계정에 `worker.records`(+ 기존 `user.read`·`mail.send`) 권한 필요.
3. **DNS**: `rb-mail-send-staging-web3.9c.gg` A레코드/firewall 등록.

helm template 로 staging web2/web3 렌더 확인 완료. dev/prod-web2 는 `league-reward-worker` 0건(무영향) 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
