### PR TITLE
feat(iap): bump mainnet api image to git-4cca284 (월별 구매 조회 status 필터)

### DIFF
--- a/9c-main/external-services/values.yaml
+++ b/9c-main/external-services/values.yaml
@@ -138,9 +138,9 @@ iap:
     enabled: true
     stage: "mainnet"
     image:
-      # PR #477 (/api/purchase/retry 500 수정). worker는 이 핫픽스로 바뀐 파일이
-      # 없어(apps/api 만 변경) 불필요한 재시작을 피하려고 그대로 둔다.
-      tag: "git-b2a6bcb950192f25dbc192a755fe14125617065e"
+      # PR #480 (월별 구매 조회가 검증 실패 영수증까지 세던 문제 — 시즌패스 재구매 차단).
+      # worker 는 이 수정의 영향 범위(admin 엔드포인트) 밖이라 그대로 둔다.
+      tag: "git-4cca284f7cb8ac35fa0e4f4ac2e7e47d234b1831"
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-main-v2-iap-worker"
 


### PR DESCRIPTION
[NineChronicles.IAP#480](https://github.com/planetarium/NineChronicles.IAP/pull/480) 배포.

## 무엇을 고치는 배포인가

시즌패스를 산 유저가 **웹샵에서 재구매를 못 하는** 문제. 구매 가능 수량은 `3/3`(3개 남음)으로 정상인데도 구매가 막혔다.

`Receipt.get_user_receipts_by_month`가 `status`를 전혀 보지 않아, 스토어 검증에 실패한 영수증(`INVALID`)까지 "이번 달에 구매함"으로 집계했다. 시즌패스 보유 판정에 쓰이는 admin 엔드포인트 5개가 이 함수를 공유한다.

사고 경로:

```
8/07  COURAGEPASS33Premium 구매
8/10  구글이 미확인 결제로 자동 환불          ← 이 시점까지 영수증 없음
8/14  #477 배포 (/api/purchase/retry 500 수정)
8/17  막혀 있던 클라이언트 재시도가 서버 도달
      → 영수증 생성(created_at=8/17) → 구글 재검증 → 이미 환불됨 → INVALID
8/18  웹샵 재구매 차단
```

집계 기준이 `purchased_at`이 아니라 `created_at`이라 8/07 구매가 8월 버킷에 잡혔다. #477이 만든 버그는 아니고, 막혀 있던 재시도를 풀어주면서 선재 결함이 드러난 것이다.

## 변경

`9c-main/external-services/values.yaml` 의 `iap.api.image.tag` 한 줄.

```
git-b2a6bcb950192f25dbc192a755fe14125617065e
→ git-4cca284f7cb8ac35fa0e4f4ac2e7e47d234b1831   (#480 머지 커밋)
```

`helm template` 렌더 차이는 **iap-api 이미지 한 줄뿐**임을 확인했다.

## 범위를 좁힌 이유

- **api 만 올린다.** 이 수정이 닿는 건 admin 엔드포인트 5개이고 worker 는 해당 함수를 쓰지 않는다.
- **인터널은 손대지 않는다.** api·worker 가 복권 테스트 태그에 고정돼 있다.

## DB 마이그레이션 — 배포 전 이미 적용 완료

```
c1a7f0d3b9e4 → 0eb7c95c9f30
  CREATE TABLE voucher_grant_outbox      (#476 바우처)
  CREATE TABLE product_voucher_grant     (#476 바우처)
  merge revision (purchase_signal ↔ voucher 체인 봉합)
```

기존 테이블 `ALTER`/`DROP` 없음. `lock_timeout=3s` 로 락 대기열 없이 적용했고, 적용 직후 결제 흐름 정상(최근 10분 영수증 6건) 확인.

main 에 바우처(#476)가 머지돼 있어 이 이미지에는 바우처 코드가 포함된다. 마이그레이션을 함께 적용한 이유이며, 바우처 기능 자체는 꺼져 있다:

```
WORKER_VOUCHER_GRANT_ENABLED   미설정
시크릿 voucher-grant-enabled    없음   → 기본값 False
```

## 배포 후 확인

- 문제 계정의 8월 집계가 0건이 되어 웹샵 구매가 풀리는지
- `/api/admin/user-receipts/courage-pass` 응답이 정상인지

운영 DB 에서 미리 시뮬레이션한 결과는 수정 전 1건(INVALID) → 수정 후 0건이다.

## 이 배포로 안 풀리는 것

**인게임 경로는 별건이다.** 인게임 상품 목록은 `get_purchase_history`를 쓰며 거긴 이미 같은 상태 필터가 있다. 8/18 인게임 차단은 클라이언트에 남은 미소비 Google Play 결제가 원인으로 보이며 후속 과제다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
