### PR TITLE
feat(portal): DB 마이그레이션 자동화 — Deployment initContainer (PLD-1401)

### DIFF
--- a/charts/portal/templates/deployment.yaml
+++ b/charts/portal/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       #   공유 DB라 포탈 하나에만 둠(백오피스까지 커버). 적용할 게 없으면 no-op으로 즉시 통과. advisory lock으로 동시성 안전.
       initContainers:
         - name: migrate
-          image: "{{ .Values.migrate.image.repository }}:{{ .Values.migrate.image.tag }}"
+          image: "{{ .Values.migrate.image.repository }}:{{ .Values.migrate.image.tag | default .Values.portalService.image.tag }}"
           imagePullPolicy: {{ .Values.migrate.image.pullPolicy | default "Always" }}
           envFrom:
             - secretRef:

--- a/charts/portal/templates/deployment.yaml
+++ b/charts/portal/templates/deployment.yaml
@@ -17,6 +17,23 @@ spec:
         app: {{ .Release.Name }}
         component: portal
     spec:
+      {{- if .Values.migrate.enabled }}
+      # (PLD-1401) DB 마이그레이션 — 앱 컨테이너 시작 '전에' initContainer로 prisma migrate deploy 1회.
+      #   migrator 이미지(prisma CLI + schema + migrations 포함). DATABASE_URL은 {{ .Release.Name }}-secrets에서 주입.
+      #   실패 시 pod가 Init에서 멈춰 새 pod가 Ready 안 됨 → rollingUpdate가 옛 pod 유지(잘못된 마이그레이션 배포 차단).
+      #   공유 DB라 포탈 하나에만 둠(백오피스까지 커버). 적용할 게 없으면 no-op으로 즉시 통과. advisory lock으로 동시성 안전.
+      initContainers:
+        - name: migrate
+          image: "{{ .Values.migrate.image.repository }}:{{ .Values.migrate.image.tag }}"
+          imagePullPolicy: {{ .Values.migrate.image.pullPolicy | default "Always" }}
+          envFrom:
+            - secretRef:
+                name: {{ .Release.Name }}-secrets
+          {{- with .Values.migrate.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Values.portalService.name }}
           image: "{{ .Values.portalService.image.repository }}:{{ .Values.portalService.image.tag }}"

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -66,3 +66,21 @@ backofficeService:
     provider: AWS
     prefix: "9c-internal-v2/backoffice"
   cronjobs:
+
+# (PLD-1401) DB 마이그레이션 자동화 — 포탈 Deployment의 initContainer로 prisma migrate deploy 1회.
+#   기본 off → 오버레이에서 opt-in. 프로드는 돈-인접이라 기본 off 권장(수동 게이트 유지).
+#   인터널은 migrator 이미지가 internal-latest에 존재하게 된 뒤(모노레포+migrator develop 머지 후) enabled:true.
+#   nodeSelector는 pod(portalService)를 따름 — initContainer 별도 지정 불필요.
+migrate:
+  enabled: false
+  image:
+    repository: planetariumhq/9c-portal-migrator
+    tag: "internal-latest"
+    pullPolicy: Always
+  resources:
+    limits:
+      cpu: 1
+      memory: 1Gi
+    requests:
+      cpu: 250m
+      memory: 512Mi

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -71,11 +71,13 @@ backofficeService:
 #   기본 off → 오버레이에서 opt-in. 프로드는 돈-인접이라 기본 off 권장(수동 게이트 유지).
 #   인터널은 migrator 이미지가 internal-latest에 존재하게 된 뒤(모노레포+migrator develop 머지 후) enabled:true.
 #   nodeSelector는 pod(portalService)를 따름 — initContainer 별도 지정 불필요.
+#   image.tag는 지정 안 하면 portalService.image.tag를 그대로 따라감(prod=핀 sha, internal=internal-latest).
+#   → 앱↔migrator 태그 드리프트 원천 차단. 굳이 다르게 쓰려면 여기 tag를 명시.
+#   (전제: migrator 이미지가 portal과 같은 sha로 빌드됨 — build-push.yml의 build-migrator가 portal과 동일 조건.)
 migrate:
   enabled: false
   image:
     repository: planetariumhq/9c-portal-migrator
-    tag: "internal-latest"
     pullPolicy: Always
   resources:
     limits:


### PR DESCRIPTION
## 개요 (PLD-1401)
포탈 DB 마이그레이션을 **배포에 자동 편입**. 앱 컨테이너 시작 '전에' `prisma migrate deploy`를 1회 실행하는 **initContainer**를 포탈 Deployment에 추가.

## 방식
- `charts/portal/templates/deployment.yaml`: `migrate.enabled`일 때만 `migrate` initContainer 렌더. 이미지 = 별도 migrator 이미지(`9c-portal-migrator`, prisma CLI+schema+migrations 포함 — 앱 standalone엔 없음). `DATABASE_URL`은 `{release}-secrets`(ExternalSecret)에서 주입.
- 실패 시 pod가 Init에서 정체 → 새 pod Ready 안 됨 → rollingUpdate가 옛 pod 유지 = **잘못된 마이그레이션이 배포를 차단**.
- 공유 DB라 **포탈 하나에만** 부착(백오피스까지 커버). 적용할 게 없으면 no-op. Prisma advisory lock으로 동시성 안전.
- **initContainer 채택 이유**: ArgoCD sync뿐 아니라 `kubectl set image`/rollout restart 등 **pod가 뜨는 모든 경로**에서 동작(PreSync hook Job은 sync 경로에서만).

## 안전
- `migrate.enabled: false` **기본** — 머지해도 no-op(initContainer 미렌더). 오버레이에서 opt-in.
- **프로드는 기본 off 유지 권장**(돈-인접, 수동 게이트). 인터널은 migrator 이미지가 `internal-latest`로 존재하게 된 뒤(모노레포+migrator develop 머지 후) `enabled:true` 전환.

## 검증
- 인터널서 migrator 이미지(`test-monorepo`)를 1회 Job으로 실행 → `migrate deploy` → **"No pending migrations to apply"** clean 종료 확인(이미지 동작 + DATABASE_URL 경로 + 마이그레이션 정합성).
- `helm template` 렌더 확인: enabled=true → initContainer 1개, false → 0개.

## 의존
- migrator 이미지 CI/Dockerfile은 **9c-portal 별도 PR**(packages/database/Dockerfile + build-push.yml build-migrator 잡). 그 PR 머지 + `9c-portal-migrator:internal-latest` 이미지 생성 후 인터널 활성화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
