### PR TITLE
chore(ragnarok-breaker): bump prod images to git-8d614bb8 (v0.0.55)

### DIFF
--- a/9c-main/ragnarok-breaker-prod-web2/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web2/values.yaml
@@ -5,22 +5,22 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-76ea20ca637231fc00b831850f79401ac5ab90f7
+    tag: git-8d614bb88a9c18894adce6453748b6f92243163c
 
 v8Gateway:
   image:
-    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
+    tag: git-8d614bb88a9c18894adce6453748b6f92243163c
 
 logStream:
   image:
-    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
+    tag: git-8d614bb88a9c18894adce6453748b6f92243163c
 
 # Anti-cheat → Slack alert worker (prod only). SLACK_VIOLATION_WEBHOOK_URL is
 # read from the ragnarok-breaker-env SecretsManager entry for this namespace.
 anticheatAlertWorker:
   enabled: true
   image:
-    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
+    tag: git-8d614bb88a9c18894adce6453748b6f92243163c
 
 # 메일 지급 워커 — prod web2 활성화. tag = petpop build:mail-send-worker 산출 이미지
 #   (env-agnostic, SM 으로 env 주입 → staging 검증 이미지 재사용).
@@ -31,7 +31,7 @@ anticheatAlertWorker:
 mailSendWorker:
   enabled: true
   image:
-    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
+    tag: git-8d614bb88a9c18894adce6453748b6f92243163c
   httpRoute:
     enabled: true
     hostnames:
@@ -47,7 +47,7 @@ mailSendWorker:
 leagueRewardWorker:
   enabled: true
   image:
-    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
+    tag: git-8d614bb88a9c18894adce6453748b6f92243163c
   config:
     verseLabel: prod-w2
 
@@ -68,7 +68,7 @@ leagueRewardWorker:
 playfullWorker:
   enabled: true
   image:
-    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
+    tag: git-8d614bb88a9c18894adce6453748b6f92243163c
 
 # web2→web3 계정 이전 브리지 — web2 verse 네임스페이스에 배치(크로스-verse 싱글톤).
 # staging(9c-internal/ragnarok-breaker-staging-web2)과 동일한 형태.
@@ -85,4 +85,4 @@ playfullWorker:
 migrationBridge:
   enabled: true
   image:
-    tag: git-30246f4a0a617b307ac751a542933023130988ed
+    tag: git-8d614bb88a9c18894adce6453748b6f92243163c

--- a/9c-main/ragnarok-breaker-prod-web3/values.yaml
+++ b/9c-main/ragnarok-breaker-prod-web3/values.yaml
@@ -5,22 +5,22 @@ imagePullSecret:
 
 worker:
   image:
-    tag: git-76ea20ca637231fc00b831850f79401ac5ab90f7
+    tag: git-8d614bb88a9c18894adce6453748b6f92243163c
 
 v8Gateway:
   image:
-    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
+    tag: git-8d614bb88a9c18894adce6453748b6f92243163c
 
 logStream:
   image:
-    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
+    tag: git-8d614bb88a9c18894adce6453748b6f92243163c
 
 # Anti-cheat → Slack alert worker (prod only). SLACK_VIOLATION_WEBHOOK_URL is
 # read from the ragnarok-breaker-env SecretsManager entry for this namespace.
 anticheatAlertWorker:
   enabled: true
   image:
-    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
+    tag: git-8d614bb88a9c18894adce6453748b6f92243163c
 
 # 메일 지급 워커 — prod web3 활성화. tag = petpop build:mail-send-worker 산출 이미지
 #   (env-agnostic, SM 으로 env 주입 → staging 검증 이미지 재사용).
@@ -31,7 +31,7 @@ anticheatAlertWorker:
 mailSendWorker:
   enabled: true
   image:
-    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
+    tag: git-8d614bb88a9c18894adce6453748b6f92243163c
   httpRoute:
     enabled: true
     hostnames:
@@ -47,7 +47,7 @@ mailSendWorker:
 leagueRewardWorker:
   enabled: true
   image:
-    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
+    tag: git-8d614bb88a9c18894adce6453748b6f92243163c
   config:
     verseLabel: prod-w3
 
@@ -68,4 +68,4 @@ leagueRewardWorker:
 playfullWorker:
   enabled: true
   image:
-    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
+    tag: git-8d614bb88a9c18894adce6453748b6f92243163c

--- a/9c-main/ragnarok-breaker-prod/values.yaml
+++ b/9c-main/ragnarok-breaker-prod/values.yaml
@@ -23,4 +23,4 @@ anticheatAlertWorker:
 analyticsWorker:
   enabled: true
   image:
-    tag: git-4d8d9da39b0515d55f0a61136175d59a8f44224d
+    tag: git-8d614bb88a9c18894adce6453748b6f92243163c


### PR DESCRIPTION
petpop v0.0.55 (8d614bb88a9c18894adce6453748b6f92243163c) 산출 이미지로 prod ragnarok-breaker 워크로드 전체를 일괄 정렬한다. prod/prod-web2/prod-web3 오버레이의 image.tag 16곳 — worker, v8-gateway, log-stream, anticheat-alert-worker, mail-send-worker, league-reward-worker, playfull-worker, analytics-worker, migration-bridge.

동기: 글로리(GLORY) 메일 전용 지급 핫픽스(petpop MR!1706)가 v0.0.55 에 포함돼 V8 게임 서버·클라는 prod 에 배포됐지만, mail-send-worker 는 k8s 이미지 핀이 git-4d8d9da3(2026-07-23)에 묶여 있어 옛 shared 코드를 돌고 있다. 그 코드의 validateMailReward 는 GLORY 를 거부하므로 /preview·/confirm 이 400 으로 튕겨 디젠 시즌 보상 지급이 불가능하다.

검증
- 대상 태그가 실제로 push 됐는지 petpop 파이프라인 #53116 잡 로그로 확인. build:{worker,v8-gateway,log-stream,playfull-worker,anticheat-alert-worker, mail-send-worker,league-reward-worker,analytics-worker,migration-bridge} 9종 전부 success + `pushing manifest ...:git-8d614bb8...` 확인 (v0.0.55/latest 동시 태깅).
- 기존 핀 대비 전부 forward bump — git-76ea20ca(worker, 07-30)·git-30246f4a (migration-bridge, 08-10) 모두 8d614bb8 의 조상. 롤백되는 워크로드 없음.
- 변경은 tag 라인 16줄뿐. enabled/호스트명/config 등 다른 키는 무변경.