### PR TITLE
feat(portal): 인터널 리딤 지급 CronJob (RB-1850)

### DIFF
--- a/9c-internal/portal/values.yaml
+++ b/9c-internal/portal/values.yaml
@@ -52,3 +52,12 @@ backofficeService:
       schedule: "*/15 * * * *"
       endpoint: "https://dev-portal.planetarium.team/api/scheduler/transaction"
       tokenEnvName: "SCHEDULER_API_KEY"
+    # RB-1850 리딤 지급/재확정 (인터널 전용, 내부 Odin 체인). REDEEM_NC_ADDRESS 미설정 시 no-op.
+    - name: redeem
+      schedule: "*/2 * * * *"
+      endpoint: "https://dev-portal.planetarium.team/api/scheduler/redeem"
+      tokenEnvName: "SCHEDULER_API_KEY"
+    - name: redeem-status
+      schedule: "*/15 * * * *"
+      endpoint: "https://dev-portal.planetarium.team/api/scheduler/redeem-status"
+      tokenEnvName: "SCHEDULER_API_KEY"


### PR DESCRIPTION
## 무엇
9c-internal overlay에 리딤 지급/재확정 CronJob 2개 추가 (인터널 전용).
- `redeem` (*/2): `/api/scheduler/redeem` — REQUESTED 픽업 → NCG 지급 → PAYING
- `redeem-status` (*/15): `/api/scheduler/redeem-status` — 폴링 → confirm(claimed) → CLAIMED

## 안전
- **9c-main(prod) 미포함** — 인터널만.
- 인터널 Odin = 메인넷과 별개 체인(genesis 동일, height 19M 블록해시 상이 → fork). 내부 체인 NCG로 지급, 메인넷 무관.
- `REDEEM_NC_ADDRESS` 미설정 시 스케줄러 no-op → 무해.
- 출금 CronJob 패턴과 동형.

🤖 Generated with [Claude Code](https://claude.com/claude-code)