### PR TITLE
chore(rb): bump prod ygg-redeem image → git-2d0a3dc3 (RB-1848 quest-state)

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -20,7 +20,7 @@ logStream:
 yggRedeem:
   enabled: false
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-2d0a3dc32109e9f11ac57e4a7da1268ec5a44f77
 yggQuestWorker:
   enabled: false
   image:

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -17,7 +17,7 @@ logStream:
 
 yggRedeem:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-2d0a3dc32109e9f11ac57e4a7da1268ec5a44f77
   deployment:
     replicas: 2
   httpRoute:


### PR DESCRIPTION
## Summary
prod-web3(실행 중) + prod-web2(핀) `yggRedeem.image.tag` → `git-2d0a3dc32109e9f11ac57e4a7da1268ec5a44f77`.
RB-1848 ygg-redeem HMAC `/quest-state` + collections shim + purchase 소스(petpop develop MR!1259 빌드). 기존 redeem 라우트 무영향(additive).

## ⚠️ 검토 포인트
- **develop 빌드**: ygg-redeem 코드는 petpop develop에만 있고 main엔 없음 → `git-2d0a3dc32`는 develop merge 빌드. dev→staging→prod / main 릴리스를 건너뜀. (코드는 additive라 redeem 영향 낮음. 정석은 main 릴리스 후 prod.)
- build:ygg-redeem success 커밋(2d0a3dc3)이라 이미지 존재(develop-hash 함정 회피).
- **구동 전 env 필요**(ExternalSecret `ragnarok-breaker/prod-web3`): `QUEST_STATE_SOURCE=collections`, `NC_API_BASE/KEY/SECRET`, `NC_VERSE_ID`. 없으면 /quest-state가 collections 조립 못 하거나 purchase 빈값.
- ArgoCD 수동 sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)