### PR TITLE
chore(rb): bump staging web2/web3 images to git-c3da22f0

### DIFF
--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -5,31 +5,31 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
 
 v8Gateway:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
 
 logStream:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
 
 # web2: ygg workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
 # bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
 
 # 메일 지급 워커 — staging 검증용 활성화. tag = petpop build:mail-send-worker 산출 이미지.
 # 발송 계정: 공유 워커/게이트웨이 계정을 재사용(admin.ts mailSendWorker role 등록됨). 워커가
@@ -39,7 +39,7 @@ bqAnalyticsWorker:
 mailSendWorker:
   enabled: true
   image:
-    tag: git-2661018f2dc44c9484398f7b14ad27e0e0388f45
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
   httpRoute:
     enabled: true
     hostnames:
@@ -47,12 +47,11 @@ mailSendWorker:
 
 # 리그 보상 메일 워커 — staging 검증용 활성화. 같은 네임스페이스 mailSendWorker(위)를
 # 내부 DNS 로 호출한다. verseLabel 은 jobId suffix 로 web2/web3 간 고유해야 함.
-# ⚠ image.tag: petpop build:league-reward-worker 가 산출하는 git-<sha> 로 pin 필요
-#   (첫 배포 전 필수 — 아래 develop 은 임시). AWS SM ragnarok-breaker/staging-web2 에
-#   R2_PUBLIC_BASE·CDN_ENV 존재 확인, 발송 계정에 worker.records 권한 필요.
+# ⚠ sync 전: AWS SM ragnarok-breaker/staging-web2 에 R2_PUBLIC_BASE·CDN_ENV 존재 확인,
+#   발송 계정에 worker.records 권한 필요.
 leagueRewardWorker:
   enabled: true
   image:
-    tag: develop
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
   config:
     verseLabel: staging-w2

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
 
 v8Gateway:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
 
 logStream:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
 
 yggRedeem:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
   httpRoute:
     enabled: true
     hostnames:
@@ -25,13 +25,13 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
 
 # bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
 
 # 메일 지급 워커 — staging-web3 도 web2 와 동일하게 활성화(그간 web2 만 있었음).
 # tag = staging 검증 이미지(web2 와 동일). 발송 계정: 공유 워커/게이트웨이 계정 재사용
@@ -40,7 +40,7 @@ bqAnalyticsWorker:
 mailSendWorker:
   enabled: true
   image:
-    tag: git-2661018f2dc44c9484398f7b14ad27e0e0388f45
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
   httpRoute:
     enabled: true
     hostnames:
@@ -48,11 +48,11 @@ mailSendWorker:
 
 # 리그 보상 메일 워커 — staging-web3 검증용 활성화. 위 mailSendWorker(web3)를 내부 DNS 호출.
 # verseLabel 은 web2 와 달라야 함(jobId 충돌 방지).
-# ⚠ image.tag: petpop build:league-reward-worker 산출 git-<sha> 로 pin 필요(develop 은 임시).
-#   AWS SM ragnarok-breaker/staging-web3 에 R2_PUBLIC_BASE·CDN_ENV 확인, 계정 worker.records 권한.
+# ⚠ sync 전: AWS SM ragnarok-breaker/staging-web3 에 R2_PUBLIC_BASE·CDN_ENV 확인,
+#   계정 worker.records 권한.
 leagueRewardWorker:
   enabled: true
   image:
-    tag: develop
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
   config:
     verseLabel: staging-w3


### PR DESCRIPTION
## Summary
staging web2/web3 의 모든 ragnarok-breaker 서비스 이미지 태그를 `git-c3da22f0afb86d512a15769b52ad1c5464b76c1d` 로 일괄 bump.

이 커밋(petpop develop, MR !1248 머지)은 `.gitlab-ci.yml` + `packages/shared` 를 변경하므로 모든 `build:*` 잡이 재빌드되어 전 서비스(신규 `league-reward-worker`, `mail-send-worker` 포함) `git-c3da22f0` 이미지를 push 한다. 앞선 #3517 에서 `develop` placeholder 였던 `leagueRewardWorker.image.tag` 를 실제 빌드 태그로 pin.

- web2/web3: worker·v8Gateway·logStream·ygg*·bqAnalytics·mailSendWorker·leagueRewardWorker 전부 `git-c3da22f0` 로 통일.
- helm template 렌더 검증: 두 env 모두 모든 rb 이미지가 동일 태그(다른 태그 0건).

#3517 후속 (그 PR 은 이미 머지되어 별도 PR).

## ArgoCD sync 전 ops (변동 없음)
- AWS SM `ragnarok-breaker/staging-web{2,3}` 에 `R2_PUBLIC_BASE`·`CDN_ENV`, 발송 계정 `worker.records` 권한.
- DNS `rb-mail-send-staging-web3.9c.gg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
