### PR TITLE
feat(rb): enable league-reward-worker on prod + bump mail-send-worker

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -46,7 +46,7 @@ anticheatAlertWorker:
 mailSendWorker:
   enabled: true
   image:
-    tag: git-2661018f2dc44c9484398f7b14ad27e0e0388f45
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
   httpRoute:
     enabled: true
     hostnames:

--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -51,3 +51,17 @@ mailSendWorker:
     enabled: true
     hostnames:
       - rb-mail-send-prod-web2.9c.gg
+
+# 리그 보상 메일 워커 — prod 실지급. 같은 네임스페이스 mailSendWorker(위)를 내부 DNS 호출.
+# ⚠ ArgoCD sync(=워커 기동) 전 필수:
+#   (1) 이 verse Redis 의 SET `league-reward:paid` 에 이미 수동 지급된 리그 시즌 id 를 전부
+#       SADD. 구 manual 도구(sendUserMailBatch)는 서버 receipt 를 안 남겨 결정론 jobId dedup 이
+#       안 걸리므로, 미시딩 시 7일 lookback 안의 수동 지급 시즌을 재지급(이중지급)한다.
+#   (2) AWS SM ragnarok-breaker/prod-web2 에 R2_PUBLIC_BASE·CDN_ENV 존재 확인.
+#   발송계정(0x3c33)은 worker.records·user.read·mail.send 보유(확인됨).
+leagueRewardWorker:
+  enabled: true
+  image:
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+  config:
+    verseLabel: prod-w2

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -50,7 +50,7 @@ anticheatAlertWorker:
 mailSendWorker:
   enabled: true
   image:
-    tag: git-2661018f2dc44c9484398f7b14ad27e0e0388f45
+    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
   httpRoute:
     enabled: true
     hostnames:

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -56,6 +56,20 @@ mailSendWorker:
     hostnames:
       - rb-mail-send-prod-web3.9c.gg
 
+# 리그 보상 메일 워커 — prod 실지급. 같은 네임스페이스 mailSendWorker(위)를 내부 DNS 호출.
+# ⚠ ArgoCD sync(=워커 기동) 전 필수:
+#   (1) 이 verse Redis 의 SET `league-reward:paid` 에 이미 수동 지급된 리그 시즌 id 를 전부
+#       SADD. 구 manual 도구(sendUserMailBatch)는 서버 receipt 를 안 남겨 결정론 jobId dedup 이
+#       안 걸리므로, 미시딩 시 7일 lookback 안의 수동 지급 시즌을 재지급(이중지급)한다.
+#   (2) AWS SM ragnarok-breaker/prod-web3 에 R2_PUBLIC_BASE·CDN_ENV 존재 확인.
+#   발송계정(0x3c33)은 worker.records·user.read·mail.send 보유(확인됨).
+leagueRewardWorker:
+  enabled: true
+  image:
+    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+  config:
+    verseLabel: prod-w3
+
 # Single shared ingest gateway for all payment envs (no app_env split) —
 # the only namespace that hosts it. The bulk `bump-image rb <hash>` keeps this
 # in sync (optional key: bumped here where present, skipped in overlays that


### PR DESCRIPTION
## Summary
프로덕션(web2/web3)에 리그 보상 메일 워커를 활성화하고, mail-send-worker 이미지를 맞춰 bump. 커밋 2개.

1. **feat(rb): enable league-reward-worker on prod web2/web3** — `leagueRewardWorker` enabled (image `git-c3da22f0`, verseLabel `prod-w2`/`prod-w3`). 리그 시즌 종료 → 검증(pending=0) → R2 보상표 계산 → 같은 네임스페이스 mailSendWorker 를 내부 DNS(`http://mail-send-worker:3100`)로 preview→(10m)→confirm.
2. **chore(rb): bump mail-send-worker prod web2/web3 to git-a5db7f0** — league-worker 가 호출하는 mail-send-worker 를 전 서비스 정상 빌드된 develop 커밋 이미지로 pin.

helm template 렌더 검증: prod-web2/web3 모두 league-worker(c3da22f0, prod-w2/w3, 내부DNS) + mail-send-worker(a5db7f0) 정상.

## ⚠ ArgoCD sync 전 필수 (실화폐 — 반드시 이 순서로)
1. **각 verse Redis SET `league-reward:paid` 프리시드**: 이미 수동 지급된 리그 시즌 id 를 전부 `SADD`. 구 manual 도구(`sendUserMailBatch`)는 서버 receipt 를 안 남겨 결정론 jobId dedup 이 안 걸리므로, **미시딩 시 7일 lookback 안의 수동 지급 시즌을 재지급(이중지급)**한다. prod-web2·prod-web3 Redis 각각(REDIS_URL 의 DB 인덱스 주의).
2. AWS SM `ragnarok-breaker/prod-web2`·`prod-web3` 에 `R2_PUBLIC_BASE`·`CDN_ENV` 존재 확인.
3. (권장) 검증 워커가 실제 시즌 종료 후 `getSeasonValidationStatus.pending=0` 을 적정 시간 내 도달시키는지 확인.

발송계정(0x3c33)은 `worker.records`·`user.read`·`mail.send` 보유 확인됨. 10분 자동확정(abort 없음)이므로 Slack 프리뷰 모니터링 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
