### PR TITLE
chore(rb): re-pin staging web2/web3 images to git-a5db7f0

### DIFF
--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -5,31 +5,31 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
 
 v8Gateway:
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
 
 logStream:
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
 
 # web2: ygg workloads are disabled, but image.tag is pinned
 # so `bump-image rb <hash>` (bulk) stays uniform across env×tier.
 yggRedeem:
   enabled: false
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
 yggQuestWorker:
   enabled: false
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
 # bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
 
 # 메일 지급 워커 — staging 검증용 활성화. tag = petpop build:mail-send-worker 산출 이미지.
 # 발송 계정: 공유 워커/게이트웨이 계정을 재사용(admin.ts mailSendWorker role 등록됨). 워커가
@@ -39,7 +39,7 @@ bqAnalyticsWorker:
 mailSendWorker:
   enabled: true
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
   httpRoute:
     enabled: true
     hostnames:
@@ -52,6 +52,6 @@ mailSendWorker:
 leagueRewardWorker:
   enabled: true
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
   config:
     verseLabel: staging-w2

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -5,19 +5,19 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
 
 v8Gateway:
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
 
 logStream:
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
 
 yggRedeem:
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
   httpRoute:
     enabled: true
     hostnames:
@@ -25,13 +25,13 @@ yggRedeem:
 
 yggQuestWorker:
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
 
 # bq-analytics runs in production only; disabled here, tag pinned for bulk bump.
 bqAnalyticsWorker:
   enabled: false
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
 
 # 메일 지급 워커 — staging-web3 도 web2 와 동일하게 활성화(그간 web2 만 있었음).
 # tag = staging 검증 이미지(web2 와 동일). 발송 계정: 공유 워커/게이트웨이 계정 재사용
@@ -40,7 +40,7 @@ bqAnalyticsWorker:
 mailSendWorker:
   enabled: true
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
   httpRoute:
     enabled: true
     hostnames:
@@ -53,6 +53,6 @@ mailSendWorker:
 leagueRewardWorker:
   enabled: true
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
   config:
     verseLabel: staging-w3


### PR DESCRIPTION
## Summary
staging web2/web3 의 모든 ragnarok-breaker 이미지 태그를 `git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0` 로 재pin.

앞선 #3518 의 `git-c3da22f0` 는 league-reward-worker 를 **제외한** 모든 서비스 빌드가 실패한 커밋이었다(다른 Dockerfile 들이 신규 워크스페이스 `services/league-reward-worker/package.json` 을 COPY 하지 않아 `bun install --frozen-lockfile` 실패 → 이미지 미push). petpop **!1251** 이 10개 Dockerfile 을 수정했고, `a5db7f0` 은 그 develop 머지 커밋으로 모든 `build:*` 잡이 성공한다.

- web2/web3: 전 서비스(worker·v8Gateway·logStream·ygg*·bqAnalytics·mailSendWorker·leagueRewardWorker) `git-a5db7f0` 통일.
- helm template 렌더 검증 완료(두 env, stale 태그 0).

#3518 후속(이미 머지되어 별도 PR).

## sync 전 ops (변동 없음)
- AWS SM `ragnarok-breaker/staging-web{2,3}`: `R2_PUBLIC_BASE`·`CDN_ENV`, 발송 계정 `worker.records`.
- DNS `rb-mail-send-staging-web3.9c.gg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
