### PR TITLE
fix(monitoring): pin 9c-main prometheus PVC to 60Gi (stop OutOfSync)

### DIFF
--- a/9c-main/values.yaml
+++ b/9c-main/values.yaml
@@ -74,6 +74,10 @@ grafana:
     - monitoring.planetarium.network
 prometheus:
   server:
+    # PVC was expanded 50Gi -> 60Gi live (PVCs can't shrink); pin desired to 60Gi
+    # so the prometheus ArgoCD app stops sitting OutOfSync on this drift.
+    persistentVolume:
+      size: 60Gi
     extraScrapeConfigs:
       - job_name: scrape-headlesses
         metrics_path: /metrics

--- a/common/bootstrap-v2/templates/prometheus.yaml
+++ b/common/bootstrap-v2/templates/prometheus.yaml
@@ -40,7 +40,10 @@ spec:
         server:
           enabled: true
           persistentVolume:
-            size: 50Gi
+            # Per-cluster override; defaults to 50Gi when unset (e.g. 9c-internal).
+            # 9c-main's PVC was expanded to 60Gi live, so it overrides here to keep
+            # the app in Sync (a PVC cannot be shrunk back to 50Gi).
+            size: {{ dig "server" "persistentVolume" "size" "50Gi" .Values.prometheus }}
           retention: "90d"
           strategy:
             type: Recreate


### PR DESCRIPTION
## 문제
`prometheus` ArgoCD 앱이 **2026-06-16부터 OutOfSync**, 마지막 sync는 **Failed** 상태로 방치.

원인: 9c-main의 `prometheus-server` PVC가 과거에 **50Gi → 60Gi로 확장**됐는데(live/capacity 모두 60Gi, Bound), 차트 값은 `50Gi` 그대로. ArgoCD가 60Gi를 50Gi로 되돌리려 하지만 **PVC는 축소 불가** → apply 실패 → selfHeal이 매번 실패하고 앱이 영원히 OutOfSync.

## 변경
공유 템플릿 `common/bootstrap-v2/templates/prometheus.yaml`의 PVC size를 **`dig`로 파라미터화(기본 `50Gi`)** 하고, **9c-main에서만 `60Gi`로 override**.

- `common/bootstrap-v2`는 9c-main·9c-internal **둘 다** 사용 → 하드코딩 대신 파라미터화해 **9c-internal(50Gi)은 무영향**.
- 9c-main desired=60Gi가 live 60Gi와 일치 → PVC Synced → 앱 Synced 복귀.

## 검증
```
helm template bs common/bootstrap-v2 -f 9c-main/values.yaml     # size: 60Gi
helm template bs common/bootstrap-v2 -f 9c-internal/values.yaml # size: 50Gi
```
양쪽 렌더 에러 없음. (9c-internal live PVC도 50Gi로 확인 → override 없이 그대로 유지)

## 머지 후
`bootstrap` 앱(수동 sync)을 sync하면 prometheus Application 재렌더 → PVC diff 사라져 `prometheus` 앱이 Synced로 복귀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
