### PR TITLE
chore(rb): bump ygg-redeem dev image → git-2d0a3dc3 (RB-1848 quest-state)

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -21,7 +21,7 @@ logStream:
 yggRedeem:
   enabled: false
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-2d0a3dc32109e9f11ac57e4a7da1268ec5a44f77
 yggQuestWorker:
   enabled: false
   image:

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -21,7 +21,7 @@ logStream:
 yggRedeem:
   enabled: false
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-2d0a3dc32109e9f11ac57e4a7da1268ec5a44f77
 yggQuestWorker:
   enabled: false
   image:


### PR DESCRIPTION
## Summary
dev(web2/web3) `yggRedeem.image.tag` → `git-2d0a3dc32109e9f11ac57e4a7da1268ec5a44f77` bump.
petpop/ragnarok-breaker develop 머지분(MR !1259: ygg-redeem HMAC `/quest-state` + collections shim + purchase 소스). `build:ygg-redeem` success 커밋(2d0a3dc3)이라 이미지 존재 확인(develop-hash 함정 회피).

## ⚠️ 배포/구동 메모
- ArgoCD **수동 sync** 필요.
- **현재 dev-web3/web2 `yggRedeem.enabled: false`** — 본 PR은 **태그만** bump. 실제 구동하려면 `enabled: true`(dev-web3) + env(`QUEST_STATE_SOURCE=collections`, `NC_API_*`)가 별도 필요(ExternalSecret `ragnarok-breaker/dev-web3`).
- 단일 워크로드 bump — 타 서비스 태그 불변.

🤖 Generated with [Claude Code](https://claude.com/claude-code)