### PR TITLE
chore(portal): 인터널 구 리딤 지급/재확정 CronJob 제거 (RB-1850 통합)

### DIFF
--- a/9c-internal/portal/values.yaml
+++ b/9c-internal/portal/values.yaml
@@ -52,12 +52,5 @@ backofficeService:
       schedule: "*/15 * * * *"
       endpoint: "https://dev-portal.planetarium.team/api/scheduler/transaction"
       tokenEnvName: "SCHEDULER_API_KEY"
-    # RB-1850 리딤 지급/재확정 (인터널 전용, 내부 Odin 체인). REDEEM_NC_ADDRESS 미설정 시 no-op.
-    - name: redeem
-      schedule: "*/2 * * * *"
-      endpoint: "https://dev-portal.planetarium.team/api/scheduler/redeem"
-      tokenEnvName: "SCHEDULER_API_KEY"
-    - name: redeem-status
-      schedule: "*/15 * * * *"
-      endpoint: "https://dev-portal.planetarium.team/api/scheduler/redeem-status"
-      tokenEnvName: "SCHEDULER_API_KEY"
+    # (통합 포인트) 구 리딤 지급/재확정 CronJob(redeem, redeem-status) 제거 — glory 소각분은 reward(GLORY_REDEEM)로
+    #   크레딧돼 통합 withdrawal이 지급하므로 별도 리딤 지급 스케줄러 불요. 살려두면 이중지급 경로가 됨(리뷰 B).


### PR DESCRIPTION
## 배경
통합 포인트(RB-1850) 설계에서 리딤은 **glory 소각 → reward(source=GLORY_REDEEM) 크레딧 → 통합 withdrawal이 지급** 흐름으로 바뀌었습니다. 따라서 별도 리딤 지급 스케줄러(`redeem`, `redeem-status`)는 불필요합니다.

## 변경
- `9c-internal/portal/values.yaml`의 cronjobs에서 `redeem`, `redeem-status` 항목 제거 (인터널 전용, 프로드엔 원래 없음).
- withdrawal / transaction(=withdrawal-status) CronJob은 유지.

## 왜 (안전)
구 리딤 스케줄러를 살려두면, 통합 흐름의 reward 크레딧과 **구 스케줄러의 온체인 지급이 겹쳐 이중지급** 경로가 됩니다(멀티에이전트 리뷰 🔴). 리딤 enable(REDEEM_ENABLED=true) 전 필수 데코미션 게이트입니다.

## 반영
머지 후 **ArgoCD portal 앱 수동 sync** 필요(auto-sync 없음) → 인터널에서 두 CronJob 제거됨. (현재 REDEEM_NC_ADDRESS 미설정으로 no-op 상태라 즉시 위험은 없음.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)