### PR TITLE
fix(ragnarok-breaker): migration-bridge 싱글톤→staging-web2 네임스페이스 이동

### DIFF
--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -56,3 +56,17 @@ playfullWorker:
   enabled: true
   image:
     tag: git-b7009db27f03ffb21864dd72b0ca4a6a67fd74e5
+
+# web2→web3 마이그레이션 브리지 — web2 verse 네임스페이스에 배치(크로스-verse 싱글톤).
+# ⚠ 반드시 이 한 네임스페이스에서만 enable — staging-web3 에는 절대 켜지 말 것
+#   (두 인스턴스가 같은 web2 큐를 폴링. claim CAS + (P,A) 멱등이라 중복 크레딧은 안 나지만 낭비).
+# ⚠ image.tag 는 petpop main MR 머지 후 CI build:migration-bridge 산출
+#   ragnarok-breaker-migration-bridge:git-<sha> 로 핀(현재 develop 은 플레이스홀더).
+# ⚠ AWS SM ragnarok-breaker/staging-web2 에 web2·web3 두 verse 자격증명 모두 추가:
+#   MIGRATION_BRIDGE_WEB2_V8_{ACCOUNT,VERSE,ENV,AUTH,REMOTE_URL}
+#   MIGRATION_BRIDGE_WEB3_V8_{ACCOUNT,VERSE,ENV,AUTH,REMOTE_URL}
+#   (파드 위치와 무관하게 web3 는 게이트웨이 URL+bearer 로 도달하므로 web3 자격증명도 여기 필요)
+migrationBridge:
+  enabled: true
+  image:
+    tag: develop

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -14,12 +14,3 @@ v8Gateway:
 logStream:
   image:
     tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
-
-# web2→web3 마이그레이션 브리지(크로스-verse 싱글톤) — staging 에서만 enable.
-# ⚠ image.tag 는 petpop main MR 머지 후 CI build:migration-bridge 가 push 하는
-#   ragnarok-breaker-migration-bridge:git-<sha> 로 핀할 것(현재 develop 은 플레이스홀더).
-# ⚠ AWS SM ragnarok-breaker/staging 에 MIGRATION_BRIDGE_WEB2_V8_* / _WEB3_V8_* (ACCOUNT·VERSE·ENV·AUTH·REMOTE_URL) 추가 필요.
-migrationBridge:
-  enabled: true
-  image:
-    tag: develop


### PR DESCRIPTION
## Summary
#3528 에서 싱글톤 `ragnarok-breaker-staging` 에 올렸던 migration-bridge 를 `ragnarok-breaker-staging-web2` 네임스페이스로 이동(운영 요청).

- 싱글톤 values 에서 `migrationBridge` 제거
- `9c-internal/ragnarok-breaker-staging-web2/values.yaml` 에서 enable

## 변경에 따른 SM 키 이동 (⚠)
브리지가 이제 `ragnarok-breaker-staging-web2` 네임스페이스 → SM 키가 `ragnarok-breaker/staging-web2`. 여기에 **web2·web3 두 verse 자격증명 모두** 필요:
- `MIGRATION_BRIDGE_WEB2_V8_{ACCOUNT,VERSE,ENV,AUTH,REMOTE_URL}`
- `MIGRATION_BRIDGE_WEB3_V8_{ACCOUNT,VERSE,ENV,AUTH,REMOTE_URL}`
(파드 위치 무관하게 web3 는 게이트웨이 URL+bearer 로 도달)

## 주의
반드시 이 한 네임스페이스에서만 enable — `staging-web3` 에는 켜지 말 것(이중 폴링). claim CAS + (P,A) 멱등이라 중복 크레딧은 안 나지만 낭비.

이미지 태그 핀은 #3528 노트와 동일(petpop build:migration-bridge git-<sha>).

🤖 Generated with [Claude Code](https://claude.com/claude-code)