### PR TITLE
fix(monitoring): scrape all longhorn-manager pods via endpoints SD

### DIFF
--- a/9c-main/values.yaml
+++ b/9c-main/values.yaml
@@ -112,9 +112,23 @@ prometheus:
         metrics_path: /metrics
         scrape_interval: 30s
         scrape_timeout: 10s
-        static_configs:
-          - targets:
-            - longhorn-backend.longhorn-system.svc.cluster.local:9500
+        # Scrape every longhorn-manager pod via endpoints SD, not the single
+        # load-balanced ClusterIP. Each manager only exports longhorn_volume_*
+        # metrics for volumes attached on its own node, so scraping the Service
+        # only ever hit one manager (~8 of 21 volumes) and the visible set
+        # flapped between scrapes — making per-PVC panels/alerts (e.g. the
+        # "Heimdall Headless PVC usage" rule) intermittently fire DatasourceNoData.
+        kubernetes_sd_configs:
+          - role: endpoints
+            namespaces:
+              names:
+                - longhorn-system
+        relabel_configs:
+          - source_labels:
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_endpoint_port_name
+            action: keep
+            regex: longhorn-backend;manager
       - job_name: kube-state-metrics
         metrics_path: /metrics
         scrape_interval: 30s


### PR DESCRIPTION
## 문제
`DatasourceNoData` — **"Heimdall Headless PVC usage"** Grafana 알람이 랜덤하게 발화 (2026-07-25 22:51, 2026-07-27 03:25 KST).

근본 원인: `longhorn` Prometheus 스크랩 job이 `longhorn-backend` **단일 ClusterIP**를 타겟으로 잡음. kube-proxy가 매 스크랩을 ~14개 longhorn-manager 파드 중 **1개**로만 라우팅하는데, 매니저는 **자기 노드에 attach된 볼륨의 `longhorn_volume_*`만** export → Prometheus가 21개 볼륨 중 **~8개만** 보고, 보이는 집합이 스크랩마다 요동침. 실사용 Heimdall headless PVC(`remote-headless-data-1`)가 수시로 누락되어 알람 쿼리가 빈 결과 → `DatasourceNoData`.

실제 스토리지/워크로드는 정상 → **오탐(false alarm)**.

## 변경
`static_configs` 단일 타겟 → `kubernetes_sd_configs: role: endpoints`(longhorn-system의 `longhorn-backend` 서비스)로 전환해 **모든 manager 엔드포인트를 스크랩**. relabel로 `longhorn-backend` + `manager` 포트만 keep.

- RBAC 확인 완료: `prometheus-server` clusterrole에 `services/endpoints/pods` get/list/watch 존재 → endpoints SD 정상 동작.
- 영향 범위: **9c-main 모니터링만** (9c-internal엔 이 job 없음).

## 검증 (ArgoCD sync 후)
```
count(longhorn_volume_actual_size_bytes)   # 8  -> ~21
count(up{job="longhorn"} == 1)             # 1  -> ~10 (ready managers)
```
+ "Heimdall Headless PVC usage" 알람 NoData 명멸 중단 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
