### PR TITLE
feat(iap): 인터널 api 이미지를 IAP#481 검증 빌드로 (git-476b4bd)

### DIFF
--- a/9c-internal/external-services/values.yaml
+++ b/9c-internal/external-services/values.yaml
@@ -92,7 +92,15 @@ iap:
     enabled: true
     stage: "internal"
     image:
-      tag: "git-b51e4a4abf152a9b7aaff480b7a8e3e0891b240f" # (복권 테스트) yang/voucher-lottery-refactor. 검증 후 복구
+      # NineChronicles.IAP#481 (yang/purchase-prev-receipt-guard) 검증용.
+      #   /purchase/request 의 멱등 조기반환에 "INVALID 영수증은 200으로 돌려주지
+      #   않는" 가드를 넣었다. 200을 주면 클라가 결제를 confirm(= consume +
+      #   acknowledge)해 스토어 자동환불이 사라진다.
+      # PR 머지 전 브랜치 빌드 이미지다 — 검증 후 main 이미지로 교체할 것.
+      # 검증: 인터널 테스트 결제 -> track_tx 한 바퀴(1분+) 대기
+      #   -> 같은 영수증으로 /purchase/request 재전송해서 200 인지 확인.
+      #   400 이면 가드가 지급 완료 건을 거절하는 것이므로 즉시 롤백.
+      tag: "git-476b4bd183a84575b95e4b53841bc329b6519103"
     serviceAccount:
       roleArn: "arn:aws:iam::319679068466:role/9c-internal-v2-seasonpass-worker"
 


### PR DESCRIPTION
[NineChronicles.IAP#481](https://github.com/planetarium/NineChronicles.IAP/pull/481) 를 인터널에서 검증하기 위한 이미지 교체다.

## 무엇을 검증하나

`/purchase/request` 의 멱등 조기반환에 **"INVALID 영수증은 200으로 돌려주지 않는"** 가드를 넣었다. 200을 주면 클라이언트가 결제를 confirm(= consume + Google acknowledge)하고, acknowledge 는 스토어 자동환불을 취소시킨다 → 지급도 환불도 없는 상태로 굳는다.

머지 전 브랜치 빌드 이미지다. 이 저장소는 브랜치 push 마다 `git-<sha>` 로 빌드하므로 머지를 기다리지 않고 검증할 수 있다. **검증 후 main 이미지로 교체할 것.**

## api 만 바꿨다

이 가드는 API 전용이다. 그리고 `worker` 는 지금 git 값 자체가 복권 테스트용 임시 핀(`git-b51e4a4a`, 주석에 "검증 후 복구")이라 이번에 건드리지 않았다.

## ⚠️ 전체 sync 금지

`iap-api` / `iap-background-job-worker` 두 Deployment 가 **라이브 드리프트** 상태다:

| | git | 라이브 |
|---|---|---|
| iap-api | `git-b51e4a4a` (복권 테스트 핀) | `git-941fb681` |
| iap-background-job-worker | `git-b51e4a4a` (복권 테스트 핀) | `git-89de9a33` |

ArgoCD `9c-external-services` 앱은 25개 리소스 중 이 2개만 OutOfSync다 — 수동 `set image` 흔적이다. **전체 sync 하면 worker 가 복권 테스트 핀으로 되돌아간다.**

`iap-api` 만 타겟 sync:

```bash
kubectl --context rke2 -n argocd patch applications.argoproj.io 9c-external-services \
  --type merge -p '{"operation":{"initiatedBy":{"username":"admin"},"sync":{
    "resources":[{"group":"apps","kind":"Deployment","name":"iap-api",
    "namespace":"9c-external-services"}]}}}'
```

## 검증 절차

1. 인터널 테스트 결제
2. `track_tx` 한 바퀴(1분+) 대기 → `tx_status` 가 붙는지 확인
3. **같은 영수증으로 `/purchase/request` 재전송 → 200 이어야 한다**

3번에서 400 이 나오면 가드가 지급 완료 건을 거절하는 것이므로 즉시 롤백한다. 이전 설계 두 개가 정확히 그 실수였다(하나는 지급 완료 98% 를 거절, 하나는 지급 후 크래시로 INIT 이 남은 건을 거절).

인터널은 구매 트래픽이 거의 없어 **스모크만으로는 근거가 되지 않는다.** 위 3단계를 직접 밟아야 한다.

## 덧붙여

인터널 iap-api 가 라이브 기준 `git-941fb681`(8/07)로 메인넷(`git-4cca284f`, 8/18)보다 2주 뒤처져 있었다. 이번 이미지는 main(4cca284) 위에 가드만 얹은 것이라 그 격차도 함께 해소된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
