### PR TITLE
feat(portal): 리딤 통계 CronJob + backoffice 태그 bump (main-a3e09d3b)

### DIFF
--- a/9c-main/portal/values.yaml
+++ b/9c-main/portal/values.yaml
@@ -52,3 +52,9 @@ backofficeService:
       schedule: "*/15 * * * *"
       endpoint: "https://portal.planetarium.team/api/scheduler/transaction"
       tokenEnvName: "SCHEDULER_API_KEY"
+    # 글로리 리딤 날짜별 통계 → Slack #9c-metrics (read-only 집계, 돈 액션 없음). 매일 10:00 KST(01:00 UTC).
+    # ⚠️ 엔드포인트(9c-portal PR #1264)가 prod backoffice에 배포된 뒤 유효. 그 전엔 404(무해).
+    - name: redeem-stats
+      schedule: "0 1 * * *"
+      endpoint: "https://portal.planetarium.team/api/scheduler/redeem-stats"
+      tokenEnvName: "SCHEDULER_API_KEY"

--- a/9c-main/portal/values.yaml
+++ b/9c-main/portal/values.yaml
@@ -37,7 +37,7 @@ backofficeService:
     node.kubernetes.io/type: baremetal
   image:
     repository: planetariumhq/9c-portal-backoffice
-    tag: main-8553220b1bfd37bd2040bb92b0f140cb39ed92e6
+    tag: main-a3e09d3bc37d84b19e2d078ddec5e7ebe213c068
     pullPolicy: Always
   externalSecret:
     enabled: true


### PR DESCRIPTION
`9c-main/portal` overlay에 **① backoffice 태그 bump + ② 글로리 리딤 통계 CronJob** 함께.

## 변경
1. **backoffice 이미지 태그 bump** (L40): `main-8553220b…` → `main-a3e09d3bc37d84b19e2d078ddec5e7ebe213c068`
   - 리딤 날짜별 통계 엔드포인트(`/api/scheduler/redeem-stats`, 9c-portal #1265 릴리즈) 포함 이미지
   - portal(L14)은 코드 변화 없어 8553220b 유지 / 스키마 변경 없음 → DB 마이그레이션 불필요
2. **CronJob 추가**: 매일 10:00 KST(`0 1 * * *`) → redeem-stats 엔드포인트 → 이번달 날짜별 리딤 통계 Slack #9c-metrics 포스트

## 배포
머지 후 ArgoCD portal sync → backoffice main-a3e09d3b 롤아웃 + 크론 등록. (엔드포인트 dry-run 사전 확인 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)