### PR TITLE
chore(ragnarok-breaker): bump prod worker image to git-76ea20ca6

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
+    tag: git-76ea20ca637231fc00b831850f79401ac5ab90f7
 
 v8Gateway:
   image:

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,7 +5,7 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
+    tag: git-76ea20ca637231fc00b831850f79401ac5ab90f7
 
 v8Gateway:
   image:


### PR DESCRIPTION
Pin the Ragnarok Breaker anti-cheat **worker** on `prod-web2` / `prod-web3` to `git-76ea20ca637231fc00b831850f79401ac5ab90f7` (digest `sha256:845ce15e072f7641ebdf9ef693607474691a11ff0f704af53801f2ca9aaeb606`).

Previous pin was `git-4d8d9da39…` (v0.0.40), so this also carries the degen anti-cheat work merged since then.

## Why now

petpop!1476 added two degen conditional-blessing guards that run in **both** the server submit path and the worker post-validation path via shared code (`packages/shared/src/degen-feasibility.ts`). Deploying only the game server would leave worker post-validation on the old logic:

- **`DEGEN_SOUL_EXCEEDS_KILLS`** (new HIGH violation) — absorbed souls exceeding kill count is physically impossible (1 soul drops per kill) but had no upper bound, so inflating `enemySouls` passed any C11 threshold.
- **C07 `WAVESHOP_SKIP`** — `evalWaveshopSkip` fell back to `?? []`, and an empty array's `every()` is vacuous truth, so omitting `waveShopHistory` granted the +30% bonus unconditionally.

Found while investigating a confirmed client-tampering report on prod-web3 (`clearHp` forced to `99999` across 6 of 7 degen runs).

## Scope — worker only, deliberately

Only the `worker` tag moves. `v8Gateway` / `logStream` / `playfullWorker` / `analyticsWorker` stay on their current pins because their `build:*` jobs **failed** on pipeline 52066 for this SHA, so `git-76ea20ca6` images do not exist for them — bumping those would cause `ImagePullBackOff`.

Those build failures are a known, unrelated flake: jobs die at `Dockerfile:1` with a bare `ERROR: failed to solve: exit code: 1` and pass on retry. `build:worker` itself needed 3 attempts.

## Verification

- `build:worker` job **330260** (pipeline 52066, petpop `main` @ `76ea20ca6`) — success, pushed `:git-76ea20ca6…` and `:main`, both digest `sha256:845ce15e…`
- Upstream tests on that commit: shared 1190 pass · server 2152 pass · worker 366 pass · typecheck 16/16

## Rollback

Revert this commit — ArgoCD re-syncs to `git-4d8d9da39…`.
