### PR TITLE
feat(iap): bump mainnet api image to git-b2a6bcb (retry 500 hotfix)

### DIFF
--- a/9c-main/external-services/values.yaml
+++ b/9c-main/external-services/values.yaml
@@ -138,7 +138,9 @@ iap:
     enabled: true
     stage: "mainnet"
     image:
-      tag: "git-9321af4246edb846db69a2c43df63cfbad5cfa16"
+      # PR #477 (/api/purchase/retry 500 수정). worker는 이 핫픽스로 바뀐 파일이
+      # 없어(apps/api 만 변경) 불필요한 재시작을 피하려고 그대로 둔다.
+      tag: "git-b2a6bcb950192f25dbc192a755fe14125617065e"
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-main-v2-iap-worker"
 


### PR DESCRIPTION
[NineChronicles.IAP#477](https://github.com/planetarium/NineChronicles.IAP/pull/477) 배포.

## 무엇을 고치는 배포인가

`POST /api/purchase/retry`가 세션 누락(`AttributeError: 'Depends' object has no attribute 'scalar'`)으로 **성공 경로에서 항상 500**이었다. 클라이언트는 응답을 못 받으면 `ConfirmPendingPurchase`(= consume)를 호출하지 않으므로, 패스류 결제가 소비되지 않은 채 스토어에서 "소유 중"으로 남아 **같은 패스를 다시 구매할 수 없었다.** 앱을 다시 켜도 매번 같은 500이라 자가 복구도 안 됐다.

배포되면 락인된 계정은 다음 앱 실행에서 자동 복구된다.

## 변경

`9c-main/external-services/values.yaml` 의 `iap.api.image.tag` 한 줄:

```
git-9321af4246edb846db69a2c43df63cfbad5cfa16
→ git-b2a6bcb950192f25dbc192a755fe14125617065e
```

`helm template` 렌더 결과 차이는 **iap-api 이미지 한 줄뿐**임을 확인했다.

## 범위를 좁힌 이유

- **api 만 올린다.** 이 핫픽스는 `apps/api` 만 건드려서(`git diff 9321af4..b2a6bcb -- apps/shared apps/worker` 결과 없음) worker 이미지는 내용이 동일하다. 지급 재시도(`iap.retryer`)·Tx 추적이 도는 워커를 이유 없이 재시작시킬 필요가 없다.
- **인터널은 손대지 않는다.** `9c-internal` 의 api·worker 는 복권 테스트 태그(`git-b51e4a4`, "검증 후 복구")에 고정돼 있다.
- **마이그레이션 없음.** 스키마 변경이 없다.

## 배포 시 주의 — 이 앱은 이미 OutOfSync 다

`9c-external-services` 앱은 **자동 sync가 없고**, 지금도 `iap-api`·`iap-background-job-worker` 두 리소스가 OutOfSync 다. 확인해보니 원인은 **git이 라이브보다 앞서 있는 것**으로, 바우처 관련 env 배선이 차트에 머지됐지만 sync가 안 된 상태다:

```
API_PORTAL_PRIZE_TABLES_URL, API_VOUCHER_GRANT_MAX_NCG_PER_GRANT
WORKER_VOUCHER_GRANT_ENABLED, WORKER_PORTAL_GRANT_URL
```

**무해하다** — 대응 키 4개가 `iap-env` 시크릿에 존재하지 않고 전부 `optional: true` 라 env 자체가 주입되지 않는다. 다만 sync하면 이 배선이 같이 적용되므로(= `iap-background-job-worker` 도 재시작된다) 알고 진행하는 게 좋다.

워커 재시작을 피하고 싶으면 리소스를 지정해 sync:

```
argocd app sync 9c-external-services --resource apps:Deployment:9c-external-services/iap-api
```

## 검증

- IAP CI(`Build Docker Images`) 머지 커밋 `b2a6bcb` 빌드 성공, Docker Hub 에 `planetariumhq/iap-api:git-b2a6bcb...` 존재 확인
- 배포 후: `POST /api/purchase/retry` 가 500 대신 200/400 을 반환하는지 로그로 확인 (그동안 이 엔드포인트의 성공률은 0% 였다)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
