### PR TITLE
chore(voucher): 인터널 복권 테스트 배포 (test 이미지 핀)

### DIFF
--- a/9c-internal/external-services/values.yaml
+++ b/9c-internal/external-services/values.yaml
@@ -92,7 +92,7 @@ iap:
     enabled: true
     stage: "internal"
     image:
-      tag: "git-9321af4246edb846db69a2c43df63cfbad5cfa16"
+      tag: "git-f885590fbe473d3d156b510caf6a4327f9688ce9" # (복권 테스트) yang/voucher-lottery-refactor. 검증 후 복구
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-internal-v2-seasonpass-worker"
 
@@ -100,6 +100,6 @@ iap:
     enabled: true
     stage: "internal"
     image:
-      tag: "git-9321af4246edb846db69a2c43df63cfbad5cfa16"
+      tag: "git-f885590fbe473d3d156b510caf6a4327f9688ce9" # (복권 테스트) yang/voucher-lottery-refactor. 검증 후 복구
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-internal-v2-iap-worker"

--- a/9c-internal/external-services/values.yaml
+++ b/9c-internal/external-services/values.yaml
@@ -92,7 +92,7 @@ iap:
     enabled: true
     stage: "internal"
     image:
-      tag: "git-f885590fbe473d3d156b510caf6a4327f9688ce9" # (복권 테스트) yang/voucher-lottery-refactor. 검증 후 복구
+      tag: "git-89de9a3341c94afa430bfff73734882c5a0b0eb2" # (복권 테스트) yang/voucher-lottery-refactor. 검증 후 복구
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-internal-v2-seasonpass-worker"
 
@@ -100,6 +100,6 @@ iap:
     enabled: true
     stage: "internal"
     image:
-      tag: "git-f885590fbe473d3d156b510caf6a4327f9688ce9" # (복권 테스트) yang/voucher-lottery-refactor. 검증 후 복구
+      tag: "git-89de9a3341c94afa430bfff73734882c5a0b0eb2" # (복권 테스트) yang/voucher-lottery-refactor. 검증 후 복구
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-internal-v2-iap-worker"

--- a/9c-internal/portal/values.yaml
+++ b/9c-internal/portal/values.yaml
@@ -10,7 +10,7 @@ portalService:
     node.kubernetes.io/node-index: "2"
   image:
     repository: planetariumhq/9c-portal
-    tag: "internal-latest"
+    tag: "test-monorepo" # (복권 테스트) ci-test/voucher-lottery 이미지. 검증 후 internal-latest로 복구
     pullPolicy: Always
   externalSecret:
     enabled: true
@@ -37,7 +37,7 @@ backofficeService:
     node.kubernetes.io/node-index: "2"
   image:
     repository: planetariumhq/9c-portal-backoffice
-    tag: "internal-latest"
+    tag: "test-monorepo" # (복권 테스트) ci-test/voucher-lottery 이미지. 검증 후 internal-latest로 복구
     pullPolicy: Always
   externalSecret:
     enabled: true

--- a/charts/external-services/templates/iap-background-job-worker.yaml
+++ b/charts/external-services/templates/iap-background-job-worker.yaml
@@ -80,6 +80,38 @@ spec:
                 secretKeyRef:
                   key: iap-sales-webhook-url
                   name: iap-env
+            # (PLD-1469/1472) NCG Voucher 발급/회수 트리거. optional=true → 키 없는 env(예: prod)에선
+            #   미주입 → config 기본값(voucher_grant_enabled=False)로 비활성. 인터널 iap-env에 키 세팅 시 활성.
+            - name: WORKER_VOUCHER_GRANT_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  key: voucher-grant-enabled
+                  name: iap-env
+                  optional: true
+            - name: WORKER_PORTAL_GRANT_URL
+              valueFrom:
+                secretKeyRef:
+                  key: portal-grant-url
+                  name: iap-env
+                  optional: true
+            - name: WORKER_PORTAL_REVOKE_URL
+              valueFrom:
+                secretKeyRef:
+                  key: portal-revoke-url
+                  name: iap-env
+                  optional: true
+            - name: WORKER_PORTAL_IAP_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: portal-iap-jwt-secret
+                  name: iap-env
+                  optional: true
+            - name: WORKER_VOUCHER_GRANT_CUTOFF_RECEIPT_ID
+              valueFrom:
+                secretKeyRef:
+                  key: voucher-grant-cutoff-receipt-id
+                  name: iap-env
+                  optional: true
           image: {{ $.Values.iap.worker.image.repository }}:{{ $.Values.iap.worker.image.tag }}
           {{- with $.Values.iap.worker.resources }}
           resources:

--- a/charts/external-services/templates/iap-background-job-worker.yaml
+++ b/charts/external-services/templates/iap-background-job-worker.yaml
@@ -106,10 +106,10 @@ spec:
                   key: portal-iap-jwt-secret
                   name: iap-env
                   optional: true
-            - name: WORKER_VOUCHER_GRANT_CUTOFF_RECEIPT_ID
+            - name: WORKER_VOUCHER_GRANT_CUTOFF
               valueFrom:
                 secretKeyRef:
-                  key: voucher-grant-cutoff-receipt-id
+                  key: voucher-grant-cutoff
                   name: iap-env
                   optional: true
           image: {{ $.Values.iap.worker.image.repository }}:{{ $.Values.iap.worker.image.tag }}


### PR DESCRIPTION
## 목적
복권 바우처(포탈 #1276 / IAP #475)를 **머지 없이** 인터널에서 테스트하기 위한 배포 준비. 테스트 이미지로 인터널 overlay 핀.

## 변경
- `9c-internal/portal`: portal·backoffice 이미지 → **`test-monorepo`** (`ci-test/voucher-lottery` 빌드, Voucher 탭 노출 build-arg 포함)
- `9c-internal/external-services`: iap api·worker → **`git-f885590...`** (`yang/voucher-lottery-refactor` 빌드)
- `iap-background-job-worker`: voucher 발급/회수 env 추가 — `WORKER_VOUCHER_GRANT_ENABLED`/`PORTAL_GRANT_URL`/`PORTAL_REVOKE_URL`/`PORTAL_IAP_JWT_SECRET`/`CUTOFF`. **`optional: true`** → 키 없는 env(prod)엔 미주입=비활성(안전)

## 검증
`helm template` 양 차트 렌더 정상(이미지 태그·voucher env·optional 반영, 에러 없음).

## ⚠️ 사람 조치 (상세 런북 별첨)
1. **iap-env(내부 AWS)** 에 voucher 키 세팅(URL·enabled·cutoff·**JWT는 포탈 JWT_IAP_SECRET_KEY와 동일**)
2. **portal-internal DB** `prisma migrate deploy`(PG<12면 SHOP_DRAW 수동+resolve) + `voucher_policy` seed(enabled=true)
3. **iap-internal DB** `alembic upgrade head` + `product_voucher_grant` seed(상품→티켓)
4. **ArgoCD 인터널 수동 sync** (portal + external-services)

## 되돌리기
검증 후 이미지 태그 원복(internal-latest / git-9321af) + iap-env voucher-grant-enabled=false + voucher_policy enabled=false.

⚠️ 테스트 전용 — 프로덕션 배포/머지 아님. 정식 배포는 #1276/#475 머지 경로.