### PR TITLE
chore(external-services): 복권 admin API 인터널 배포 (P1)

### DIFF
--- a/9c-internal/external-services/values.yaml
+++ b/9c-internal/external-services/values.yaml
@@ -92,7 +92,7 @@ iap:
     enabled: true
     stage: "internal"
     image:
-      tag: "git-89de9a3341c94afa430bfff73734882c5a0b0eb2" # (복권 테스트) yang/voucher-lottery-refactor. 검증 후 복구
+      tag: "git-b51e4a4abf152a9b7aaff480b7a8e3e0891b240f" # (복권 테스트) yang/voucher-lottery-refactor. 검증 후 복구
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-internal-v2-seasonpass-worker"
 
@@ -100,6 +100,6 @@ iap:
     enabled: true
     stage: "internal"
     image:
-      tag: "git-89de9a3341c94afa430bfff73734882c5a0b0eb2" # (복권 테스트) yang/voucher-lottery-refactor. 검증 후 복구
+      tag: "git-b51e4a4abf152a9b7aaff480b7a8e3e0891b240f" # (복권 테스트) yang/voucher-lottery-refactor. 검증 후 복구
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-internal-v2-iap-worker"

--- a/charts/external-services/templates/iap-api.yaml
+++ b/charts/external-services/templates/iap-api.yaml
@@ -174,6 +174,21 @@ spec:
                 secretKeyRef:
                   key: jwt-secret-9c
                   name: iap-env
+            # (PLD-1472) 바우처 상품매핑 admin — C1(정책 크로스read)/C3-lite(cap). optional=true →
+            #   키 없는 env(예: prod)에선 미주입 → config 기본 None(portal_prize_tables_url None이면
+            #   admin 매핑 저장이 503으로 fail-closed, cap None이면 C3-lite 스킵). 인터널 iap-env에 키 세팅 시 활성.
+            - name: API_PORTAL_PRIZE_TABLES_URL
+              valueFrom:
+                secretKeyRef:
+                  key: portal-prize-tables-url
+                  name: iap-env
+                  optional: true
+            - name: API_VOUCHER_GRANT_MAX_NCG_PER_GRANT
+              valueFrom:
+                secretKeyRef:
+                  key: voucher-grant-max-ncg-per-grant
+                  name: iap-env
+                  optional: true
           image: {{ $.Values.iap.api.image.repository }}:{{ $.Values.iap.api.image.tag }}
           {{- with $.Values.iap.api.resources }}
           resources:


### PR DESCRIPTION
## 목적
P1 복권 admin API(product-voucher-grant CRUD + R2 grant retryable + CSV C1b)를 인터널에 배포.

## 변경
- iap api+worker 태그 → `git-b51e4a4` (브랜치 `yang/pld-voucher-admin-iap`, 검증 후 복구)
- iap-api에 `API_PORTAL_PRIZE_TABLES_URL` / `API_VOUCHER_GRANT_MAX_NCG_PER_GRANT` env(secretKeyRef, optional=true)

## 사람 조치 (머지 후)
1. AWS `9c-internal-v2/external-services/iap-env` 에 키 추가:
   - `portal-prize-tables-url` = `http://portal-service.portal.svc.cluster.local:3000/api/voucher/prize-tables`
   - (선택) `voucher-grant-max-ncg-per-grant` = <C3-lite 상한, 미설정=스킵>
2. AWS `9c-internal-v2/portal/env` 에 `JWT_VOUCHER_ADMIN_SECRET` 추가(신규 랜덤). 포탈은 dataFrom extract라 자동 주입.
3. ArgoCD `9c-external-services` sync (iap 새 이미지+env). 포탈은 test-monorepo 재빌드 후 rollout restart.

⚠️ optional=true라 prod엔 무영향(키 없으면 미주입).

🤖 Generated with [Claude Code](https://claude.com/claude-code)