### PR TITLE
fix(cert-manager): inject IRSA creds explicitly to prevent dns01 renewal stall

### DIFF
--- a/common/bootstrap-v2/templates/cert-manager.yaml
+++ b/common/bootstrap-v2/templates/cert-manager.yaml
@@ -29,3 +29,37 @@ spec:
             {{- with .Values.certManager.serviceAccount.annotations }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+        {{- with .Values.certManager.serviceAccount.annotations }}
+        {{- with (index . "eks.amazonaws.com/role-arn") }}
+        # Inject IRSA credentials explicitly instead of relying on the
+        # eks-pod-identity-webhook. The webhook has failurePolicy=Ignore, so a webhook
+        # blip at pod-create time silently drops the injection; the controller then
+        # falls back to EC2 IMDS, the route53 dns01 solver fails, and cert renewal
+        # stalls for every SAN on the shared cert (petpop.fun, *.9c.gg, ...). This
+        # mirrors what the webhook would inject; the webhook no-ops when
+        # AWS_WEB_IDENTITY_TOKEN_FILE is already present, so there is no double-mount.
+        # Region matches the route53 region hardcoded in the letsencrypt issuer.
+        extraEnv:
+          - name: AWS_DEFAULT_REGION
+            value: us-east-2
+          - name: AWS_REGION
+            value: us-east-2
+          - name: AWS_ROLE_ARN
+            value: {{ . | quote }}
+          - name: AWS_WEB_IDENTITY_TOKEN_FILE
+            value: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
+        volumes:
+          - name: aws-iam-token
+            projected:
+              defaultMode: 420
+              sources:
+                - serviceAccountToken:
+                    audience: sts.amazonaws.com
+                    expirationSeconds: 86400
+                    path: token
+        volumeMounts:
+          - name: aws-iam-token
+            mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+            readOnly: true
+        {{- end }}
+        {{- end }}


### PR DESCRIPTION
## 배경 / 증상
2026-07-22, \"펫팝 인증서가 다시 만료됐다\"는 신고. 실제로는 즉시 만료가 아니라 **자동 갱신 스톨**이었음.

9c-main(rke2-main) traefik의 TLS는 **단일 멀티-SAN 인증서**(cert-manager `Certificate/certificate` → secret `certificate-secret`, Let's Encrypt ACME)로, `petpop.fun · *.petpop.fun · *.9c.gg · nine-chronicles.com · *.nine-chronicles.com · *.planetarium.network · *.planetarium.team · bridge-api.dccnft.com`을 한 장에 담는다. **한 도메인 검증만 실패해도 인증서 전체가 갱신되지 않고 묶인 전 도메인이 같이 만료**된다. (petpop-backoffice.9c.gg = `*.9c.gg`, www.petpop.fun = `*.petpop.fun`)

## 근본 원인
cert-manager 컨트롤러 파드에 IRSA 토큰 주입이 누락 → `AWS_ROLE_ARN`/`AWS_WEB_IDENTITY_TOKEN_FILE` env·`aws-iam-token` 볼륨 없음 → AWS SDK가 EC2 IMDS로 폴백해 실패:
\`\`\`
failed to determine Route 53 hosted zone ID ... no EC2 IMDS role found ... context deadline exceeded
\`\`\`
와일드카드 도메인은 dns01(route53)로만 검증 가능 → dns01 챌린지 전부 pending → Order pending → 갱신 정지(7/5부터 17일).

**왜 누락되나:** `pod-identity-webhook`의 `failurePolicy=Ignore`(fail-open). 파드 생성 시 webhook이 잠깐 불가용하면 주입 없이 스케줄되고, 파드 재시작은 admission을 재실행하지 않아 계속 방치된다. IAM role/OIDC/route53 권한 자체는 정상(같은 role `gke-external-dns`을 쓰는 external-dns는 멀쩡).

## 즉시 조치 (완료, 이 PR 외)
cert-manager 컨트롤러 파드 재시작 → webhook 재admission으로 IRSA 재주입 확인. (현재 라이브 파드는 이미 정상 주입 상태이며, 죽은 옛 Order는 백오프 후 재발급되어 갱신됨.)

## 이 PR (재발 방지)
`AWS_*` env + projected serviceaccount token 볼륨을 cert-manager 차트 values에 **명시 주입**해 webhook 의존을 제거한다. webhook이 주입하던 것과 동일하게 미러링했고, `AWS_WEB_IDENTITY_TOKEN_FILE`이 이미 있으면 webhook은 no-op이라 중복 마운트 없음. 기존 role-arn 어노테이션으로 가드되어 9c-main/9c-internal에 동일 적용.

## 검증 (helm template, 로컬)
- bootstrap-v2 → cert-manager Application 렌더: role-arn 치환·유효 YAML 확인
- 렌더된 values를 실제 `jetstack/cert-manager v1.16.3`에 주입 → 컨트롤러 Deployment에 `AWS_ROLE_ARN`(=gke-external-dns), `AWS_WEB_IDENTITY_TOKEN_FILE`, projected `aws-iam-token`(audience `sts.amazonaws.com`, exp 86400) 볼륨·마운트 정상 확인 — **9c-main / 9c-internal 양쪽**
- 전체 bootstrap-v2 차트 양 클러스터 렌더 클린(템플릿 에러 없음)

## 롤아웃 주의
- bootstrap ArgoCD app은 **auto-sync 없음** → 머지 후 수동 sync 필요.
- sync 시 cert-manager Deployment가 새 pod spec으로 재생성되며, 그때부터 IRSA 주입이 webhook과 무관하게 보장됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)