### PR TITLE
feat(ragnarok-breaker): web2→web3 migration-bridge staging 워크로드

### DIFF
--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -14,3 +14,12 @@ v8Gateway:
 logStream:
   image:
     tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+
+# web2→web3 마이그레이션 브리지(크로스-verse 싱글톤) — staging 에서만 enable.
+# ⚠ image.tag 는 petpop main MR 머지 후 CI build:migration-bridge 가 push 하는
+#   ragnarok-breaker-migration-bridge:git-<sha> 로 핀할 것(현재 develop 은 플레이스홀더).
+# ⚠ AWS SM ragnarok-breaker/staging 에 MIGRATION_BRIDGE_WEB2_V8_* / _WEB3_V8_* (ACCOUNT·VERSE·ENV·AUTH·REMOTE_URL) 추가 필요.
+migrationBridge:
+  enabled: true
+  image:
+    tag: develop

--- a/charts/ragnarok-breaker/templates/migration-bridge-deployment.yaml
+++ b/charts/ragnarok-breaker/templates/migration-bridge-deployment.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.migrationBridge.enabled }}
+# web2→web3 계정 마이그레이션 브리지.
+# web2(소스)/web3(대상) 두 verse 에 동시에 헤드리스 접속하는 **크로스-verse 싱글톤** —
+# 반드시 한 네임스페이스에서만 enable 한다(web2/web3 양쪽에서 돌리면 이중 처리).
+# 필요 env 는 전부 ragnarok-breaker-env(AWS SM)에서 주입:
+#   MIGRATION_BRIDGE_WEB2_V8_{ACCOUNT,VERSE,ENV,AUTH,REMOTE_URL}
+#   MIGRATION_BRIDGE_WEB3_V8_{ACCOUNT,VERSE,ENV,AUTH,REMOTE_URL}
+#   (선택) MIGRATION_BRIDGE_{POLL_INTERVAL_MS,BATCH_LIMIT,STALE_PROCESSING_MS}
+# HMAC 시크릿은 브리지가 보유하지 않는다(web3 verse 서버가 단독 검증).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: migration-bridge
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: migration-bridge
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: migration-bridge
+spec:
+  replicas: {{ .Values.migrationBridge.deployment.replicas }}
+  # 단일 폴러 + claim CAS 소비자 → 롤아웃 중 두 파드 동시 폴링 방지.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: migration-bridge
+  template:
+    metadata:
+      labels:
+        app: migration-bridge
+    spec:
+      {{- if .Values.imagePullSecret.secretKey }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret.name }}
+      {{- end }}
+      containers:
+        - name: migration-bridge
+          image: "{{ .Values.migrationBridge.image.repository }}:{{ .Values.migrationBridge.image.tag }}"
+          imagePullPolicy: {{ .Values.migrationBridge.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.migrationBridge.deployment.port }}
+          env:
+            - name: MIGRATION_BRIDGE_HTTP_PORT
+              value: {{ .Values.migrationBridge.deployment.port | quote }}
+          envFrom:
+            - secretRef:
+                name: ragnarok-breaker-env
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.migrationBridge.deployment.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.migrationBridge.deployment.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.migrationBridge.deployment.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always
+{{- end }}

--- a/charts/ragnarok-breaker/values.yaml
+++ b/charts/ragnarok-breaker/values.yaml
@@ -223,3 +223,24 @@ analyticsWorker:
     limits:
       cpu: 500m
       memory: 512Mi
+
+# === Migration bridge (web2→web3 계정 이전 폴러) ===
+# web2 migrationRequests 를 폴링해 web3 applyInbound 로 밀어넣고 web2 finalize 를 호출하는
+# 크로스-verse 싱글톤. 한 네임스페이스에서만 enable(analytics-worker 와 동일 원칙).
+# verse 접속/토큰 등 모든 설정은 ragnarok-breaker-env(AWS SM)의 MIGRATION_BRIDGE_* 키.
+migrationBridge:
+  enabled: false
+  image:
+    repository: planetariumhq/ragnarok-breaker-migration-bridge
+    tag: develop
+    pullPolicy: IfNotPresent
+  deployment:
+    replicas: 1
+    port: 3300
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi


### PR DESCRIPTION
## Summary
petpop web2→web3 계정 마이그레이션 브리지 워커를 **staging** 에 배포하기 위한 차트/오버라이드.

- `charts/ragnarok-breaker/templates/migration-bridge-deployment.yaml` — Deployment. web2(소스)/web3(대상) 두 verse 동시 헤드리스 접속 **크로스-verse 싱글톤**(한 네임스페이스만 enable; Recreate). verse 접속설정은 `ragnarok-breaker-env`(AWS SM), `/health` probe.
- `charts/ragnarok-breaker/values.yaml` — `migrationBridge` 기본(enabled:false).
- `9c-internal/ragnarok-breaker-staging/values.yaml` — 싱글톤에서 enabled:true.

## 배포 전 필요 (⚠)
1. **이미지 태그 핀**: petpop main MR(!1330) 머지 → CI `build:migration-bridge` 가 `ragnarok-breaker-migration-bridge:git-<sha>` push → staging `migrationBridge.image.tag` 를 그 sha 로(현재 develop 플레이스홀더).
2. **AWS SM `ragnarok-breaker/staging`**: `MIGRATION_BRIDGE_WEB2_V8_*` / `MIGRATION_BRIDGE_WEB3_V8_*`(ACCOUNT·VERSE·ENV·AUTH·REMOTE_URL) 추가.
3. web3 verse 서버에 `MIGRATION_SECRET` 배포(브리지는 미보유 — web3 단독검증).

🤖 Generated with [Claude Code](https://claude.com/claude-code)