### PR TITLE
chore(portal): bump prod portal image to main-e81d7c11 (CS #14917)

### DIFF
--- a/9c-main/portal/values.yaml
+++ b/9c-main/portal/values.yaml
@@ -11,7 +11,7 @@ portalService:
     node.kubernetes.io/type: baremetal
   image:
     repository: planetariumhq/9c-portal
-    tag: main-8553220b1bfd37bd2040bb92b0f140cb39ed92e6
+    tag: main-e81d7c11e0fcaa47a0913bc53cc389189d700920
     pullPolicy: Always
   externalSecret:
     enabled: true


### PR DESCRIPTION
프로드 포탈 이미지를 `main-8553220b…` → **`main-e81d7c11e0fcaa47a0913bc53cc389189d700920`** 으로 bump.

## 내용

CS #14917 — 코트디부아르(+225) 유저가 SMS 인증 전화번호를 등록하지 못하는 문제 수정. `react-phone-input-2` 2.15.1(마지막 릴리스 2022-07)의 하드코딩 마스크가 구 번호체계(8자리)에 멈춰 있어 2021-01 개편 후 10자리 번호의 뒤 2자리가 입력 단계에서 버려지고, 잘린 8자리는 `libphonenumber-js` 검증에서 invalid가 되어 Send Code까지 비활성 → 유저 우회 불가.

- 앱 PR: planetarium/9c-portal#1273 (fix), #1274 (release develop→main)
- 릴리스 델타: 전화번호 입력 컴포넌트 3파일 + 스펙 1개, +86줄. **DB 스키마·마이그레이션 없음**
- 백오피스 태그는 그대로 (`main-0dd2760b…`) — 백오피스 코드 변경 없음

## 검증

- `helm template portal charts/portal -f 9c-main/portal/values.yaml` 정상 렌더, 렌더 결과 이미지: portal `main-e81d7c11…` / backoffice `main-0dd2760b…`(변화 없음)
- 앱 쪽: 신규 스펙 4건 + 뮤테이션 회귀 검증, vitest 25 / jest 155 통과, #1273·#1274 CI 그린
- 배포 전 프로드 상태: ArgoCD `portal` 앱 **Synced / Healthy**, 실행 이미지 `main-8553220b…` × 2 replica (드리프트 없음)

## 배포 절차

1. 이 PR 머지
2. **ArgoCD `portal` 앱 수동 sync** — 이 앱은 auto-sync 없음
3. 검증: nine-chronicles.com 마이페이지 > 전화번호 등록에서 +225 선택 → 10자리 입력 시 `+225 07 07 12 34 56` 표시 및 Send Code 활성 확인

⚠️ 포탈 Deployment에는 liveness/readiness probe가 없다. 롤아웃 후 pod가 Running인데 응답이 없는 상태를 자동 감지하지 못하므로, sync 후 `kubectl -n portal get pods`와 실제 페이지 응답을 한 번 확인할 것.

🤖 Generated with [Claude Code](https://claude.com/claude-code)