### PR TITLE
feat(ragnarok-breaker): enable playfull-worker in prod web2/web3

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -50,3 +50,22 @@ leagueRewardWorker:
     tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
   config:
     verseLabel: prod-w2
+
+# Playfull CPE 아웃바운드 워커 — prod web2 활성화 (per-env consumer, own Redis).
+# 파이프라인: 게임서버가 검증된 stage_clear 시 playfull_event 로그 emit
+#   → log-stream 이 playfull-event 큐로 라우팅(LOG_STREAM_ENABLE_PLAYFULL=true 일 때만)
+#   → 이 워커가 소비해 HMAC 서명 후 Playfull Events API 로 POST.
+# 워커는 V8 의존이 없다 — 잡을 받아 서명 후 POST 할 뿐. tag = staging 검증 이미지 재사용.
+#
+# ⚠ sync 전 AWS SM ragnarok-breaker/prod-web2 에 아래 키 추가 필요:
+#     PLAYFULL_CLIENT_ID / PLAYFULL_CLIENT_SECRET / PLAYFULL_GAME_ID
+#     PLAYFULL_DRY_RUN=true            (실 전송 없이 서명·바디만 로그. 검증 후 false)
+#     LOG_STREAM_ENABLE_PLAYFULL=true  (log-stream 이 큐로 라우팅. 미설정 시 emit drop)
+#     PLAYFULL_V8_ADMIN_TOKEN          (선택 — 지갑→이메일 귀속. 없으면 지갑 식별자만으로 흐름)
+#
+# ⚠ 순서: 워커가 먼저 뜬 뒤 LOG_STREAM_ENABLE_PLAYFULL 을 켠다.
+#   반대로 하면 컨슈머 없는 큐에 잡이 적체된다.
+playfullWorker:
+  enabled: true
+  image:
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -50,3 +50,22 @@ leagueRewardWorker:
     tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
   config:
     verseLabel: prod-w3
+
+# Playfull CPE 아웃바운드 워커 — prod web3 활성화 (per-env consumer, own Redis).
+# 파이프라인: 게임서버가 검증된 stage_clear 시 playfull_event 로그 emit
+#   → log-stream 이 playfull-event 큐로 라우팅(LOG_STREAM_ENABLE_PLAYFULL=true 일 때만)
+#   → 이 워커가 소비해 HMAC 서명 후 Playfull Events API 로 POST.
+# 워커는 V8 의존이 없다 — 잡을 받아 서명 후 POST 할 뿐. tag = staging 검증 이미지 재사용.
+#
+# ⚠ sync 전 AWS SM ragnarok-breaker/prod-web3 에 아래 키 추가 필요:
+#     PLAYFULL_CLIENT_ID / PLAYFULL_CLIENT_SECRET / PLAYFULL_GAME_ID
+#     PLAYFULL_DRY_RUN=true            (실 전송 없이 서명·바디만 로그. 검증 후 false)
+#     LOG_STREAM_ENABLE_PLAYFULL=true  (log-stream 이 큐로 라우팅. 미설정 시 emit drop)
+#     PLAYFULL_V8_ADMIN_TOKEN          (선택 — 지갑→이메일 귀속. 없으면 지갑 식별자만으로 흐름)
+#
+# ⚠ 순서: 워커가 먼저 뜬 뒤 LOG_STREAM_ENABLE_PLAYFULL 을 켠다.
+#   반대로 하면 컨슈머 없는 큐에 잡이 적체된다.
+playfullWorker:
+  enabled: true
+  image:
+    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d


### PR DESCRIPTION
## 요약

Playfull CPE 아웃바운드 워커(`playfull-worker`)를 **prod-web2 / prod-web3** 오버라이드에서 활성화합니다.

템플릿(`charts/ragnarok-breaker/templates/playfull-worker-deployment.yaml`), default values, staging 설정은 이미 #3523 에 머지돼 있고, **prod 오버라이드만 빠져 있어** 이 PR에서 채웁니다.

## 변경

- `9c-main/ragnarok-breaker-prod-web2/values.yaml` — `playfullWorker.enabled: true`
- `9c-main/ragnarok-breaker-prod-web3/values.yaml` — `playfullWorker.enabled: true`
- 이미지 태그는 형제 워크로드와 동일한 `git-4d8d9da39b0515d55f0a61136175d59a8f44224d` 로 핀 (staging 검증 이미지 재사용). per-env consumer + own Redis 라 두 env 각각 enable.

`helm template` 로 두 env 모두 정상 렌더 확인.

## 파이프라인

게임서버가 검증된 stage_clear 시 `playfull_event` 로그 emit → log-stream 이 `pf:playfull-event` 큐로 라우팅(`LOG_STREAM_ENABLE_PLAYFULL=true` 일 때만) → 이 워커가 소비해 HMAC 서명 후 Playfull Events API 로 POST. 워커는 V8 의존 없음.

## ⚠ ArgoCD sync 전 필수 (AWS SM)

`ragnarok-breaker/prod-web2` · `ragnarok-breaker/prod-web3` 에 아래 키 추가:

- `PLAYFULL_CLIENT_ID` / `PLAYFULL_CLIENT_SECRET` / `PLAYFULL_GAME_ID`
- `PLAYFULL_DRY_RUN=true` (실 전송 없이 서명·바디만 로그. 검증 후 `false`)
- `LOG_STREAM_ENABLE_PLAYFULL=true` — **워커가 먼저 뜬 뒤** 켤 것 (반대로 하면 컨슈머 없는 큐에 잡 적체)
- `PLAYFULL_V8_ADMIN_TOKEN` (선택 — 지갑→이메일 귀속. 없으면 지갑 식별자만으로 흐름)

🤖 Generated with [Claude Code](https://claude.com/claude-code)