### PR TITLE
fix(snapshot): preload 로그 파일 선생성으로 tail 레이스 제거

### DIFF
--- a/charts/all-in-one/scripts/snapshots/preload_headless.sh
+++ b/charts/all-in-one/scripts/snapshots/preload_headless.sh
@@ -26,6 +26,15 @@ HEADLESS_LOG_DIR=${4:-"/data/snapshot_logs"}
 HEADLESS_LOG="$HEADLESS_LOG_DIR/$HEADLESS_LOG_NAME"
 mkdir -p "$HEADLESS_LOG_DIR"
 
+# Create the log file up front. run_headless() backgrounds headless with the
+# redirect applied in the forked child, so the file's open() races against the
+# `tail -f "$HEADLESS_LOG"` that wait_preloading() starts immediately after. If
+# tail loses, it exits with "cannot open ... No such file or directory", grep
+# sees EOF, MATCH comes back empty and the job falsely reports a preload
+# timeout seconds into the run. (Observed 2026-08-11 on pt6: alerted 6s in,
+# while the timeout is 144000s.)
+: > "$HEADLESS_LOG"
+
 PID_FILE="$HOME/headless_pid"
 function senderr() {
   echo "$1"
@@ -67,7 +76,7 @@ function run_headless() {
       {{- range $i, $s := $.Values.global.peerStrings }}
       --peer "$SEED{{ add $i 1 }}" \
       {{- end }}
-      > "$HEADLESS_LOG" 2>&1 &
+      >> "$HEADLESS_LOG" 2>&1 &
 
   PID="$!"
 


### PR DESCRIPTION
## 문제

2026-08-11 00:00 UTC, pt6에서 다음 알람이 발생했습니다.

```
[pt6] [K8S] Preload timed out with no completion log..
Check snapshot-partition-v200460 in 9c-pt6 cluster at preload_headless.sh.
```

그런데 **타임아웃이 아닙니다.** 컨테이너 시작 6초 만에 발생했고, 해당 분기의 `timeout`은 144000초(40시간)입니다.

| 시각 (UTC) | 이벤트 |
|---|---|
| 00:00:01 | 1차 컨테이너 시작 |
| 00:00:07 | Exit 1 + 알람 |
| 00:00:08 | 재시작 → 2차 시도 정상 완료 |

## 원인

`run_headless()`가 헤드리스를 `> "$HEADLESS_LOG" 2>&1 &`로 백그라운드 실행하는데, 로그 파일의 `open()`은 **fork된 자식**이 수행합니다. 부모 셸은 기다리지 않고 곧바로 `wait_preloading()`의 `tail -f "$HEADLESS_LOG"`로 진입하므로 둘이 경합합니다.

`tail`이 지면 이렇게 됩니다.

```
tail: cannot open '/data/snapshot_logs/headless_202608110000.log' for reading: No such file or directory
tail: no files remaining
```

`tail`이 즉시 죽으니 `grep -m1`은 빈 입력으로 EOF를 받고, `MATCH`가 공백이 되어 `[ -z "$MATCH" ]` 분기를 타 `senderr` + `kill $PID` + `exit 1` 합니다.

자식의 `open()`이 밀린 건 직전 `chmod 777 -R "$STORE_PATH"` 때문으로 보입니다. 수백 GB RocksDB 스토어에 재귀 chmod를, **로그 파일과 같은 HDD(sdb)** 에 겁니다.

## 수정

로그 파일을 백그라운드 실행 **전에** 생성하고 리다이렉트를 `>>`로 바꿔 경합 자체를 없앱니다. 정상 경로 동작은 동일합니다(빈 파일 생성 후 append).

## 검증

**1. 레이스 재현 및 수정 확인** (pt6, GNU bash 5.2.21 — 컨테이너와 동일 계열)

`open()`을 늦게 수행하는 writer + 즉시 실행되는 `tail -f`로 재현:

```
--- before fix (no pre-create) ---
RESULT[broken]: FALSE timeout alarm  <-- bug
--- after fix  (: > LOG)       ---
RESULT[fixed]: OK -> preloading is no longer needed
```

`broken` 케이스가 프로덕션 증상과 정확히 일치합니다.

**2. 실제 렌더 결과 문법 검증**

pt6의 라이브 ConfigMap(`odin-snapshot-script-partition`)에서 렌더된 스크립트를 받아 동일 패치를 적용 후 `bash -n` 통과 확인했습니다.

> `helm template`은 무관한 `9c-network/templates/validator.yaml`의 기존 에러로 실패합니다. `git stash`로 baseline에서도 동일하게 재현되는 것을 확인했으며 본 변경과 무관합니다.

## 영향 범위

- 이 스크립트만 변경. ConfigMap 갱신 후 **다음 preload 실행부터** 적용됩니다.
- 현재 실행 중인 잡에는 영향 없습니다.
- 템플릿 문법 추가 없음 (bash 2줄).

## 남은 동일 결함 (이 PR 범위 밖)

같은 fork/redirect 레이스가 아래에도 있습니다. 알람 문구만 `grep failed. Failed to preload.` 로 다릅니다. 별도로 정리할지 논의가 필요해 이번 PR에는 포함하지 않았습니다.

- `charts/snapshot/templates/configmap-partition.yaml` (66행 / 87행, 311행 / 332행)
- `charts/snapshot/templates/configmap-full.yaml` (66행 / 87행)
- `charts/snapshot/templates/configmap-partition-reset.yaml` (66행 / 87행)
- `charts/data-provider/templates/configmap-snapshot.yaml` (267행 / 288행)

## 참고

`#9c-mainnet` 채널 전체 이력에서 이 알람은 2회입니다 (2026-06-27, 2026-08-11). 빈도는 낮지만, 재시도가 분(分) 경계를 넘으면 `HEADLESS_LOG_NAME`이 `date -u +%Y%m%d%H%M`으로 새로 계산돼 "이미 존재하는 파일" 덕을 못 보고 같은 레이스를 다시 겪습니다. 이번엔 1초 만에 재시작해 자동 복구됐습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
