### PR TITLE
chore(external-services): iap 인터널 태그 → git-941fb68 (voucher CSV 3쌍)

### DIFF
--- a/9c-internal/external-services/values.yaml
+++ b/9c-internal/external-services/values.yaml
@@ -92,7 +92,7 @@ iap:
     enabled: true
     stage: "internal"
     image:
-      tag: "git-b51e4a4abf152a9b7aaff480b7a8e3e0891b240f" # (복권 테스트) yang/voucher-lottery-refactor. 검증 후 복구
+      tag: "git-941fb681b2c0f62cd207712bcbffdf8fc78aeb29" # (복권 테스트) yang/voucher-lottery-refactor. 검증 후 복구
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-internal-v2-seasonpass-worker"
 
@@ -100,6 +100,6 @@ iap:
     enabled: true
     stage: "internal"
     image:
-      tag: "git-b51e4a4abf152a9b7aaff480b7a8e3e0891b240f" # (복권 테스트) yang/voucher-lottery-refactor. 검증 후 복구
+      tag: "git-941fb681b2c0f62cd207712bcbffdf8fc78aeb29" # (복권 테스트) yang/voucher-lottery-refactor. 검증 후 복구
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-internal-v2-iap-worker"


### PR DESCRIPTION
voucher CSV 매핑을 (type,count) 고정 3쌍 슬롯으로 리팩터한 iap 빌드(git-941fb68) 인터널 반영. api+worker 태그만 bump. 머지 후 ArgoCD 9c-external-services sync(또는 이미 set-image로 라이브).