### PR TITLE
chore(portal): bump prod portal+backoffice to main-8553220b (monorepo 통합포인트/리딤)

### DIFF
--- a/9c-main/portal/values.yaml
+++ b/9c-main/portal/values.yaml
@@ -11,7 +11,7 @@ portalService:
     node.kubernetes.io/type: baremetal
   image:
     repository: planetariumhq/9c-portal
-    tag: main-5ccaf2b0f078e0a3ca3ce7b103d9251b163b6b45
+    tag: main-8553220b1bfd37bd2040bb92b0f140cb39ed92e6
     pullPolicy: Always
   externalSecret:
     enabled: true
@@ -37,7 +37,7 @@ backofficeService:
     node.kubernetes.io/type: baremetal
   image:
     repository: planetariumhq/9c-portal-backoffice
-    tag: main-63ab8eab20b6dcd85dc5c0614f156c1f21ae6710
+    tag: main-8553220b1bfd37bd2040bb92b0f140cb39ed92e6
     pullPolicy: Always
   externalSecret:
     enabled: true


### PR DESCRIPTION
## 요약
prod 포탈·백오피스 이미지를 모노레포 통합 릴리즈로 bump.

| 서비스 | 기존 | 신규 |
|---|---|---|
| portal (L14) | `main-5ccaf2b0…` | `main-8553220b1bfd37bd2040bb92b0f140cb39ed92e6` |
| backoffice (L40) | `main-63ab8eab…` | `main-8553220b1bfd37bd2040bb92b0f140cb39ed92e6` |

- 릴리즈 내용: **RB-1848/1850 통합 포인트 원장 + 글로리 리딤** (9c-portal `develop→main` #1262, + CI 게이트 수정 #1263 머지 커밋 `8553220b`)
- 모노레포 전환으로 portal/backoffice가 **동일 sha** 공유(이전엔 별도 repo라 sha 상이)
- 이미지 Docker Hub 확인 완료(둘 다 존재).

## ⚠️ 배포 순서 (반드시 지킬 것)
1. **prod DB `migrate deploy` 먼저** (사람 실행) — 신규 코드는 신규 스키마 전제. sync보다 선행.
2. 본 PR 머지 → **ArgoCD 수동 sync**(portal 앱, auto-sync 없음).

### prod DB 선점검 (read-only 완료 — 전부 GREEN)
| 점검 | 결과 |
|---|---|
| 적용될 마이그레이션 | 5개 pending (add_quest_tables/create_redemption_table/generalize_reward/drop_quest_point_earning/rb_web3_address_unique) |
| 낀(실패/롤백) 마이그레이션 | 없음 → deploy abort 리스크 없음 |
| redemption / quest_point_earning 테이블 | 미존재(greenfield) |
| **rb_web3_address_unique 영향** | **중복 0 (207/207 유일) → unlink 계정 0, 데이터 영향 없음** |

## 비고
- **리딤 활성화**는 RB팀 prod `glory.*` 배포(3시) 후 재프로브 확인 필요. env(REDEEM_ENABLED=true, GLORY_PER_NCG=50, COOLDOWN_MS=0, V8_GATEWAY_URL)는 prod secret에 세팅 완료.
- 롤백: 태그를 각각 `main-5ccaf2b0…`/`main-63ab8eab…`로 되돌리고 sync. (단, DB 마이그레이션은 forward-only라 스키마는 롤백 안 됨 — 신규 스키마는 구 코드와 호환)

🤖 Generated with [Claude Code](https://claude.com/claude-code)