### PR TITLE
chore(9c-internal): bump headless image to release/394 (git-f8043233)

### DIFF
--- a/9c-internal/network/general.yaml
+++ b/9c-internal/network/general.yaml
@@ -4,7 +4,7 @@ provider: RKE2
 global:
   image:
     repository: planetariumhq/ninechronicles-headless
-    tag: "git-436932c92da4c179a8fbbf3a8a3f327a540c6be2"
+    tag: "git-f80432335a6eca29fc0cc7685a5895aad4c30f1d"
 
 seed:
   image:


### PR DESCRIPTION
## 목적
9c-internal(odin + heimdall) 헤드리스 노드를 release/394 이미지로 업데이트.

- Source: [NineChronicles.Headless#2765](https://github.com/planetarium/NineChronicles.Headless/pull/2765) (Release/394, `f8043233`, *Bump lib9c 1.36.3 / MessagePack 2.5.301*)
- Image: `planetariumhq/ninechronicles-headless:git-f80432335a6eca29fc0cc7685a5895aad4c30f1d` (DockerHub 확인됨)
- `9c-internal/network/general.yaml` `global.image.tag`: `git-436932c…` → `git-f8043233…`

## 영향 범위 (인터널 only, 메인넷 무관)
- heimdall: `remote-headless-1`, `validator-5`
- odin: `validator-5`

## 배포 주의사항
- odin/heimdall ArgoCD 앱은 auto-sync 없음 + 기존 라이브 드리프트(arena/mimir/ingress/snapshot script) 존재 → **헤드리스 StatefulSet만 타겟 sync** (전체 sync 금지).
- lib9c/MessagePack 버전 bump → 이미지 교체 후 PVC `/data/plugins/` 캐시 삭제 + 재시작 필요 (MessagePack 직렬화 이슈 방지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)