### PR TITLE
chore(rb): dev/staging/prod 이미지 태그 git-4d8d9da로 범프

### DIFF
--- a/9c-internal/ragnarok-breaker-dev-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web2/values.yaml
@@ -5,12 +5,12 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 v8Gateway:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 logStream:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d

--- a/9c-internal/ragnarok-breaker-dev-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-dev-web3/values.yaml
@@ -5,12 +5,12 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 v8Gateway:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 logStream:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d

--- a/9c-internal/ragnarok-breaker-staging-web2/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web2/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 v8Gateway:
   image:
-    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 logStream:
   image:
-    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 # 메일 지급 워커 — staging 검증용 활성화. tag = petpop build:mail-send-worker 산출 이미지.
 # 발송 계정: 공유 워커/게이트웨이 계정을 재사용(admin.ts mailSendWorker role 등록됨). 워커가
@@ -23,7 +23,7 @@ logStream:
 mailSendWorker:
   enabled: true
   image:
-    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
   httpRoute:
     enabled: true
     hostnames:
@@ -36,7 +36,7 @@ mailSendWorker:
 leagueRewardWorker:
   enabled: true
   image:
-    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
   config:
     verseLabel: staging-w2
 
@@ -55,7 +55,7 @@ leagueRewardWorker:
 playfullWorker:
   enabled: true
   image:
-    tag: git-b7009db27f03ffb21864dd72b0ca4a6a67fd74e5
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 # web2→web3 마이그레이션 브리지 — web2 verse 네임스페이스에 배치(크로스-verse 싱글톤).
 # ⚠ 반드시 이 한 네임스페이스에서만 enable — staging-web3 에는 절대 켜지 말 것

--- a/9c-internal/ragnarok-breaker-staging-web3/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging-web3/values.yaml
@@ -5,15 +5,15 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 v8Gateway:
   image:
-    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 logStream:
   image:
-    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 # 메일 지급 워커 — staging-web3 도 web2 와 동일하게 활성화(그간 web2 만 있었음).
 # tag = staging 검증 이미지(web2 와 동일). 발송 계정: 공유 워커/게이트웨이 계정 재사용
@@ -22,7 +22,7 @@ logStream:
 mailSendWorker:
   enabled: true
   image:
-    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
   httpRoute:
     enabled: true
     hostnames:
@@ -35,7 +35,7 @@ mailSendWorker:
 leagueRewardWorker:
   enabled: true
   image:
-    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
   config:
     verseLabel: staging-w3
 
@@ -54,4 +54,4 @@ leagueRewardWorker:
 playfullWorker:
   enabled: true
   image:
-    tag: git-b7009db27f03ffb21864dd72b0ca4a6a67fd74e5
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d

--- a/9c-internal/ragnarok-breaker-staging/values.yaml
+++ b/9c-internal/ragnarok-breaker-staging/values.yaml
@@ -5,12 +5,12 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 v8Gateway:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 logStream:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d

--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,22 +5,22 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-55f0ca0126a2d3daebc63d2c616d638127c97cdb
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 v8Gateway:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 logStream:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 # Anti-cheat → Slack alert worker (prod only). SLACK_VIOLATION_WEBHOOK_URL is
 # read from the ragnarok-breaker-env SecretsManager entry for this namespace.
 anticheatAlertWorker:
   enabled: true
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 # 메일 지급 워커 — prod web2 활성화. tag = petpop build:mail-send-worker 산출 이미지
 #   (env-agnostic, SM 으로 env 주입 → staging 검증 이미지 재사용).
@@ -31,7 +31,7 @@ anticheatAlertWorker:
 mailSendWorker:
   enabled: true
   image:
-    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
   httpRoute:
     enabled: true
     hostnames:
@@ -47,6 +47,6 @@ mailSendWorker:
 leagueRewardWorker:
   enabled: true
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
   config:
     verseLabel: prod-w2

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,22 +5,22 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-55f0ca0126a2d3daebc63d2c616d638127c97cdb
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 v8Gateway:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 logStream:
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 # Anti-cheat → Slack alert worker (prod only). SLACK_VIOLATION_WEBHOOK_URL is
 # read from the ragnarok-breaker-env SecretsManager entry for this namespace.
 anticheatAlertWorker:
   enabled: true
   image:
-    tag: git-35a74b3660456b21eb29b1342bc3d835070b815b
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
 
 # 메일 지급 워커 — prod web3 활성화. tag = petpop build:mail-send-worker 산출 이미지
 #   (env-agnostic, SM 으로 env 주입 → staging 검증 이미지 재사용).
@@ -31,7 +31,7 @@ anticheatAlertWorker:
 mailSendWorker:
   enabled: true
   image:
-    tag: git-a5db7f0fa8877084f6c992b391e9d2a7b037c3c0
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
   httpRoute:
     enabled: true
     hostnames:
@@ -47,6 +47,6 @@ mailSendWorker:
 leagueRewardWorker:
   enabled: true
   image:
-    tag: git-c3da22f0afb86d512a15769b52ad1c5464b76c1d
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
   config:
     verseLabel: prod-w3

--- a/9c-main/ragnarok-breaker-prod/values.yaml
+++ b/9c-main/ragnarok-breaker-prod/values.yaml
@@ -23,4 +23,4 @@ anticheatAlertWorker:
 analyticsWorker:
   enabled: true
   image:
-    tag: git-6a36a446c18128a2e8fe1b142a87b96ac5467440
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d


### PR DESCRIPTION
## 변경 사항
ragnarok-breaker 전 환경의 이미지 태그를 `git-4d8d9da39b0515d55f0a61136175d59a8f44224d`로 통일합니다.

### 9c-internal (dev/staging)
- **dev-web2 / dev-web3 / staging**: worker, v8Gateway, logStream
- **staging-web2 / staging-web3**: 위 3개 + mailSendWorker, leagueRewardWorker, playfullWorker

### 9c-main (prod)
- **prod-web2 / prod-web3**: worker, v8Gateway, logStream, anticheatAlertWorker, mailSendWorker, leagueRewardWorker
- **prod**: analyticsWorker

## 제외
- migrationBridge (`develop` 플레이스홀더 — CI build:migration-bridge 산출 이미지 핀 전)

## 참고
mailSendWorker·leagueRewardWorker·playfullWorker·anticheatAlertWorker·analyticsWorker는 별도 CI 잡으로 빌드되는 이미지라, 해당 커밋 CI에서 이미지가 산출됐는지 sync 전 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)