### PR TITLE
chore(portal): bump prod backoffice to main-0dd2760b (NCG·PTS 병기)

### DIFF
--- a/9c-main/portal/values.yaml
+++ b/9c-main/portal/values.yaml
@@ -37,7 +37,7 @@ backofficeService:
     node.kubernetes.io/type: baremetal
   image:
     repository: planetariumhq/9c-portal-backoffice
-    tag: main-a3e09d3bc37d84b19e2d078ddec5e7ebe213c068
+    tag: main-0dd2760b293051c07cedeb32e6f59575e95086c9
     pullPolicy: Always
   externalSecret:
     enabled: true


### PR DESCRIPTION
## 요약
prod backoffice 이미지 태그 bump — **금액 표시 NCG·PTS 병기**.

| | 기존 | 신규 |
|---|---|---|
| backoffice (L40) | `main-a3e09d3b…` | `main-0dd2760b293051c07cedeb32e6f59575e95086c9` |

## 배경
7/23 통합포인트 업데이트로 백오피스 금액이 포인트(×100)로만 보여, **출금 승인 시** 금액을 오해하는 운영 문의 발생 (예: `136.80 NCG`가 `13,680`으로 보임). → 전 금액 표시를 `formatNcgWithPoints`로 **"136.80 NCG (13,680 PTS)"** 병기 (9c-portal #1266 → #1267 릴리즈, main `0dd2760b`).

## 비고
- **표시 전용** 변경 → 저장 규약/스키마 불변, **DB 마이그레이션 불필요**
- portal(L14)은 코드 변화 없어 `main-8553220b` 유지 (backoffice만 롤아웃)
- 이미지 Docker Hub 확인 완료(200)

## 배포
머지 후 **ArgoCD portal sync** → backoffice가 `main-0dd2760b`로 롤아웃. (운영자 승인 대기 중 — sync 후 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)